### PR TITLE
Fix #106 Convert facet value to string

### DIFF
--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -27,7 +27,7 @@ var lib = {
    * Adds a refinement to a RefinementList
    * @param {RefinementList} refinementList the initial list
    * @param {string} attribute the attribute to refine
-   * @param {string} value the value of the refinement
+   * @param {string} value the value of the refinement, if the value is not a string it will be converted
    * @return {RefinementList} a new and updated prefinement list
    */
   addRefinement : function addRefinement( refinementList, attribute, value ) {
@@ -35,7 +35,9 @@ var lib = {
       return refinementList;
     }
 
-    var facetRefinement = !refinementList[ attribute ] ? [ value ] : refinementList[ attribute ].concat( value );
+    var valueAsString = "" + value;
+
+    var facetRefinement = !refinementList[ attribute ] ? [ valueAsString ] : refinementList[ attribute ].concat( valueAsString );
 
     var mod = {};
     mod[ attribute ] = facetRefinement;
@@ -56,8 +58,10 @@ var lib = {
       return lib.clearRefinement( refinementList, attribute );
     }
 
+    var valueAsString = "" + value;
+
     return lib.clearRefinement( refinementList, function( v, f ) {
-      return attribute === f && value === v;
+      return attribute === f && valueAsString === v;
     } );
   },
   /**
@@ -118,12 +122,14 @@ var lib = {
     var containsRefinements = refinementList[ attribute ] &&
                               refinementList[ attribute ].length > 0;
 
-    if( refinementValue === undefined ) {
+    if( isUndefined( refinementValue ) ) {
       return containsRefinements;
     }
 
+    var refinementValueAsString = "" + refinementValue;
+
     return containsRefinements &&
-           refinementList[ attribute ].indexOf( refinementValue ) !== -1;
+           refinementList[ attribute ].indexOf( refinementValueAsString ) !== -1;
   }
 };
 

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -489,7 +489,7 @@ SearchParameters.prototype = {
    * Add a refinement on a "normal" facet
    * @method
    * @param {string} facet attribute to apply the facetting on
-   * @param {string} value value of the attribute
+   * @param {string} value value of the attribute (will be converted to string)
    * @return {SearchParameters}
    */
   addFacetRefinement : function addFacetRefinement( facet, value ) {
@@ -503,7 +503,7 @@ SearchParameters.prototype = {
    * Exclude a value from a "normal" facet
    * @method
    * @param {string} facet attribute to apply the exclusion on
-   * @param {string} value value of the attribute
+   * @param {string} value value of the attribute (will be converted to string)
    * @return {SearchParameters}
    */
   addExcludeRefinement : function addExcludeRefinement( facet, value ) {
@@ -517,7 +517,7 @@ SearchParameters.prototype = {
    * Adds a refinement on a disjunctive facet.
    * @method
    * @param {string} facet attribute to apply the facetting on
-   * @param {string} value value of the attribute
+   * @param {string} value value of the attribute (will be converted to string)
    * @return {SearchParameters}
    */
   addDisjunctiveFacetRefinement : function addDisjunctiveFacetRefinement( facet, value ) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -76,7 +76,7 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
- * @param  {string} value the associated value
+ * @param  {string} value the associated value (will be converted to string)
  * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function( facet, value ) {
@@ -101,7 +101,7 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function( attribute, operat
 /**
  * Ensure a facet refinement exists
  * @param  {string} facet the facet to refine
- * @param  {string} value the associated value
+ * @param  {string} value the associated value (will be converted to string)
  * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
@@ -113,7 +113,7 @@ AlgoliaSearchHelper.prototype.addRefine = function( facet, value ) {
 /**
  * Ensure a facet exclude exists
  * @param  {string} facet the facet to refine
- * @param  {string} value the associated value
+ * @param  {string} value the associated value (will be converted to string)
  * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.addExclude = function( facet, value ) {
@@ -145,7 +145,6 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function( attribute, ope
   this._change();
   return this;
 };
-
 
 /**
  * Ensure a facet refinement does not exist

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -175,6 +175,7 @@ test( "getRefinements should return all the refinements for a given facet", func
 
   t.end();
 } );
+
 test( "getRefinements should return an empty array if the facet has no refinement", function( t ) {
   var helper = algoliasearchHelper( null, null, {
     facets : [ "facet1" ],
@@ -183,6 +184,69 @@ test( "getRefinements should return an empty array if the facet has no refinemen
 
   t.deepEqual( helper.getRefinements( "facet1" ), [], "" );
   t.deepEqual( helper.getRefinements( "facet2" ), [], "" );
+
+  t.end();
+} );
+
+test( "[Conjunctive] Facets should be resilient to user attempt to use numbers", function( t ) {
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ "facet1" ],
+    disjunctiveFacets : [ "facet2" ]
+  } );
+
+  helper.addRefine( "facet1", 42 );
+  t.ok( helper.isRefined( "facet1", 42 ), "[facet][number] should be refined" );
+  t.ok( helper.isRefined( "facet1", "42" ), "[facet][string] should be refined" );
+
+  var stateWithFacet1and42 = helper.state;
+  helper.removeRefine( "facet1", "42" );
+  t.notOk( helper.isRefined( "facet1", "42" ), "[facet][string] should not be refined" );
+
+  helper.setState( stateWithFacet1and42 );
+  helper.removeRefine( "facet1", 42 );
+  t.notOk( helper.isRefined( "facet1", 42 ), "[facet][number] should not be refined" );
+
+  t.end();
+} );
+
+test( "[Disjunctive] Facets should be resilient to user attempt to use numbers", function( t ) {
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ "facet1" ],
+    disjunctiveFacets : [ "facet2" ]
+  } );
+
+  helper.addExclude( "facet1", 42 );
+  t.ok( helper.isExcluded( "facet1", 42 ), "[facet][number] should be refined" );
+  t.ok( helper.isExcluded( "facet1", "42" ), "[facet][string] should be refined" );
+
+  var stateWithFacet1Without42 = helper.state;
+  helper.removeExclude( "facet1", "42" );
+  t.notOk( helper.isExcluded( "facet1", "42" ), "[facet][string] should not be refined" );
+
+  helper.setState( stateWithFacet1Without42 );
+  helper.removeExclude( "facet1", 42 );
+  t.notOk( helper.isExcluded( "facet1", 42 ), "[facet][number] should not be refined" );
+
+  t.end();
+} );
+
+test( "[Disjunctive] Facets should be resilient to user attempt to use numbers", function( t ) {
+  var helper = algoliasearchHelper( null, null, {
+    facets : [ "facet1" ],
+    disjunctiveFacets : [ "facet2" ]
+  } );
+
+  helper.addDisjunctiveRefine( "facet2", 42 );
+  t.ok( helper.isDisjunctiveRefined( "facet2", 42 ), "[facet][number] should be refined" );
+  t.ok( helper.isDisjunctiveRefined( "facet2", "42" ), "[facet][string] should be refined" );
+
+  var stateWithFacet2and42 = helper.state;
+  helper.removeDisjunctiveRefine( "facet2", "42" );
+  t.notOk( helper.isDisjunctiveRefined( "facet2", "42" ), "[facet][string] should not be refined" );
+  helper.setState( stateWithFacet2and42 );
+
+  helper.removeDisjunctiveRefine( "facet2", 42 );
+  t.notOk( helper.isDisjunctiveRefined( "facet2", 42 ), "[facet][number] should not be refined" );
 
   t.end();
 } );


### PR DESCRIPTION
Use case : 
 - user input a number as a facet filter
 - algolia returns string for facet values
 - user can't loop over the values to check if they are refined because on one side the value is a string, and on the other the value is a number, making the comparison false.

In this fix, the lib will always convert any input value for the filters to strings. This will apply to conjunctive, disjunctive and exclude refinements.