### PR TITLE
Fix #53 : handle numeric filters for attributes declared as disjunctive facets

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1,5 +1,6 @@
 "use strict";
 var keys = require( "lodash/object/keys" );
+var intersection = require( "lodash/array/intersection" );
 var forEach = require( "lodash/collection/forEach" );
 var reduce = require( "lodash/collection/reduce" );
 var isEmpty = require( "lodash/lang/isEmpty" );
@@ -485,7 +486,11 @@ SearchParameters.prototype = {
    * @return {string[]}
    */
   getRefinedDisjunctiveFacets : function getRefinedDisjunctiveFacets() {
-    return keys( this.disjunctiveFacetsRefinements ).concat( keys( this.numericRefinements ) );
+    var disjunctiveNumericRefinedFacets = intersection(
+      keys( this.numericRefinements ),
+      this.disjunctiveFacets
+    );
+    return keys( this.disjunctiveFacetsRefinements ).concat( disjunctiveNumericRefinedFacets );
   },
   /**
    * Returned the list of all disjunctive facets not refined

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -485,7 +485,7 @@ SearchParameters.prototype = {
    * @return {string[]}
    */
   getRefinedDisjunctiveFacets : function getRefinedDisjunctiveFacets() {
-    return keys( this.disjunctiveFacetsRefinements );
+    return keys( this.disjunctiveFacetsRefinements ).concat( keys( this.numericRefinements ) );
   },
   /**
    * Returned the list of all disjunctive facets not refined

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -369,7 +369,7 @@ AlgoliaSearchHelper.prototype._getHitsSearchParams = function() {
  */
 AlgoliaSearchHelper.prototype._getDisjunctiveFacetSearchParams = function( facet ) {
   var facetFilters = this._getFacetFilters( facet );
-  var numericFilters = this._getNumericFilters();
+  var numericFilters = this._getNumericFilters( facet );
   var additionalParams = {
     hitsPerPage : 1,
     page : 0,
@@ -397,11 +397,13 @@ AlgoliaSearchHelper.prototype._getDisjunctiveFacetSearchParams = function( facet
  * @private
  * @return {array.<string>} the numeric filters in the algolia format
  */
-AlgoliaSearchHelper.prototype._getNumericFilters = function() {
+AlgoliaSearchHelper.prototype._getNumericFilters = function( facetName ) {
   var numericFilters = [];
   forEach( this.state.numericRefinements, function( operators, attribute ) {
     forEach( operators, function( value, operator ) {
-      numericFilters.push( attribute + operator + value );
+      if( facetName !== attribute ) {
+        numericFilters.push( attribute + operator + value );
+      }
     } );
   } );
   return numericFilters;

--- a/test/spec/SearchParameters.getRefinedDisjunctiveFacets.js
+++ b/test/spec/SearchParameters.getRefinedDisjunctiveFacets.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var test = require( "tape" );
+//var _ = require( "lodash" );
+var SearchParameters = require( "../../src/SearchParameters" );
+
+test( "getRefinedDisjunctiveFacets should return the refined facets declared as disjunctive", function( t ) {
+  var sp = new SearchParameters( {
+    disjunctiveFacets : [ "myNumericFacet" ]
+  } );
+
+  t.equal( sp.getRefinedDisjunctiveFacets().length, 0, "Should be empty at first" );
+  sp.addNumericRefinement( "myNumericFacet", ">", 3 );
+  t.equal( sp.getRefinedDisjunctiveFacets().indexOf( "myNumericFacet" ), 0, "Should contain myNumericFacet" );
+
+  t.end();
+} );
+
+test( "getRefinedDisjunctiveFacets should return the refined once even if there are multiple filters on the same facet", function( t ) {
+  var sp = new SearchParameters( {
+    disjunctiveFacets : [ "myNumericFacet" ]
+  } );
+
+  t.equal( sp.getRefinedDisjunctiveFacets().length, 0, "Should be empty at first" );
+  sp.addNumericRefinement( "myNumericFacet", ">", 3 );
+  sp.addNumericRefinement( "myNumericFacet", "=", 3 );
+  t.equal( sp.getRefinedDisjunctiveFacets().indexOf( "myNumericFacet" ), 0, "Should contain myNumericFacet" );
+
+  t.end();
+} );
+
+test( "getRefinedDisjunctiveFactes should not return refined normal facets", function( t ) {
+  var sp = new SearchParameters( {
+    facets : [ "myNumericFacet" ]
+  } );
+
+  t.equal( sp.getRefinedDisjunctiveFacets().length, 0, "Should be empty at first" );
+  sp.addNumericRefinement( "myNumericFacet", ">", 3 );
+  t.equal( sp.getRefinedDisjunctiveFacets().length, 0, "Should still be empty" );
+
+  t.end();
+} );

--- a/test/spec/SearchResults.getFacet.js
+++ b/test/spec/SearchResults.getFacet.js
@@ -8,12 +8,12 @@ test( "getFacetByName should return a given facet be it disjunctive or conjuncti
   var result = new SearchResults( data.searchParams, data.response );
 
   var cityFacet = result.getFacetByName( "city" );
-  t.equal( cityFacet.name, "city", "name");
+  t.equal( cityFacet.name, "city", "name" );
   t.deepEqual( cityFacet.data, {
     "New York" : 1,
     "Paris" : 3,
     "San Francisco" : 1
-  }, "values");
+  }, "values" );
 
   t.end();
 } );

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -1,11 +1,11 @@
-var test = require("tape");
+"use strict";
+var test = require( "tape" );
 var _ = require( "lodash" );
-var sinon = require("sinon"); 
 var algoliasearchHelper = require( "../../index" );
 
-test( "isDisjunctiveRefined", function( t ){
+test( "isDisjunctiveRefined", function( t ) {
   var helper = algoliasearchHelper( null, null, {} );
-  helper._search = function(){};
+  helper._search = function() {};
 
   var facet = "MyFacet";
   var value = "MyValue";
@@ -23,35 +23,35 @@ test( "isDisjunctiveRefined", function( t ){
 
 test( "Adding refinments should add an entry to the refinments attribute", function( t ) {
   var helper = algoliasearchHelper( {}, "index", {} );
-  helper._search = function(){};
+  helper._search = function() {};
 
   var facetName = "facet1";
   var facetValue = "42";
 
-  t.ok( _.isEmpty( helper.state.facetsRefinements ), "should be empty at first");
+  t.ok( _.isEmpty( helper.state.facetsRefinements ), "should be empty at first" );
   helper.addRefine( facetName, "42" );
   t.ok( _.size( helper.state.facetsRefinements ) === 1 &&
-          helper.state.facetsRefinements["facet1"] === facetValue,
+          helper.state.facetsRefinements.facet1 === facetValue,
           "when adding a refinment, should have one" );
   helper.addRefine( facetName, facetValue );
-  t.ok( _.size( helper.state.facetsRefinements ) === 1, "when adding the same, should still be one");
+  t.ok( _.size( helper.state.facetsRefinements ) === 1, "when adding the same, should still be one" );
   helper.removeRefine( facetName, facetValue );
-  t.ok( _.size( helper.state.facetsRefinements ) === 0, "Then empty ");
+  t.ok( _.size( helper.state.facetsRefinements ) === 0, "Then empty " );
   t.end();
 } );
 
-test( "IsRefined should return true if the ( facet, value ) is refined.", function( t ){
+test( "IsRefined should return true if the ( facet, value ) is refined.", function( t ) {
   var helper = algoliasearchHelper( null, null, {
     facets : [ "facet1" ]
   } );
 
   helper.addRefine( "facet1", "boom" );
 
-  t.ok( helper.isRefined( "facet1", "boom"), "the facet is refined >> true" );
+  t.ok( helper.isRefined( "facet1", "boom" ), "the facet is refined >> true" );
 
-  t.notOk( helper.isRefined( "facet1", "booohh" ), "not refined but is a facet");
+  t.notOk( helper.isRefined( "facet1", "booohh" ), "not refined but is a facet" );
   t.notOk( helper.isRefined( "notAFacet", "maoooh" ), "not refined because it's not a facet" );
-  t.notOk( helper.isRefined( null, null), "not even valid values" );
+  t.notOk( helper.isRefined( null, null ), "not even valid values" );
 
   t.end();
 } );


### PR DESCRIPTION
The ability to declare a numeric attribute as a disjunctive facet makes it easy to create sliders in instant search implementations.