### PR TITLE
style: run jsfmt on current code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var AlgoliaSearchHelper = require('./src/algoliasearch.helper');
 
 var SearchParameters = require('./src/SearchParameters');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "doc:watch": "onchange 'src/**/*.js' 'index.js' 'tutorials/*.md' '../minami/**/*.*' -- npm run doc",
     "doc:publish": "gh-pages-deploy",
     "test-ci": "scripts/test-ci.sh",
-    "test": "scripts/test.sh"
+    "test": "scripts/test.sh",
+    "jsfmt": "jsfmt"
   },
   "gh-pages-deploy": {
     "prep": [
@@ -42,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@algolia/jsfmt": "1.3.0",
     "algoliasearch": "latest",
     "browserify": "10.2.4",
     "bulk-require": "0.2.1",
@@ -50,7 +52,7 @@
     "envify": "3.4.0",
     "eslint": "0.24.0",
     "eslint-config-airbnb": "0.0.6",
-    "eslint-config-algolia": "2.0.4",
+    "eslint-config-algolia": "2.1.1",
     "gh-pages-deploy": "0.3.0",
     "http-server": "0.8.0",
     "jscs": "1.13.1",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,3 +6,4 @@ set -x # debug messages
 echo "Lint"
 
 eslint . --quiet
+jsfmt --diff

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Functions to manipulate refinement lists
  *
@@ -10,7 +12,6 @@
  * @typedef {Object.<string, SearchParameters.refinementList.Refinements>} SearchParameters.refinementList.RefinementList
  */
 
-'use strict';
 
 var extend = require('../functions/extend');
 

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var keys = require('lodash/object/keys');
 var intersection = require('lodash/array/intersection');
 var forEach = require('lodash/collection/forEach');
@@ -852,7 +853,7 @@ SearchParameters.prototype = {
     'facets', 'disjunctiveFacets', 'facetsRefinements',
     'facetsExcludes', 'disjunctiveFacetsRefinements',
     'numericRefinements', 'tagRefinements'
- ],
+  ],
   getQueryParams: function getQueryParams() {
     var managedParameters = this.managedParameters;
 

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var forEach = require('lodash/collection/forEach');
 var compact = require('lodash/array/compact');
 var sum = require('lodash/collection/sum');

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var SearchParameters = require('./SearchParameters');
 var SearchResults = require('./SearchResults');
 var extend = require('./functions/extend');
@@ -220,7 +221,7 @@ AlgoliaSearchHelper.prototype.toggleRefine = function(facet, value) {
     this.state = this.state.toggleDisjunctiveFacetRefinement(facet, value);
   } else {
     throw new Error("Can't refine the undeclared facet '" + facet +
-                    "'; it should be added to the helper options 'facets' or 'disjunctiveFacets'");
+      "'; it should be added to the helper options 'facets' or 'disjunctiveFacets'");
   }
 
   this._change();

--- a/src/functions/deepFreeze.js
+++ b/src/functions/deepFreeze.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var isObject = require('lodash/lang/isObject');
 var forEach = require('lodash/collection/forEach');
 

--- a/src/functions/extend.js
+++ b/src/functions/extend.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = function extend(out) {
   out = out || {};
 

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -20,7 +20,7 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
       {facet: ['f1', 'f2']},
       {facet: ['f1', 'f3']},
       {facet: ['f2', 'f3']}
-   ])
+    ])
       .then(function() {
         return index.setSettings({
           attributesToIndex: ['facet'],
@@ -47,7 +47,7 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
 
       if (calls === 1) {
         t.equal(content.hits.length, 2, 'filter should result in two items');
-        t.deepEqual(content.facets[ 0 ].data, {
+        t.deepEqual(content.facets[0].data, {
           f1: 2,
           f2: 1,
           f3: 1
@@ -58,7 +58,7 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
 
       if (calls === 2) {
         t.equal(content.hits.length, 1, 'filter should result in one item');
-        t.deepEqual(content.facets[ 0 ].data, {
+        t.deepEqual(content.facets[0].data, {
           f1: 1,
           f2: 1
         });
@@ -67,7 +67,7 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
 
       if (calls === 3) {
         t.equal(content.hits.length, 0, 'filter should result in 0 item');
-        t.equal(content.facets[ 0 ], undefined);
+        t.equal(content.facets[0], undefined);
         helper.removeRefine('facet', 'f2').search();
       }
 
@@ -87,5 +87,5 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
 
     helper.addRefine('facet', 'f1').search();
   })
-  .then(null, bind(t.error, t));
+    .then(null, bind(t.error, t));
 });

--- a/test/integration-spec/helper.highlight.js
+++ b/test/integration-spec/helper.highlight.js
@@ -43,21 +43,21 @@ test('[INT][HIGHLIGHT] The highlight should be consistent with the parameters', 
       calls++;
       if (calls === 1) {
         t.equal(content.hits[0]._highlightResult.facet[0].value,
-                '<em>f1</em>',
-                'should be hightlighted with em (default)');
+          '<em>f1</em>',
+          'should be hightlighted with em (default)');
         t.equal(content.hits[1]._highlightResult.facet[0].value,
-                '<em>f1</em>',
-                'should be hightlighted with em (default)');
+          '<em>f1</em>',
+          'should be hightlighted with em (default)');
         helper.setQueryParameter('highlightPostTag', '</strong>')
-              .setQueryParameter('highlightPreTag', '<strong>')
-              .search();
+          .setQueryParameter('highlightPreTag', '<strong>')
+          .search();
       } else if (calls === 2) {
         t.equal(content.hits[0]._highlightResult.facet[0].value,
-                '<strong>f1</strong>',
-                'should be hightlighted with strong (setting)');
+          '<strong>f1</strong>',
+          'should be hightlighted with strong (setting)');
         t.equal(content.hits[1]._highlightResult.facet[0].value,
-                '<strong>f1</strong>',
-                'should be hightlighted with strong (setting)');
+          '<strong>f1</strong>',
+          'should be hightlighted with strong (setting)');
         client.deleteIndex(indexName);
         if (!process.browser) {
           client.destroy();
@@ -67,7 +67,7 @@ test('[INT][HIGHLIGHT] The highlight should be consistent with the parameters', 
     });
 
     helper.setQuery('f1')
-          .search();
+      .search();
   })
-  .then(null, bind(t.error, t));
+    .then(null, bind(t.error, t));
 });

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -88,5 +88,5 @@ test('[INT][TAGS]Test tags operations on the helper and their results on the alg
 
     helper.search();
   })
-  .then(null, bind(t.error, t));
+    .then(null, bind(t.error, t));
 });

