### PR TITLE
Fix #41 : rm holdSearch non sensible API

### DIFF
--- a/examples/instantsearch+helper+excludes.html
+++ b/examples/instantsearch+helper+excludes.html
@@ -56,17 +56,19 @@
         $inputfield.keyup( search );
 
         window.toggleRefine = function(facet, value) {
-          helper.toggleRefine(facet, value);
+          helper.toggleRefine(facet, value).search();
         }
 
         window.toggleExclude = function(facet, value) {
-          helper.toggleExclude(facet, value);
+          helper.toggleExclude(facet, value).search();
         }
 
         search();
 
+        //Functions
+
         function search() {
-          helper.search( $inputfield.val() );
+          helper.setQuery( $inputfield.val() ).search();
         }
 
         function searchCallback( content ) {

--- a/examples/instantsearch+helper.html
+++ b/examples/instantsearch+helper.html
@@ -48,15 +48,14 @@
         helper.on( "result", searchCallback);
 
         $inputfield.keyup( function( e ){
-          helper.search( $inputfield.val() );
+          helper.setQuery( $inputfield.val() ).search();
         } );
 
         window.toggleRefine = function(facet, value) {
-          helper.toggleRefine(facet, value);
+          helper.toggleRefine(facet, value).search();
         }
 
-        helper.search( $inputfield.val() );
-
+        helper.search();
 
         function searchCallback( content ) {
           if (content.query != $inputfield.val()) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -24,48 +24,58 @@ util.inherits( AlgoliaSearchHelper, events.EventEmitter );
 
 /**
  * Start the search with the parameters set in the state.
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.search = function(){
   this._search();
+  return this;
 };
 
 /**
  * Sets the query. Also sets the current page to 0.
  * @param  {string} q the user query
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.setQuery = function( q ) {
   this.state = this.state.setQuery( q )
                          .setPage( 0 );
 
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Remove all refinements (disjunctive + conjunctive + excludes )
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.clearRefinements = function( ) {
   this.state = this.state.clearRefinements();
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.addDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Ensure a facet refinement does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.removeDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
@@ -73,74 +83,92 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value )
  * @param  {string} attribute
  * @param  {string} operator
  * @param  {number} value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.addNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
+  return this;
 }
 
 /**
- *
+ * Remove a numeric filter.
+ * @param  {string} attribute
+ * @param  {string} operator
+ * @param  {number} value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.removeNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
+  return this;
 }
 
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
   this.state = this.state.addFacetRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Ensure a facet refinement does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.removeRefine = function( facet, value ) {
   this.state = this.state.removeFacetRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Ensure a facet exclude exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addExclude = function( facet, value ) {
   this.state = this.state.addExcludeRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Ensure a facet exclude does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.removeExclude = function( facet, value ) {
   this.state = this.state.removeExcludeRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Toggle refinement state of an exclude
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.toggleExclude = function( facet, value ) {
   this.state = this.state.toggleExcludeFacetRefinement( facet, value );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Toggle refinement state of a facet
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value ) {
   if( this.state.facets.indexOf( facet ) > -1 ) {
@@ -152,51 +180,60 @@ AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value ) {
   else {
     console.log( "warning : you're trying to refine the undeclared facet '" + facet +
                 "'; add it to the helper options 'facets' or 'disjunctiveFacets'" );
-    return;
+    return this;
   }
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Go to next page
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.nextPage = function() {
-  this.setPage( this.state.page + 1 );
+  return this.setPage( this.state.page + 1 );
 };
 
 /**
  * Go to previous page
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.previousPage = function() {
-  this.setPage( this.state.page - 1 );
+  return this.setPage( this.state.page - 1 );
 };
 
 /**
  * Change the current page
  * @param  {integer} page The page number
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.setPage = function( page ) {
   if( page < 0 ) throw new Error( "Page requested below 0." );
 
   this.state = this.state.setPage( page );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**
  * Configure the underlying index name
  * @param {string} name the index name
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.setIndex = function( name ) {
   this.index = name;
+  return this;
 };
 
 /**
  * Set the whole state ( warning : will erase previous state )
  * @param {SearchParameters} newState the whole new state
+ * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.setState = function( newState ){
   this.state = new SearchParameters( newState );
   this.emit( "change", this.state );
+  return this;
 };
 
 /**

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -22,12 +22,18 @@ function AlgoliaSearchHelper( client, index, options ) {
 
 util.inherits( AlgoliaSearchHelper, events.EventEmitter );
 
+/**
+ * Start the search with the parameters set in the state.
+ */
+AlgoliaSearchHelper.prototype.search = function(){
+  this._search();
+};
 
 /**
- * Perform a query
+ * Sets the query. Also sets the current page to 0.
  * @param  {string} q the user query
  */
-AlgoliaSearchHelper.prototype.search = function( q ) {
+AlgoliaSearchHelper.prototype.setQuery = function( q ) {
   this.state = this.state.setQuery( q )
                          .setPage( 0 );
 

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -32,7 +32,6 @@ AlgoliaSearchHelper.prototype.search = function( q ) {
                          .setPage( 0 );
 
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -41,7 +40,6 @@ AlgoliaSearchHelper.prototype.search = function( q ) {
 AlgoliaSearchHelper.prototype.clearRefinements = function( ) {
   this.state = this.state.clearRefinements();
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -52,7 +50,6 @@ AlgoliaSearchHelper.prototype.clearRefinements = function( ) {
 AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.addDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -63,7 +60,6 @@ AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value ) {
 AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.removeDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -75,7 +71,6 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value )
 AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.addNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
-  this._search();
 }
 
 /**
@@ -84,7 +79,6 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operat
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.removeNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
-  this._search();
 }
 
 /**
@@ -95,7 +89,6 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, ope
 AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
   this.state = this.state.addFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -106,7 +99,6 @@ AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
 AlgoliaSearchHelper.prototype.removeRefine = function( facet, value ) {
   this.state = this.state.removeFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -117,7 +109,6 @@ AlgoliaSearchHelper.prototype.removeRefine = function( facet, value ) {
 AlgoliaSearchHelper.prototype.addExclude = function( facet, value ) {
   this.state = this.state.addExcludeRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -128,7 +119,6 @@ AlgoliaSearchHelper.prototype.addExclude = function( facet, value ) {
 AlgoliaSearchHelper.prototype.removeExclude = function( facet, value ) {
   this.state = this.state.removeExcludeRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -139,7 +129,6 @@ AlgoliaSearchHelper.prototype.removeExclude = function( facet, value ) {
 AlgoliaSearchHelper.prototype.toggleExclude = function( facet, value ) {
   this.state = this.state.toggleExcludeFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**
@@ -150,17 +139,16 @@ AlgoliaSearchHelper.prototype.toggleExclude = function( facet, value ) {
 AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value ) {
   if( this.state.facets.indexOf( facet ) > -1 ) {
     this.state = this.state.toggleFacetRefinement( facet, value );
-    this.emit( "change", this.state );
   }
   else if( this.state.disjunctiveFacets.indexOf( facet ) > -1 ) {
     this.state = this.state.toggleDisjunctiveFacetRefinement( facet, value );
-    this.emit( "change", this.state );
   }
   else {
     console.log( "warning : you're trying to refine the undeclared facet '" + facet +
-                "'; add it to the helper parameter 'facets' or 'disjunctiveFacets'" );
+                "'; add it to the helper options 'facets' or 'disjunctiveFacets'" );
+    return;
   }
-  this._search();
+  this.emit( "change", this.state );
 };
 
 /**
@@ -186,8 +174,6 @@ AlgoliaSearchHelper.prototype.setPage = function( page ) {
 
   this.state = this.state.setPage( page );
   this.emit( "change", this.state );
-
-  this._search();
 };
 
 /**
@@ -196,7 +182,6 @@ AlgoliaSearchHelper.prototype.setPage = function( page ) {
  */
 AlgoliaSearchHelper.prototype.setIndex = function( name ) {
   this.index = name;
-  this._search();
 };
 
 /**
@@ -206,7 +191,6 @@ AlgoliaSearchHelper.prototype.setIndex = function( name ) {
 AlgoliaSearchHelper.prototype.setState = function( newState ){
   this.state = new SearchParameters( newState );
   this.emit( "change", this.state );
-  this._search();
 };
 
 /**

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -26,56 +26,44 @@ util.inherits( AlgoliaSearchHelper, events.EventEmitter );
 /**
  * Perform a query
  * @param  {string} q the user query
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.search = function( q, holdSearch ) {
+AlgoliaSearchHelper.prototype.search = function( q ) {
   this.state = this.state.setQuery( q )
                          .setPage( 0 );
 
   this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Remove all refinements (disjunctive + conjunctive + excludes )
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.clearRefinements = function( holdSearch ) {
+AlgoliaSearchHelper.prototype.clearRefinements = function( ) {
   this.state = this.state.clearRefinements();
   this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.addDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Ensure a facet refinement does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value ) {
   this.state = this.state.removeDisjunctiveFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
 };
 
 /**
@@ -83,105 +71,83 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function( facet, value, 
  * @param  {string} attribute
  * @param  {string} operator
  * @param  {number} value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operator, value, holdSearch ){
+AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.addNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 }
 
 /**
  *
  */
-AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, operator, value, holdSearch ){
+AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, operator, value ){
   this.state = this.state.removeNumericRefinement( attribute, operator, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 }
 
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.addRefine = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
   this.state = this.state.addFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Ensure a facet refinement does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.removeRefine = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.removeRefine = function( facet, value ) {
   this.state = this.state.removeFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Ensure a facet exclude exists
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.addExclude = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.addExclude = function( facet, value ) {
   this.state = this.state.addExcludeRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Ensure a facet exclude does not exist
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.removeExclude = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.removeExclude = function( facet, value ) {
   this.state = this.state.removeExcludeRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Toggle refinement state of an exclude
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @return {boolean} true if the facet has been found
- * @param {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.toggleExclude = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.toggleExclude = function( facet, value ) {
   this.state = this.state.toggleExcludeFacetRefinement( facet, value );
   this.emit( "change", this.state );
-  if( !holdSearch ){
-    this._search();
-  }
+  this._search();
 };
 
 /**
  * Toggle refinement state of a facet
  * @param  {string} facet the facet to refine
  * @param  {string} value the associated value
- * @param  {boolean} holdSearch Optionnal parameter to specify that the search should not be triggered right away
  */
-AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value, holdSearch ) {
+AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value ) {
   if( this.state.facets.indexOf( facet ) > -1 ) {
     this.state = this.state.toggleFacetRefinement( facet, value );
     this.emit( "change", this.state );
@@ -194,9 +160,53 @@ AlgoliaSearchHelper.prototype.toggleRefine = function( facet, value, holdSearch 
     console.log( "warning : you're trying to refine the undeclared facet '" + facet +
                 "'; add it to the helper parameter 'facets' or 'disjunctiveFacets'" );
   }
-  if( !holdSearch ) {
-    this._search();
-  }
+  this._search();
+};
+
+/**
+ * Go to next page
+ */
+AlgoliaSearchHelper.prototype.nextPage = function() {
+  this.setPage( this.state.page + 1 );
+};
+
+/**
+ * Go to previous page
+ */
+AlgoliaSearchHelper.prototype.previousPage = function() {
+  this.setPage( this.state.page - 1 );
+};
+
+/**
+ * Change the current page
+ * @param  {integer} page The page number
+ */
+AlgoliaSearchHelper.prototype.setPage = function( page ) {
+  if( page < 0 ) throw new Error( "Page requested below 0." );
+
+  this.state = this.state.setPage( page );
+  this.emit( "change", this.state );
+
+  this._search();
+};
+
+/**
+ * Configure the underlying index name
+ * @param {string} name the index name
+ */
+AlgoliaSearchHelper.prototype.setIndex = function( name ) {
+  this.index = name;
+  this._search();
+};
+
+/**
+ * Set the whole state ( warning : will erase previous state )
+ * @param {SearchParameters} newState the whole new state
+ */
+AlgoliaSearchHelper.prototype.setState = function( newState ){
+  this.state = new SearchParameters( newState );
+  this.emit( "change", this.state );
+  this._search();
 };
 
 /**
@@ -230,44 +240,6 @@ AlgoliaSearchHelper.prototype.isDisjunctiveRefined = function( facet, value ) {
 };
 
 /**
- * Go to next page
- */
-AlgoliaSearchHelper.prototype.nextPage = function( holdSearch ) {
-  this.setPage( this.state.page + 1, holdSearch );
-};
-
-/**
- * Go to previous page
- */
-AlgoliaSearchHelper.prototype.previousPage = function( holdSearch ) {
-  this.setPage( this.state.page - 1, holdSearch );
-};
-
-/**
- * Change the current page
- * @param  {integer} page The page number
- */
-AlgoliaSearchHelper.prototype.setPage = function( page, holdSearch ) {
-  if( page < 0 ) throw new Error( "Page requested below 0." );
-
-  this.state = this.state.setPage( page );
-  this.emit( "change", this.state );
-
-  if( !holdSearch ){
-    this._search();
-  }
-};
-
-/**
- * Configure the underlying index name
- * @param {string} name the index name
- */
-AlgoliaSearchHelper.prototype.setIndex = function( name ) {
-  this.index = name;
-  this._search();
-};
-
-/**
  * Get the underlying configured index name
  */
 AlgoliaSearchHelper.prototype.getIndex = function() {
@@ -287,19 +259,6 @@ AlgoliaSearchHelper.prototype.getCurrentPage = function() {
  */
 AlgoliaSearchHelper.prototype.clearExtraQueries = function() {
   this.extraQueries = [];
-};
-
-/**
- * Set the whole state ( warning : will erase previous state )
- * @param {SearchParameters} newState the whole new state
- * @param {boolean} holdSearch hold the search
- */
-AlgoliaSearchHelper.prototype.setState = function( newState, holdSearch ){
-  this.state = new SearchParameters( newState );
-  this.emit( "change", this.state );
-  if( !holdSearch ) {
-    this._search();
-  }
 };
 
 /**

--- a/test/spec/helper.events.js
+++ b/test/spec/helper.events.js
@@ -4,7 +4,7 @@ var sinon = require("sinon");
 var algoliaSearchHelper = require( "../../index" );
 var optionsDefaults = require( "../../src/algoliasearch.helper" ).optionsDefaults;
 
-test( "Change events should be emitted as soon as the state change (before search)", function( t ){
+test( "Change events should be emitted as soon as the state change, but search should be triggered (refactored)", function( t ){
   var helper = algoliaSearchHelper( undefined, "Index", {
     disjunctiveFacets : ["city"],
     facets : ["tower"]
@@ -16,76 +16,41 @@ test( "Change events should be emitted as soon as the state change (before searc
   } );
   var stubbedSearch = sinon.stub( helper, "_search" );
 
-  helper.search( "" );
-  t.equal( count, stubbedSearch.callCount, "search");
-  
-  helper.clearRefinements();
-  t.equal( count, stubbedSearch.callCount, "clearRefinements");
-  
-  helper.addDisjunctiveRefine( "city", "Paris" );
-  t.equal( count, stubbedSearch.callCount, "addDisjunctiveRefine" );
-  
-  helper.removeDisjunctiveRefine( "city", "Paris" );
-  t.equal( count, stubbedSearch.callCount, "removeDisjunctiveRefine" );
-  
-  helper.addExclude( "tower", "Empire State Building" );
-  t.equal( count, stubbedSearch.callCount, "addExclude" );
-  
-  helper.removeExclude( "tower", "Empire State Building" );
-  t.equal( count, stubbedSearch.callCount, "removeExclude" );
-  
-  helper.addRefine( "tower", "Empire State Building" );
-  t.equal( count, stubbedSearch.callCount, "addRefine" );
-
-  helper.removeRefine( "tower", "Empire State Building" );
-  t.equal( count, stubbedSearch.callCount, "removeRefine" );
-   
-  t.end();
-} );
-
-test( "Change events should be emitted as soon as the state change (before search), even if search is delayed", function( t ){
-  var helper = algoliaSearchHelper( undefined, "Index", {
-    disjunctiveFacets : ["city"],
-    facets : ["tower"]
-  });
-
-  var count = 0;
-  helper.on( "change", function(){
-    count++;
-  } );
-  var stubbedSearch = sinon.stub( helper, "_search" );
-
-  helper.search( "" , true);
+  helper.setQuery( "" );
   t.equal( count, 1, "search" );
   t.equal( stubbedSearch.callCount, 0, "search");
-  
-  helper.clearRefinements( true );
+
+  helper.clearRefinements();
   t.equal( count, 2, "clearRefinements" );
   t.equal( stubbedSearch.callCount, 0, "clearRefinements");
-  
-  helper.addDisjunctiveRefine( "city", "Paris", true );
+
+  helper.addDisjunctiveRefine( "city", "Paris" );
   t.equal( count, 3, "addDisjunctiveRefine" );
   t.equal( stubbedSearch.callCount, 0, "addDisjunctiveRefine" );
-  
-  helper.removeDisjunctiveRefine( "city", "Paris", true );
+
+  helper.removeDisjunctiveRefine( "city", "Paris" );
   t.equal( count, 4, "removeDisjunctiveRefine" );
   t.equal( stubbedSearch.callCount, 0, "removeDisjunctiveRefine" );
-  
-  helper.addExclude( "tower", "Empire State Building", true );
+
+  helper.addExclude( "tower", "Empire State Building" );
   t.equal( count, 5, "addExclude" );
   t.equal( stubbedSearch.callCount, 0, "addExclude" );
-  
-  helper.removeExclude( "tower", "Empire State Building", true );
+
+  helper.removeExclude( "tower", "Empire State Building" );
   t.equal( count, 6, "removeExclude" );
   t.equal( stubbedSearch.callCount, 0, "removeExclude" );
-  
-  helper.addRefine( "tower", "Empire State Building", true );
+
+  helper.addRefine( "tower", "Empire State Building" );
   t.equal( count, 7, "addRefine" );
   t.equal( stubbedSearch.callCount, 0, "addRefine" );
 
-  helper.removeRefine( "tower", "Empire State Building", true );
+  helper.removeRefine( "tower", "Empire State Building" );
   t.equal( count, 8, "removeRefine" );
   t.equal( stubbedSearch.callCount, 0, "removeRefine" );
-   
+
+  helper.search();
+  t.equal( count, 8, "final search doesn't call the change" );
+  t.equal( stubbedSearch.callCount, 1, "final search triggers the search" );
+
   t.end();
 } );

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -31,7 +31,7 @@ test( "Search should call the algolia client according to the number of refineme
   helper.search( "" );
 } );
 
-test( "all mutating methods should trigger a search", function( t ){
+test( "no mutating methods should trigger a search", function( t ){
   var helper = Helper( undefined, "Index", {
     disjunctiveFacets : ["city"],
     facets : ["tower"]
@@ -39,7 +39,7 @@ test( "all mutating methods should trigger a search", function( t ){
 
   var stubbedSearch = sinon.stub( helper, "_search" );
 
-  helper.search( "" );
+  helper.setQuery( "" );
   helper.clearRefinements();
   helper.addDisjunctiveRefine( "city", "Paris" );
   helper.removeDisjunctiveRefine( "city", "Paris" );
@@ -48,29 +48,11 @@ test( "all mutating methods should trigger a search", function( t ){
   helper.addRefine( "tower", "Empire State Building" );
   helper.removeRefine( "tower", "Empire State Building" );
 
-  t.equal( stubbedSearch.callCount, 8, "should have triggered calls for each mutating methods");
+  t.equal( stubbedSearch.callCount, 0, "should not have triggered calls");
 
-  t.end();
-} );
+  helper.search();
 
-test( "all mutating methods should not trigger a search if holdSearch flag is passed", function( t ){
-  var helper = Helper( undefined, "Index", {
-    disjunctiveFacets : ["city"],
-    facets : ["tower"]
-  });
-
-  var stubbedSearch = sinon.stub( helper, "_search" );
-
-  helper.search( "", true);
-  helper.clearRefinements( true );
-  helper.addDisjunctiveRefine( "city", "Paris", true );
-  helper.removeDisjunctiveRefine( "city", "Paris", true );
-  helper.addExclude( "tower", "Empire State Building", true );
-  helper.removeExclude( "tower", "Empire State Building", true );
-  helper.addRefine( "tower", "Empire State Building", true );
-  helper.removeRefine( "tower", "Empire State Building", true );
-
-  t.equal( stubbedSearch.callCount, 0, "should not trigger calls for each mutating methods");
+  t.equal( stubbedSearch.callCount, 1, "should have triggered a single search");
 
   t.end();
 } );


### PR DESCRIPTION
In order to clarify the API for the users, this pull requests changes the following : 
 - no automatic search on state changes
 - no more hold search parameter to prevent this behavior
 - chainable mutation api to ease the use
 - separate genuine search from setting the query