### PR TITLE
Fix #51 : conjunctive facets with multiple filtering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 CHANGELOG
 
 UNRELEASED
+  * FEATURE : #51 multiple filters for a single conjunctive facet (tests)
   * FEATURE : Ability to modify any parameter of the state easily (#76 #84)
   * FEATURE : #69 Ability to know if a facet is refined, whatever the value
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "test-ci": "echo \"Error: no test specified\" && exit 1",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
+  },
   "author": {
     "name": "Algolia SAS",
     "url": "https://www.algolia.com"
@@ -31,6 +36,7 @@
     "browserify": "9.0.3",
     "bulk-require": "0.2.1",
     "bulkify": "1.1.1",
+    "envify": "3.4.0",
     "eslint": "0.17.1",
     "http-server": "0.8.0",
     "jsdoc": "3.3.0-beta3",

--- a/test/integation-spec/helper.filters.js
+++ b/test/integation-spec/helper.filters.js
@@ -1,0 +1,65 @@
+"use strict";
+
+var test = require( "tape" );
+var algoliasearch = require( "algoliasearch" );
+var algoliasearchHelper = require( "../../index" );
+
+function setup( indexName, fn ) {
+  var appID = process.env.INTEGRATION_TEST_APPID;
+  var key = process.env.INTEGRATION_TEST_API_KEY;
+
+  var client = algoliasearch( appID, key, { protocol : "https:" } );
+  return client.deleteIndex( indexName )
+               .then( function( ) {
+                 var index = client.initIndex( indexName );
+                 return fn( client, index );
+               } );
+}
+
+test( "Should retrieve different values for multi facetted records", function( t ) {
+  var indexName = "helper_refinements";
+
+  setup( indexName, function( client, index ) {
+    return index.addObjects( [
+                  { facet : [ "f1", "f2" ] },
+                  { facet : [ "f1", "f3" ] },
+                  { facet : [ "f2", "f3" ] }
+                ] )
+                .then( function() {
+                  return index.setSettings( {
+                    attributesToIndex : [ "facet" ],
+                    attributesForFaceting : [ "facet" ]
+                  } );
+                } )
+                .then( function( content ) {
+                  return index.waitTask( content.taskID );
+                } ).then( function() {
+                  return client;
+                } );
+  } ).then( function( client ) {
+    var helper = algoliasearchHelper( client, indexName, {
+      facets : [ "facet" ]
+    } );
+
+    var calls = 0;
+    helper.on( "result", function( content ) {
+      calls++;
+      if( calls === 1 ) {
+        t.equal( content.hits.length, 2, "filter should result in two items" );
+        t.equal( content.facets[ 0 ].data.f1, 2 );
+        t.equal( content.facets[ 0 ].data.f2, 1 );
+        t.equal( content.facets[ 0 ].data.f3, 1 );
+      }
+      if( calls === 2 ) {
+        t.equal( content.hits.length, 1, "filter should result in one item" );
+        t.equal( content.facets[ 0 ].data.f1, 1 );
+        t.equal( content.facets[ 0 ].data.f2, 1 );
+        t.end();
+      }
+    } );
+
+    helper.addRefine( "facet", "f1" ).search();
+    helper.addRefine( "facet", "f2" ).search();
+  } );
+
+} );

--- a/test/integation-spec/helper.filters.js
+++ b/test/integation-spec/helper.filters.js
@@ -46,20 +46,39 @@ test( "Should retrieve different values for multi facetted records", function( t
       calls++;
       if( calls === 1 ) {
         t.equal( content.hits.length, 2, "filter should result in two items" );
-        t.equal( content.facets[ 0 ].data.f1, 2 );
-        t.equal( content.facets[ 0 ].data.f2, 1 );
-        t.equal( content.facets[ 0 ].data.f3, 1 );
+        t.deepEqual( content.facets[ 0 ].data, {
+          f1 : 2,
+          f2 : 1,
+          f3 : 1
+        } );
       }
       if( calls === 2 ) {
         t.equal( content.hits.length, 1, "filter should result in one item" );
-        t.equal( content.facets[ 0 ].data.f1, 1 );
-        t.equal( content.facets[ 0 ].data.f2, 1 );
+        t.deepEqual( content.facets[ 0 ].data, {
+          f1 : 1,
+          f2 : 1
+        } );
+      }
+      if( calls === 3 ) {
+        t.equal( content.hits.length, 0, "filter should result in 0 item" );
+        t.equal( content.facets[ 0 ], undefined );
+      }
+      if( calls === 4 ) {
+        t.equal( content.hits.length, 1, "filter should result in one item again" );
+        t.deepEqual( content.facets[ 0 ].data, {
+          f1 : 1,
+          f3 : 1
+        } );
         t.end();
+
       }
     } );
 
     helper.addRefine( "facet", "f1" ).search();
     helper.addRefine( "facet", "f2" ).search();
+    helper.toggleRefine( "facet", "f3" ).search();
+    helper.removeRefine( "facet", "f2" ).search();
+
   } );
 
 } );

--- a/test/run.js
+++ b/test/run.js
@@ -1,1 +1,6 @@
 require('bulk-require')(__dirname, ['spec/**/*.js']);
+
+if ( process.env.INTEGRATION_TEST_API_KEY && process.env.INTEGRATION_TEST_APPID ) {
+  // usage: INTEGRATION_TEST_APPID=$APPID INTEGRATION_TEST_API_KEY=$APIKEY npm run dev
+  require('bulk-require')(__dirname, ['integation-spec/**/*.js']);
+}