--- a/test/spec/SearchParameters.noChanges.js
+++ b/test/spec/SearchParameters.noChanges.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 
 var SearchParameters = require('../../src/SearchParameters');

--- a/test/spec/SearchParameters.setQueryParameter.js
+++ b/test/spec/SearchParameters.setQueryParameter.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var SearchParameters = require('../../src/SearchParameters');
 

--- a/test/spec/SearchParameters.setQueryParameters.js
+++ b/test/spec/SearchParameters.setQueryParameters.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var SearchParameters = require('../../src/SearchParameters');
 

--- a/test/spec/SearchResults.getFacet.js
+++ b/test/spec/SearchResults.getFacet.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var SearchResults = require('../../src/SearchResults');
 

--- a/test/spec/helper.clears.js
+++ b/test/spec/helper.clears.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliasearchHelper = require('../../index');
 var forEach = require('lodash/collection/forEach');

--- a/test/spec/helper.distinct.js
+++ b/test/spec/helper.distinct.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var forEach = require('lodash/collection/forEach');
 

--- a/test/spec/helper.facetFilters.js
+++ b/test/spec/helper.facetFilters.js
@@ -1,6 +1,7 @@
+'use strict';
+
 // Make sure we do facet filters correctly before sending them to algolia
 
-'use strict';
 
 var test = require('tape');
 var algoliasearchHelper = require('../../index');

--- a/test/spec/helper.getQueryParameter.js
+++ b/test/spec/helper.getQueryParameter.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliaSearchHelper = require('../../index.js');
 

--- a/test/spec/helper.numericFilters.js
+++ b/test/spec/helper.numericFilters.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliaSearch = require('algoliasearch');
 var algoliasearchHelper = require('../../index');

--- a/test/spec/helper.pages.js
+++ b/test/spec/helper.pages.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliasearchHelper = require('../../index');
 

--- a/test/spec/helper.queryID.js
+++ b/test/spec/helper.queryID.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliasearchHelper = require('../../index');
 

--- a/test/spec/helper.setQueryParameter.js
+++ b/test/spec/helper.setQueryParameter.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliasearchHelper = require('../../index');
 

--- a/test/spec/helper.tags.js
+++ b/test/spec/helper.tags.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var algoliasearchHelper = require('../../index');
 

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var _ = require('lodash');
 var algoliasearchHelper = require('../../index');

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var test = require('tape');
 var sinon = require('sinon');
 var algoliaSearch = require('algoliasearch');

--- a/test/spec/search.testdata.js
+++ b/test/spec/search.testdata.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var SearchParameters = require('../../src/SearchParameters');
 
 var response = {

--- a/zuul.config.js
+++ b/zuul.config.js
@@ -34,7 +34,7 @@ var browsers = {
   all: [{
     name: 'chrome',
     version: '42..beta',
-    platform: 'Windows 2012 R2'  // Force Win 8.1, more stable than linux etc
+    platform: 'Windows 2012 R2' // Force Win 8.1, more stable than linux etc
   }, {
     name: 'firefox',
     version: '37..beta',
@@ -75,7 +75,6 @@ var browsers = {
   }]
 };
 
-zuulConfig.browsers =
-  process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST !== 'false' ?
-    browsers.pullRequest :
-    browsers.all;
+zuulConfig.browsers = process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST !== 'false' ?
+  browsers.pullRequest :
+  browsers.all;


### PR DESCRIPTION
- upgrade eslint configuration to latest (some spacing were not consistent)
- created [algolia/jsfmt](https://github.com/algolia/jsfmt) that can rewrite a whole project according to our style
- add an `npm run jsfmt` script
- run `jsfmt --diff` as part of the linting, so that when code style is not conform, we error. Most of the time, fixing the ESLint errors should get you out of the way of jsfmt.
- If you just want to reformat at any point, do `npm run jsfmt`

Also

```sh
npm install @algolia/jsfmt -g
```

To use it anywhere in any project.