### PR TITLE
Clear refinements by name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 CHANGELOG
 
 UNRELEASED
+  * FEATURE : clear refinements by name
   * FIX : handle distinct parameter automatically
   * FIX : batch response handler gets the proper search state
   * FEATURE : (breaking) Facets stats and timeout infos are consistently

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -3,6 +3,8 @@ var keys = require( "lodash/object/keys" );
 var forEach = require( "lodash/collection/forEach" );
 var reduce = require( "lodash/collection/reduce" );
 var isEmpty = require( "lodash/lang/isEmpty" );
+var isUndefined = require( "lodash/lang/isUndefined" );
+var isString = require( "lodash/lang/isString" );
 
 /**
  * @typedef FacetList
@@ -103,13 +105,19 @@ var SearchParameters = function( newParameters ) {
 
 SearchParameters.prototype = {
   constructor : SearchParameters,
-  clearRefinements : function clearRefinements() {
-    return this.mutateMe( function( m ) {
-      m.facetsRefinements = {};
-      m.facetsExcludes = {};
-      m.disjunctiveFacetsRefinements = {};
-      m.numericRefinements = {};
-    } );
+
+  /**
+   * Remove all refinements (disjunctive + conjunctive + excludes + numeric filters)
+   * @method
+   * @param {string} [name] - If given, name of the facet / attribute on which  we want to remove all refinements
+   * @return {AlgoliaSearchHelper}
+   */
+  clearRefinements : function clearRefinements( name ) {
+    return this
+      .clearNumericRefinements( name )
+      .clearFacetRefinements( name )
+      .clearExcludeRefinements( name )
+      .clearDisjunctiveFacetRefinements( name );
   },
   /**
    * Query setter
@@ -205,6 +213,25 @@ SearchParameters.prototype = {
     } );
   },
   /**
+   * Clear numeric filters.
+   * @method
+   * @param {string} [attribute] -
+   * - If not given, means to clear all the filters.
+   * - If `string`, means to clear all refinements for the `attribute` named filter.
+   */
+  clearNumericRefinements : function( attribute ) {
+    return this.mutateMe( function( m ) {
+      if ( isUndefined( attribute ) ) {
+        m.numericRefinements = {};
+      }
+      else if ( isString( attribute ) ) {
+        if ( !isUndefined( m.numericRefinements[ attribute ] ) ) {
+          delete m.numericRefinements[ attribute ];
+        }
+      }
+    } );
+  },
+  /**
    * Add a refinement on a "normal" facet
    * @method
    * @param {string} facet attribute to apply the facetting on
@@ -253,9 +280,7 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   removeFacetRefinement : function removeFacetRefinement( facet ) {
-    return this.mutateMe( function( m ) {
-      delete m.facetsRefinements[ facet ];
-    } );
+    return this.clearFacetRefinements( facet );
   },
   /**
    * Remove a negative refinement on a facet
@@ -293,6 +318,63 @@ SearchParameters.prototype = {
           if( m.disjunctiveFacetsRefinements[facet].length === 0 ){
             delete m.disjunctiveFacetsRefinements[ facet ];
           }
+        }
+      }
+    } );
+  },
+  /**
+   * Clear the facet refinements
+   * @method
+   * @param {string} [facet] -
+   * - If not given, means to clear the refinement of all facets.
+   * - If `string`, means to clear the refinement for the `facet` named facet.
+   */
+  clearFacetRefinements : function clearFacetRefinements( facet ) {
+    return this.mutateMe( function( m ) {
+      if ( isUndefined( facet ) ) {
+        m.facetsRefinements = {};
+      }
+      else if ( isString( facet ) ) {
+        if ( !isUndefined( m.facetsRefinements[ facet ] ) ) {
+          delete m.facetsRefinements[ facet ];
+        }
+      }
+    } );
+  },
+  /**
+   * Clear the exclude refinements
+   * @method
+   * @param {string} [facet] -
+   * - If not given, means to clear all the excludes of all facets.
+   * - If `string`, means to clear all the excludes for the `facet` named facet.
+   */
+  clearExcludeRefinements : function clearExcludeRefinements( facet ) {
+    return this.mutateMe( function( m ) {
+      if ( isUndefined( facet ) ) {
+        m.facetsExcludes = {};
+      }
+      else if ( isString( facet ) ) {
+        if ( !isUndefined( m.facetsExcludes[ facet ] ) ) {
+          delete m.facetsExcludes[ facet ];
+        }
+      }
+    } );
+  },
+  /**
+   * Clear the disjunctive refinements
+   * @method
+   * @param {string} [facet] -
+   * - If not given, means to clear all the refinements of all disjunctive facets.
+   * - If `string`, means to clear all the refinements for the `facet` named facet.
+   */
+  clearDisjunctiveFacetRefinements : function clearDisjunctiveFacetRefinements( facet ) {
+    return this.mutateMe( function( m ) {
+      if ( isUndefined( facet ) ) {
+        m.disjunctiveFacetsRefinements = {};
+      }
+      else if ( isString( facet ) ) {
+        if ( !isUndefined( m.disjunctiveFacetsRefinements[ facet ] ) ) {
+          delete m.disjunctiveFacetsRefinements[ facet ];
         }
       }
     } );

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -113,11 +113,12 @@ SearchParameters.prototype = {
    * @return {AlgoliaSearchHelper}
    */
   clearRefinements : function clearRefinements( name ) {
-    return this
-      .clearNumericRefinements( name )
-      .clearFacetRefinements( name )
-      .clearExcludeRefinements( name )
-      .clearDisjunctiveFacetRefinements( name );
+    return this.mutateMe( function( m ) {
+      m._clearNumericRefinements( name );
+      m._clearFacetRefinements( name );
+      m._clearExcludeRefinements( name );
+      m._clearDisjunctiveFacetRefinements( name );
+    } );
   },
   /**
    * Query setter
@@ -215,21 +216,20 @@ SearchParameters.prototype = {
   /**
    * Clear numeric filters.
    * @method
+   * @private
    * @param {string} [attribute] -
    * - If not given, means to clear all the filters.
    * - If `string`, means to clear all refinements for the `attribute` named filter.
    */
-  clearNumericRefinements : function( attribute ) {
-    return this.mutateMe( function( m ) {
-      if ( isUndefined( attribute ) ) {
-        m.numericRefinements = {};
+  _clearNumericRefinements : function _clearNumericRefinements( attribute ) {
+    if ( isUndefined( attribute ) ) {
+      this.numericRefinements = {};
+    }
+    else if ( isString( attribute ) ) {
+      if ( !isUndefined( this.numericRefinements[ attribute ] ) ) {
+        delete this.numericRefinements[ attribute ];
       }
-      else if ( isString( attribute ) ) {
-        if ( !isUndefined( m.numericRefinements[ attribute ] ) ) {
-          delete m.numericRefinements[ attribute ];
-        }
-      }
-    } );
+    }
   },
   /**
    * Add a refinement on a "normal" facet
@@ -280,7 +280,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   removeFacetRefinement : function removeFacetRefinement( facet ) {
-    return this.clearFacetRefinements( facet );
+    return this.mutateMe( function( m ) {
+      m._clearFacetRefinements( facet );
+    } );
   },
   /**
    * Remove a negative refinement on a facet
@@ -325,59 +327,56 @@ SearchParameters.prototype = {
   /**
    * Clear the facet refinements
    * @method
+   * @private
    * @param {string} [facet] -
    * - If not given, means to clear the refinement of all facets.
    * - If `string`, means to clear the refinement for the `facet` named facet.
    */
-  clearFacetRefinements : function clearFacetRefinements( facet ) {
-    return this.mutateMe( function( m ) {
-      if ( isUndefined( facet ) ) {
-        m.facetsRefinements = {};
+  _clearFacetRefinements : function _clearFacetRefinements( facet ) {
+    if ( isUndefined( facet ) ) {
+      this.facetsRefinements = {};
+    }
+    else if ( isString( facet ) ) {
+      if ( !isUndefined( this.facetsRefinements[ facet ] ) ) {
+        delete this.facetsRefinements[ facet ];
       }
-      else if ( isString( facet ) ) {
-        if ( !isUndefined( m.facetsRefinements[ facet ] ) ) {
-          delete m.facetsRefinements[ facet ];
-        }
-      }
-    } );
+    }
   },
   /**
    * Clear the exclude refinements
    * @method
+   * @private
    * @param {string} [facet] -
    * - If not given, means to clear all the excludes of all facets.
    * - If `string`, means to clear all the excludes for the `facet` named facet.
    */
-  clearExcludeRefinements : function clearExcludeRefinements( facet ) {
-    return this.mutateMe( function( m ) {
-      if ( isUndefined( facet ) ) {
-        m.facetsExcludes = {};
+  _clearExcludeRefinements : function _clearExcludeRefinements( facet ) {
+    if ( isUndefined( facet ) ) {
+      this.facetsExcludes = {};
+    }
+    else if ( isString( facet ) ) {
+      if ( !isUndefined( this.facetsExcludes[ facet ] ) ) {
+        delete this.facetsExcludes[ facet ];
       }
-      else if ( isString( facet ) ) {
-        if ( !isUndefined( m.facetsExcludes[ facet ] ) ) {
-          delete m.facetsExcludes[ facet ];
-        }
-      }
-    } );
+    }
   },
   /**
    * Clear the disjunctive refinements
    * @method
+   * @private
    * @param {string} [facet] -
    * - If not given, means to clear all the refinements of all disjunctive facets.
    * - If `string`, means to clear all the refinements for the `facet` named facet.
    */
-  clearDisjunctiveFacetRefinements : function clearDisjunctiveFacetRefinements( facet ) {
-    return this.mutateMe( function( m ) {
-      if ( isUndefined( facet ) ) {
-        m.disjunctiveFacetsRefinements = {};
+  _clearDisjunctiveFacetRefinements : function _clearDisjunctiveFacetRefinements( facet ) {
+    if ( isUndefined( facet ) ) {
+      this.disjunctiveFacetsRefinements = {};
+    }
+    else if ( isString( facet ) ) {
+      if ( !isUndefined( this.disjunctiveFacetsRefinements[ facet ] ) ) {
+        delete this.disjunctiveFacetsRefinements[ facet ];
       }
-      else if ( isString( facet ) ) {
-        if ( !isUndefined( m.disjunctiveFacetsRefinements[ facet ] ) ) {
-          delete m.disjunctiveFacetsRefinements[ facet ];
-        }
-      }
-    } );
+    }
   },
   /**
    * Switch the refinement applied over a facet/value

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -50,11 +50,12 @@ AlgoliaSearchHelper.prototype.setQuery = function( q ) {
 };
 
 /**
- * Remove all refinements (disjunctive + conjunctive + excludes )
+ * Remove all refinements (disjunctive + conjunctive + excludes + numeric filters)
+ * @param {string} [name] - If given, name of the facet / attribute on which  we want to remove all refinements
  * @return {AlgoliaSearchHelper}
  */
-AlgoliaSearchHelper.prototype.clearRefinements = function( ) {
-  this.state = this.state.clearRefinements();
+AlgoliaSearchHelper.prototype.clearRefinements = function( name ) {
+  this.state = this.state.clearRefinements( name );
   this.emit( "change", this.state );
   return this;
 };

--- a/test/spec/helper.clears.js
+++ b/test/spec/helper.clears.js
@@ -1,0 +1,104 @@
+"use strict";
+
+var test = require( "tape" ),
+    algoliasearchHelper = require( "../../index" ),
+    isUndefined = require( "lodash/lang/isUndefined" );
+
+var init = function init() {
+  var helper = algoliasearchHelper( undefined, "Index", {
+    facets : ["facet1", "facet2", "both_facet"],
+    disjunctiveFacets : ["disjunctiveFacet1", "disjunctiveFacet2", "both_facet"]
+  } );
+
+  return helper.toggleRefine( "facet1", "0" )
+    .toggleRefine( "facet2", "0" )
+    .toggleRefine( "disjunctiveFacet1", "0" )
+    .toggleRefine( "disjunctiveFacet2", "0" )
+    .toggleExclude( "excluded1", "0" )
+    .toggleExclude( "excluded2", "0" )
+    .addNumericRefinement( "numeric1", ">=", "0" )
+    .addNumericRefinement( "numeric1", "<", "10" )
+    .addNumericRefinement( "numeric2", ">=", 0 )
+    .addNumericRefinement( "numeric2", "<", 10 );
+};
+
+test( "Check that the state objects match how we test them", function( t ) {
+  var helper = init();
+
+  t.deepEqual( helper.state.facetsRefinements, { "facet1" : "0", "facet2" : "0" } );
+  t.deepEqual( helper.state.disjunctiveFacetsRefinements, { "disjunctiveFacet1" : [ "0" ], "disjunctiveFacet2" : [ "0" ] } );
+  t.deepEqual( helper.state.facetsExcludes, { "excluded1" : [ "0" ], "excluded2" : [ "0" ] } );
+  t.deepEqual( helper.state.numericRefinements, { "numeric1" : { ">=" : "0", "<" : "10" }, "numeric2" : { ">=" : 0, "<" : 10 } } );
+
+  t.end();
+} );
+
+test( "Clear with a name should work on every type and not remove others than targetted name", function( t ) {
+  var helper = init();
+
+  helper.clearRefinements( "facet1" );
+  t.deepEqual( helper.state.facetsRefinements, { "facet2" : "0" } );
+
+  helper.clearRefinements( "disjunctiveFacet1" );
+  t.deepEqual( helper.state.disjunctiveFacetsRefinements, { "disjunctiveFacet2" : [ "0" ] } );
+
+  helper.clearRefinements( "excluded1" );
+  t.deepEqual( helper.state.facetsExcludes, { "excluded2" : [ "0" ] } );
+
+  helper.clearRefinements( "numeric1" );
+  t.deepEqual( helper.state.numericRefinements, { "numeric2" : { ">=" : 0, "<" : 10 } } );
+
+  t.end();
+} );
+
+
+test( "Clearing the same field from multiple elements should remove it everywhere", function( t ) {
+  var helper = init();
+
+  helper.addNumericRefinement( "facet1", ">=", "10" ).toggleExclude( "facet1", "value" );
+
+  t.equal( helper.state.facetsRefinements.facet1, "0" );
+  t.deepEqual( helper.state.numericRefinements.facet1, { ">=" : "10" } );
+  t.deepEqual( helper.state.facetsExcludes.facet1, [ "value" ] );
+
+  helper.clearRefinements( "facet1" );
+  t.assert( isUndefined( helper.state.facetsRefinements.facet1 ) );
+  t.assert( isUndefined( helper.state.numericRefinements.facet1 ) );
+  t.assert( isUndefined( helper.state.facetsExcludes.facet1 ) );
+
+  t.end();
+} );
+
+test( "Clearing twice the same attribute should be not problem", function( t ) {
+  var helper = init();
+
+  t.equal( helper.state.facetsRefinements.facet1, "0" );
+  helper.clearRefinements( "facet1" );
+  t.assert( isUndefined( helper.state.facetsRefinements.facet1 ) );
+  t.doesNotThrow( function() {
+    helper.clearRefinements( "facet1" );
+  } );
+
+  t.deepEqual( helper.state.disjunctiveFacetsRefinements.disjunctiveFacet1, [ "0" ] );
+  helper.clearRefinements( "disjunctiveFacet1" );
+  t.assert( isUndefined( helper.state.disjunctiveFacetsRefinements.disjunctiveFacet1 ) );
+  t.doesNotThrow( function() {
+    helper.clearRefinements( "disjunctiveFacet1" );
+  } );
+
+  t.deepEqual( helper.state.facetsExcludes.excluded1, [ "0" ] );
+  helper.clearRefinements( "excluded1" );
+  t.assert( isUndefined( helper.state.facetsExcludes.excluded1 ) );
+  t.doesNotThrow( function() {
+    helper.clearRefinements( "excluded1" );
+  } );
+
+  t.deepEqual( helper.state.numericRefinements.numeric1, { ">=" : "0", "<" : "10" } );
+  helper.clearRefinements( "numeric1" );
+  t.assert( isUndefined( helper.state.numericRefinements.numeric1 ) );
+  t.doesNotThrow( function() {
+    helper.clearRefinements( "numeric1" );
+  } );
+
+  t.end();
+} );


### PR DESCRIPTION
Designed to provide a first answer to #25.
Added 4 internal functions :
- clearFacetRefinements
- clearDisjunctiveFacetRefinements
- clearExcludeRefinements
- clearNumericRefinements

Each of them can clear everything but also be limitted by `name`.
It doesn't change how `helper.clearRefinements()` works, but
adds `helper.clearRefinements( name )` will search and remove
the refinements of a given facet / attribute.