### PR TITLE
FIX #25 Advanced clear refinement

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -4,6 +4,7 @@ var intersection = require( "lodash/array/intersection" );
 var forEach = require( "lodash/collection/forEach" );
 var reduce = require( "lodash/collection/reduce" );
 var filter = require( "lodash/collection/filter" );
+var pick = require( "lodash/object/pick" );
 var isEmpty = require( "lodash/lang/isEmpty" );
 var isUndefined = require( "lodash/lang/isUndefined" );
 var isString = require( "lodash/lang/isString" );
@@ -250,12 +251,12 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   clearRefinements : function clearRefinements( name ) {
-    return this.mutateMe( function( m ) {
-      m.page = 0;
-      m._clearNumericRefinements( name );
-      m._clearFacetRefinements( name );
-      m._clearExcludeRefinements( name );
-      m._clearDisjunctiveFacetRefinements( name );
+    return this.setQueryParameters( {
+      page : 0,
+      numericRefinements : this._clearNumericRefinements( name ),
+      facetsRefinements : this._clearFacetRefinements( name ),
+      facetsExcludes : this._clearExcludeRefinements( name ),
+      disjunctiveFacetsRefinements : this._clearDisjunctiveFacetRefinements( name )
     } );
   },
   /**
@@ -436,12 +437,12 @@ SearchParameters.prototype = {
    */
   _clearNumericRefinements : function _clearNumericRefinements( attribute ) {
     if ( isUndefined( attribute ) ) {
-      this.numericRefinements = {};
+      return {};
     }
     else if ( isString( attribute ) ) {
-      if ( !isUndefined( this.numericRefinements[ attribute ] ) ) {
-        delete this.numericRefinements[ attribute ];
-      }
+      return pick( this.numericRefinements, function( value, key ) {
+        return attribute !== key;
+      } );
     }
   },
   /**
@@ -533,7 +534,7 @@ SearchParameters.prototype = {
         }
       }
       else {
-        m._clearFacetRefinements( facet );
+        m.facetsRefinements = m._clearFacetRefinements( facet );
       }
     } );
   },
@@ -606,12 +607,12 @@ SearchParameters.prototype = {
    */
   _clearFacetRefinements : function _clearFacetRefinements( facet ) {
     if ( isUndefined( facet ) ) {
-      this.facetsRefinements = {};
+      return {};
     }
     else if ( isString( facet ) ) {
-      if ( !isUndefined( this.facetsRefinements[ facet ] ) ) {
-        delete this.facetsRefinements[ facet ];
-      }
+      return pick( this.facetsRefinements, function( value, key ) {
+        return key !== facet;
+      } );
     }
   },
   /**
@@ -625,12 +626,12 @@ SearchParameters.prototype = {
    */
   _clearExcludeRefinements : function _clearExcludeRefinements( facet ) {
     if ( isUndefined( facet ) ) {
-      this.facetsExcludes = {};
+      return {};
     }
     else if ( isString( facet ) ) {
-      if ( !isUndefined( this.facetsExcludes[ facet ] ) ) {
-        delete this.facetsExcludes[ facet ];
-      }
+      return pick( this.facetsExcludes, function( value, key ) {
+        return key !== facet;
+      } );
     }
   },
   /**
@@ -644,12 +645,12 @@ SearchParameters.prototype = {
    */
   _clearDisjunctiveFacetRefinements : function _clearDisjunctiveFacetRefinements( facet ) {
     if ( isUndefined( facet ) ) {
-      this.disjunctiveFacetsRefinements = {};
+      return {};
     }
     else if ( isString( facet ) ) {
-      if ( !isUndefined( this.disjunctiveFacetsRefinements[ facet ] ) ) {
-        delete this.disjunctiveFacetsRefinements[ facet ];
-      }
+      return pick( this.disjunctiveFacetsRefinements, function( value, key ) {
+        return key !== facet;
+      } );
     }
   },
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -445,9 +445,7 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( attribute ) ) {
-      return omit( this.numericRefinements, function( value, key ) {
-        return attribute === key;
-      } );
+      return omit( this.numericRefinements, attribute );
     }
     else if ( isFunction( attribute ) ) {
       return reduce( this.numericRefinements, function( memo, operators, key ) {
@@ -626,9 +624,7 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return omit( this.facetsRefinements, function( value, key ) {
-        return key === facet;
-      } );
+      return omit( this.facetsRefinements, facet );
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.facetsRefinements, function( memo, values, key ) {
@@ -656,9 +652,7 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return omit( this.facetsExcludes, function( value, key ) {
-        return key === facet;
-      } );
+      return omit( this.facetsExcludes, facet );
     }
     else if( isFunction( facet ) ) {
       return reduce( this.facetsExcludes, function( memo, excludes, key ) {
@@ -686,9 +680,7 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return omit( this.disjunctiveFacetsRefinements, function( value, key ) {
-        return key === facet;
-      } );
+      return omit( this.disjunctiveFacetsRefinements, facet );
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.disjunctiveFacetsRefinements, function( memo, values, key ) {

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -4,7 +4,7 @@ var intersection = require( "lodash/array/intersection" );
 var forEach = require( "lodash/collection/forEach" );
 var reduce = require( "lodash/collection/reduce" );
 var filter = require( "lodash/collection/filter" );
-var pick = require( "lodash/object/pick" );
+var omit = require( "lodash/object/omit" );
 var isEmpty = require( "lodash/lang/isEmpty" );
 var isUndefined = require( "lodash/lang/isUndefined" );
 var isString = require( "lodash/lang/isString" );
@@ -251,7 +251,7 @@ SearchParameters.prototype = {
    * @param {string|SearchParameters.clearCallback} [attribute] optionnal string or function
    * - If not given, means to clear all the filters.
    * - If `string`, means to clear all refinements for the `attribute` named filter.
-   * - If `function`, means to clear all the refinements that return falsey values.
+   * - If `function`, means to clear all the refinements that return truthy values.
    * @return {SearchParameters}
    */
   clearRefinements : function clearRefinements( attribute ) {
@@ -437,7 +437,7 @@ SearchParameters.prototype = {
    * @param {string|SearchParameters.clearCallback} [attribute] optionnal string or function
    * - If not given, means to clear all the filters.
    * - If `string`, means to clear all refinements for the `attribute` named filter.
-   * - If `function`, means to clear all the refinements that return falsey values.
+   * - If `function`, means to clear all the refinements that return truthy values.
    * @return {Object.<string, OperatorList>}
    */
   _clearNumericRefinements : function _clearNumericRefinements( attribute ) {
@@ -445,17 +445,18 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( attribute ) ) {
-      return pick( this.numericRefinements, function( value, key ) {
-        return attribute !== key;
+      return omit( this.numericRefinements, function( value, key ) {
+        return attribute === key;
       } );
     }
     else if ( isFunction( attribute ) ) {
       return reduce( this.numericRefinements, function( memo, operators, key ) {
-        var operatorList = pick( operators, function( value ) {
-          return attribute( value, key, "numeric" );
+        var operatorList = omit( operators, function( value, operator ) {
+          return attribute( { val : value, op : operator }, key, "numeric" );
         } );
 
         if( !isEmpty( operatorList ) ) memo[ key ] = operatorList;
+        return memo;
       }, {} );
     }
   },
@@ -617,7 +618,7 @@ SearchParameters.prototype = {
    * @param {string|SearchParameters.clearCallback} [facet] optionnal string or function
    * - If not given, means to clear the refinement of all facets.
    * - If `string`, means to clear the refinement for the `facet` named facet.
-   * - If `function`, means to clear all the refinements that return falsey values.
+   * - If `function`, means to clear all the refinements that return truthy values.
    * @return {Object.<string, FacetList>}
    */
   _clearFacetRefinements : function _clearFacetRefinements( facet ) {
@@ -625,17 +626,18 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return pick( this.facetsRefinements, function( value, key ) {
-        return key !== facet;
+      return omit( this.facetsRefinements, function( value, key ) {
+        return key === facet;
       } );
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.facetsRefinements, function( memo, values, key ) {
-        var facetList = pick( values, function( value ) {
+        var facetList = omit( values, function( value ) {
           return facet( value, key, "conjunctiveFacet" );
         } );
 
         if( !isEmpty( facetList ) ) memo[ key ] = facetList;
+        return memo;
       }, {} );
     }
   },
@@ -646,7 +648,7 @@ SearchParameters.prototype = {
    * @param {string|SearchParameters.clearCallback} [facet] optionnal string or function
    * - If not given, means to clear all the excludes of all facets.
    * - If `string`, means to clear all the excludes for the `facet` named facet.
-   * - If `function`, means to clear all the refinements that return falsey values
+   * - If `function`, means to clear all the refinements that return truthy values
    * @return {Object.<string, FacetList>}
    */
   _clearExcludeRefinements : function _clearExcludeRefinements( facet ) {
@@ -654,17 +656,18 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return pick( this.facetsExcludes, function( value, key ) {
-        return key !== facet;
+      return omit( this.facetsExcludes, function( value, key ) {
+        return key === facet;
       } );
     }
     else if( isFunction( facet ) ) {
       return reduce( this.facetsExcludes, function( memo, excludes, key ) {
-        var excludeList = pick( excludes, function( exclude ) {
+        var excludeList = omit( excludes, function( exclude ) {
           return facet( exclude, key, "exclude" );
         } );
 
         if( !isEmpty( excludeList ) ) memo[ key ] = excludeList;
+        return memo;
       }, {} );
     }
   },
@@ -675,7 +678,7 @@ SearchParameters.prototype = {
    * @param {string|SearchParameters.clearCallback} [facet] optionnal string or function
    * - If not given, means to clear all the refinements of all disjunctive facets.
    * - If `string`, means to clear all the refinements for the `facet` named facet.
-   * - If `function`, means to clear all the refinements that return falsey values.
+   * - If `function`, means to clear all the refinements that return truthy values.
    * @return {Object.<string, FacetList>}
    */
   _clearDisjunctiveFacetRefinements : function _clearDisjunctiveFacetRefinements( facet ) {
@@ -683,17 +686,18 @@ SearchParameters.prototype = {
       return {};
     }
     else if ( isString( facet ) ) {
-      return pick( this.disjunctiveFacetsRefinements, function( value, key ) {
-        return key !== facet;
+      return omit( this.disjunctiveFacetsRefinements, function( value, key ) {
+        return key === facet;
       } );
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.disjunctiveFacetsRefinements, function( memo, values, key ) {
-        var facetList = pick( values, function( value ) {
+        var facetList = omit( values, function( value ) {
           return facet( value, key, "disjunctiveFacet" );
         } );
 
         if( !isEmpty( facetList ) ) memo[ key ] = facetList;
+        return memo;
       }, {} );
     }
   },

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -632,8 +632,8 @@ SearchParameters.prototype = {
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.facetsRefinements, function( memo, values, key ) {
-        var facetList = omit( values, function( value ) {
-          return facet( value, key, "conjunctiveFacet" );
+        var facetList = filter( values, function( value ) {
+          return !facet( value, key, "conjunctiveFacet" );
         } );
 
         if( !isEmpty( facetList ) ) memo[ key ] = facetList;
@@ -662,8 +662,8 @@ SearchParameters.prototype = {
     }
     else if( isFunction( facet ) ) {
       return reduce( this.facetsExcludes, function( memo, excludes, key ) {
-        var excludeList = omit( excludes, function( exclude ) {
-          return facet( exclude, key, "exclude" );
+        var excludeList = filter( excludes, function( exclude ) {
+          return !facet( exclude, key, "exclude" );
         } );
 
         if( !isEmpty( excludeList ) ) memo[ key ] = excludeList;
@@ -692,8 +692,8 @@ SearchParameters.prototype = {
     }
     else if ( isFunction( facet ) ) {
       return reduce( this.disjunctiveFacetsRefinements, function( memo, values, key ) {
-        var facetList = omit( values, function( value ) {
-          return facet( value, key, "disjunctiveFacet" );
+        var facetList = filter( values, function( value ) {
+          return !facet( value, key, "disjunctiveFacet" );
         } );
 
         if( !isEmpty( facetList ) ) memo[ key ] = facetList;

--- a/test/spec/helper.clears.js
+++ b/test/spec/helper.clears.js
@@ -71,11 +71,11 @@ test( "Clearing the same field from multiple elements should remove it everywher
   t.end();
 } );
 
-test( "Clear with a function : neutral and abosorbing ops", function( t ) {
+test( "Clear with a function : neutral predicate", function( t ) {
   var helper = init();
   var state0 = helper.state;
 
-  helper.clearRefinements( function( value, key, type ) {
+  helper.clearRefinements( function() {
     return false;
   } );
 
@@ -84,7 +84,13 @@ test( "Clear with a function : neutral and abosorbing ops", function( t ) {
   t.deepEqual( helper.state.facetsExcludes, state0.facetsExcludes, "Neutral op : exclude ref should be equal" );
   t.deepEqual( helper.state.disjunctiveFacetsRefinements, state0.disjunctiveFacetsRefinements, "Neutral op : disj ref should be equal" );
 
-  helper.clearRefinements( function( value, key, type ) {
+  t.end();
+} );
+
+test( "Clear with a function : remove all predicate", function( t ) {
+  var helper = init();
+
+  helper.clearRefinements( function() {
     return true;
   } );
 

--- a/test/spec/helper.clears.js
+++ b/test/spec/helper.clears.js
@@ -6,7 +6,7 @@ var test = require( "tape" ),
     isEmpty = require( "lodash/lang/isEmpty" ),
     isUndefined = require( "lodash/lang/isUndefined" );
 
-var init = function init() {
+var fixture = function fixture() {
   var helper = algoliasearchHelper( undefined, "Index", {
     facets : ["facet1", "facet2", "both_facet"],
     disjunctiveFacets : ["disjunctiveFacet1", "disjunctiveFacet2", "both_facet"]
@@ -25,7 +25,7 @@ var init = function init() {
 };
 
 test( "Check that the state objects match how we test them", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   t.deepEqual( helper.state.facetsRefinements, { "facet1" : [ "0" ], "facet2" : [ "0" ] } );
   t.deepEqual( helper.state.disjunctiveFacetsRefinements, { "disjunctiveFacet1" : [ "0" ], "disjunctiveFacet2" : [ "0" ] } );
@@ -36,7 +36,7 @@ test( "Check that the state objects match how we test them", function( t ) {
 } );
 
 test( "Clear with a name should work on every type and not remove others than targetted name", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   helper.clearRefinements( "facet1" );
   t.deepEqual( helper.state.facetsRefinements, { "facet2" : [ "0" ] } );
@@ -55,7 +55,7 @@ test( "Clear with a name should work on every type and not remove others than ta
 
 
 test( "Clearing the same field from multiple elements should remove it everywhere", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   helper.addNumericRefinement( "facet1", ">=", "10" ).toggleExclude( "facet1", "value" );
 
@@ -72,7 +72,7 @@ test( "Clearing the same field from multiple elements should remove it everywher
 } );
 
 test( "Clear with a function : neutral predicate", function( t ) {
-  var helper = init();
+  var helper = fixture();
   var state0 = helper.state;
 
   helper.clearRefinements( function() {
@@ -88,7 +88,7 @@ test( "Clear with a function : neutral predicate", function( t ) {
 } );
 
 test( "Clear with a function : remove all predicate", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   helper.clearRefinements( function() {
     return true;
@@ -103,7 +103,7 @@ test( "Clear with a function : remove all predicate", function( t ) {
 } );
 
 test( "Clear with a function : filtering", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   var checkType = {
     numeric : false,
@@ -130,7 +130,7 @@ test( "Clear with a function : filtering", function( t ) {
 } );
 
 test( "Clearing twice the same attribute should be not problem", function( t ) {
-  var helper = init();
+  var helper = fixture();
 
   t.deepEqual( helper.state.facetsRefinements.facet1, [ "0" ] );
   helper.clearRefinements( "facet1" );


### PR DESCRIPTION
Let the user use a function to clear specific refinements.

Will go through all the refinements, and call the user function with the parameters : 
 - value : for numeric the value and the operator, otherwise just the facet value
 - attribute : the attribute the refinement is applied on
 - type : the type of refinement