--- a/test/spec/helper.facetFilters.js
+++ b/test/spec/helper.facetFilters.js
@@ -1,0 +1,29 @@
+//Make sure we do facet filters correctly before sending them to algolia
+
+"use strict";
+
+var test = require( "tape" );
+var algoliasearchHelper = require( "../../index" );
+
+test( "The filters should contain the different filters for a single conjunctive facet with multiple refinements",
+      function( t ) {
+  var facetName = "myFacet";
+  var helper = algoliasearchHelper( "", "", {
+    facets : [ facetName ]
+  } );
+
+  helper.addRefine( facetName, "value1" );
+  t.deepEqual( helper._getFacetFilters(),
+               [ facetName + ":value1" ],
+               "One value : one filter" );
+  helper.addRefine( facetName, "value2" );
+  t.deepEqual( helper._getFacetFilters(),
+               [ facetName + ":value1", facetName + ":value2" ],
+               "Two values : two filters" );
+  helper.addRefine( facetName, "value1" );
+  t.deepEqual( helper._getFacetFilters(),
+               [ facetName + ":value1", facetName + ":value2"],
+               "Add multiple times the same parameter : only two parameters" );
+
+  t.end();
+} );

--- a/test/spec/helper.facetFilters.js
+++ b/test/spec/helper.facetFilters.js
@@ -20,6 +20,14 @@ test( "The filters should contain the different filters for a single conjunctive
   t.deepEqual( helper._getFacetFilters(),
                [ facetName + ":value1", facetName + ":value2" ],
                "Two values : two filters" );
+  helper.toggleRefine( facetName, "value3" );
+  t.deepEqual( helper._getFacetFilters(),
+               [ facetName + ":value1", facetName + ":value2", facetName + ":value3" ],
+               "Three values : three filters" );
+  helper.removeRefine( facetName, "value3" );
+  t.deepEqual( helper._getFacetFilters(),
+               [ facetName + ":value1", facetName + ":value2" ],
+               "Three values : three filters" );
   helper.addRefine( facetName, "value1" );
   t.deepEqual( helper._getFacetFilters(),
                [ facetName + ":value1", facetName + ":value2"],

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -39,6 +39,44 @@ test( "Adding several refinements for a single attribute should be handled", fun
   t.end();
 } );
 
+test( "Toggling several refinements for a single attribute should be handled", function( t ) {
+  var facetName = "facet";
+
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ facetName ]
+  } );
+
+  t.ok( _.isEmpty( helper.state.facetsRefinements ), "empty" );
+  helper.toggleRefine( facetName, "value1" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 1, "Adding one refinement, should have one" );
+  helper.toggleRefine( facetName, "value2" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 2, "Adding another refinement, should have two" );
+  helper.toggleRefine( facetName, "value1" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 1, "Adding same refinement as the first, should have two" );
+  t.deepEqual( helper.state.facetsRefinements[ facetName ], [ "value2" ], "should contain value2" );
+
+  t.end();
+} );
+
+test( "Removing several refinements for a single attribute should be handled", function( t ) {
+  var facetName = "facet";
+
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ facetName ]
+  } );
+
+  t.ok( _.isEmpty( helper.state.facetsRefinements ), "empty" );
+  helper.addRefine( facetName, "value1" );
+  helper.addRefine( facetName, "value2" );
+  helper.addRefine( facetName, "value3" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 3, "Adding another refinement, should have two" );
+  helper.removeRefine( facetName, "value2" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 2, "Adding same refinement as the first, should have two" );
+  t.deepEqual( helper.state.facetsRefinements[ facetName ], [ "value1", "value3" ], "should contain value1 and value3" );
+
+  t.end();
+} );
+
 test( "isDisjunctiveRefined", function( t ) {
   var helper = algoliasearchHelper( null, null, {} );
 

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -6,7 +6,6 @@ var algoliasearchHelper = require( "../../index" );
 
 test( "Adding refinments should add an entry to the refinments attribute", function( t ) {
   var helper = algoliasearchHelper( {}, "index", {} );
-  helper._search = function() {};
 
   var facetName = "facet1";
   var facetValue = "42";
@@ -22,9 +21,26 @@ test( "Adding refinments should add an entry to the refinments attribute", funct
   t.end();
 } );
 
+test( "Adding several refinements for a single attribute should be handled", function( t ) {
+  var facetName = "facet";
+
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ facetName ]
+  } );
+
+  t.ok( _.isEmpty( helper.state.facetsRefinements ), "empty" );
+  helper.addRefine( facetName, "value1" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 1, "Adding one refinement, should have one" );
+  helper.addRefine( facetName, "value2" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 2, "Adding another refinement, should have two" );
+  helper.addRefine( facetName, "value1" );
+  t.ok( _.size( helper.state.facetsRefinements[ facetName ] ) === 2, "Adding same refinement as the first, should have two" );
+
+  t.end();
+} );
+
 test( "isDisjunctiveRefined", function( t ) {
   var helper = algoliasearchHelper( null, null, {} );
-  helper._search = function() {};
 
   var facet = "MyFacet";
   var value = "MyValue";


### PR DESCRIPTION
This PR is not a new feature. It tests that the feature is actually there. The tests implemented cover the different aspects required for the feature : SearchParameters can use many refinements for a single conjunctive facet, that those refinements lead to correct filtering in the query for the js client and finally that we get the expected results from Algolia engine.

It also provides the framework for integration testing with Algolia engine.

Special thanks to @vvo for the help on the integration tests ;)