### PR TITLE
jsdelivr versionning

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ helper.search();
 
 Include this in your page :
 
-`<script src="//cdn.jsdelivr.net/algoliasearch.helper/2.0.0/algoliasearch.helper.min.js"></script>`
+`<script src="//cdn.jsdelivr.net/algoliasearch.helper/2/algoliasearch.helper.min.js"></script>`
 
 ## How to contribute
 


### PR DESCRIPTION
Since we're using Semver, I believe we should recommend to use v2 instead of v2.0.0.
jsDelivr's cache lasts 7 days (and we can rebuild it manually if needed), which means that we have some room to fix an issue introduced in a version, while being able to push an update on our clients websites seamlessly.