### PR TITLE
FIX #110 : provide a way to test if an attribute is numerically defined

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -713,11 +713,13 @@ SearchParameters.prototype = {
     return RefinementList.isRefined( this.disjunctiveFacetsRefinements, facet, value );
   },
   /**
-   * Test if the triple attribute operator value is already refined.
+   * Test if the triple (attribute, operator, value) is already refined.
+   * If only the attribute and the operator are provided, it tests if the
+   * contains any refinement value.
    * @method
    * @param {string} attribute attribute for which the refinement is applied
    * @param {string} operator operator of the refinement
-   * @param {string} value value of the refinement
+   * @param {string} [value] value of the refinement
    * @return {boolean} true if it is refined
    */
   isNumericRefined : function isNumericRefined( attribute, operator, value ) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -5,6 +5,7 @@ var extend = require( "./functions/extend" );
 var util = require( "util" );
 var events = require( "events" );
 var forEach = require( "lodash/collection/forEach" );
+var isEmpty = require( "lodash/lang/isEmpty" );
 var bind = require( "lodash/function/bind" );
 
 /**
@@ -346,12 +347,12 @@ AlgoliaSearchHelper.prototype.isRefined = function( facet, value ) {
 };
 
 /**
- * Check if the facet has any disjunctive or conjunctive refinements
- * @param {string} facet the facet attribute name
+ * Check if the attribute has any numeric, disjunctive or conjunctive refinements
+ * @param {string} attribute the facet attribute name
  * @return {boolean} true if the facet is facetted by at least one value
  */
-AlgoliaSearchHelper.prototype.hasRefinements = function( facet ) {
-  return this.isRefined( facet );
+AlgoliaSearchHelper.prototype.hasRefinements = function( attribute ) {
+  return !isEmpty( this.state.getNumericRefinements( attribute ) ) || this.isRefined( attribute );
 };
 
 /**

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -352,7 +352,8 @@ AlgoliaSearchHelper.prototype.isRefined = function( facet, value ) {
  * @return {boolean} true if the attribute is filtered by at least one value
  */
 AlgoliaSearchHelper.prototype.hasRefinements = function( attribute ) {
-  return !isEmpty( this.state.getNumericRefinements( attribute ) ) || this.isRefined( attribute );
+  var attributeHasNumericRefinements = !isEmpty( this.state.getNumericRefinements( attribute ) );
+  return attributeHasNumericRefinements || this.isRefined( attribute );
 };
 
 /**

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -348,8 +348,8 @@ AlgoliaSearchHelper.prototype.isRefined = function( facet, value ) {
 
 /**
  * Check if the attribute has any numeric, disjunctive or conjunctive refinements
- * @param {string} attribute the facet attribute name
- * @return {boolean} true if the facet is facetted by at least one value
+ * @param {string} attribute the name of the attribute
+ * @return {boolean} true if the attribute is filtered by at least one value
  */
 AlgoliaSearchHelper.prototype.hasRefinements = function( attribute ) {
   return !isEmpty( this.state.getNumericRefinements( attribute ) ) || this.isRefined( attribute );

--- a/test/spec/helper.numericFilters.js
+++ b/test/spec/helper.numericFilters.js
@@ -52,3 +52,13 @@ test( "Should be able to remove a value if it equals 0", function( t ) {
   t.equal( helper.state.numericRefinements.attribute, undefined, "should set to undefined" );
   t.end();
 } );
+
+test( "Should be able to get if an attribute has numeric filter with hasRefinements", function( t ) {
+  var helper = algoliasearchHelper( null, null, null );
+
+  t.notOk( helper.hasRefinements( "attribute" ), "not refined initially" );
+  helper.addNumericRefinement( "attribute", "=", 42 );
+  t.ok( helper.hasRefinements( "attribute" ), "should be refined" );
+
+  t.end();
+} );


### PR DESCRIPTION
hasRefinements now test if a given attribute contains a numeric filter too.