### PR TITLE
feat: hierarchical facets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@ CHANGELOG
 UNRELEASED
   * FIX: #130 toggleRefine should throw an exception when executed with an
   attribute that is not a declared facet
-  * test: add CI testing (browsers, phantom, node, io)
+  * TEST: add CI testing (browsers, phantom, node, io)
+  * FEATURE: add hierarchicalFacets
 
 2.1.2 - 2015-06-26
   * FIX: #113 support for attributes hightlightPreTag and hightlighPostTag

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ var helper = algoliasearchHelper(client, indexName, {
     separator: '|'
   }]
 });
+
+helper.toggleRefine('products', 'fruits|citrus');
 ```
 
 Would mean that your objects look like so:
@@ -394,6 +396,29 @@ Would mean that your objects look like so:
   }
 }
 ```
+
+##### Asking for the current breadcrumb
+
+```js
+var helper = algoliasearchHelper(client, indexName, {
+  hierarchicalFacets: [{
+    name: 'products',
+    attributes: ['categories.lvl0', 'categories.lvl1'],
+    separator: '|'
+  }]
+});
+
+helper.toggleRefine('products', 'fruits|citrus');
+var breadcrumb = helper.getHierarchicalFacetBreadcrumb('products');
+
+console.log(breadcrumb);
+// ['fruits', 'citrus']
+
+console.log(breadcrumb.join(' | '));
+// 'fruits | citrus'
+```
+
+
 
 #### Clearing filters
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,106 @@ helper.addNumericRefinement('numericFacet', '=', '3').search();
 helper.removeNumericRefinemetn('numericFacet', '=', '3').search();
 ```
 
+#### Hierarchical facets
+
+Hierarchical facets are useful to build such navigation menus:
+
+```txt
+| products
+  > fruits
+    > citrus
+    | strawberries
+    | peaches
+    | apples
+```
+
+Here, we refined the search this way:
+- click on fruits
+- click on citrus
+
+To build such menu, you need to use hierarchical faceting:
+
+```javascript
+var helper = algoliasearchHelper(client, indexName, {
+  hierarchicalFacets: [{
+    name: 'products',
+    attributes: ['categories.lvl0', 'categories.lvl1']
+  }]
+});
+```
+
+Given your objects looks like this:
+
+```json
+{
+  "objectID": "123",
+  "name": "orange",
+  "categories": {
+    "lvl0": "fruits",
+    "lvl1": "fruits > citrus"
+  }
+}
+```
+
+And you refine `products`:
+
+```js
+helper.toggleRefine('products', 'fruits > citrus');
+```
+
+You will get a hierarchical presentation of your facet values: a navigation menu
+of your facet values.
+
+```js
+helper.on('result', function(data){
+  console.log(data.hierarchicalFacets[0]);
+  // {
+  //   'name': 'products',
+  //   'count': null,
+  //   'isRefined': true,
+  //   'path': null,
+  //   'data': [{
+  //     'name': 'fruits',
+  //     'path': 'fruits',
+  //     'count': 1,
+  //     'isRefined': true,
+  //     'data': [{
+  //       'name': 'citrus',
+  //       'path': 'fruits > citrus',
+  //       'count': 1,
+  //       'isRefined': true,
+  //       'data': null
+  //     }]
+  //   }]
+  // }
+});
+```
+
+##### Specifying another separator
+
+```js
+var helper = algoliasearchHelper(client, indexName, {
+  hierarchicalFacets: [{
+    name: 'products',
+    attributes: ['categories.lvl0', 'categories.lvl1'],
+    separator: '|'
+  }]
+});
+```
+
+Would mean that your objects look like so:
+
+```json
+{
+  "objectID": "123",
+  "name": "orange",
+  "categories": {
+    "lvl0": "fruits",
+    "lvl1": "fruits|citrus"
+  }
+}
+```
+
 #### Clearing filters
 
 ##### Clear all the refinements for all the refined attributes

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "readme:toc": "doctoc --notitle README.md --maxlevel 3",
     "test-ci": "scripts/test-ci.sh",
     "test": "scripts/test.sh",
+    "test-node": "clear && node test/run",
+    "test:watch": "onchange '{src,test}/**/*.js' 'index.js' -- npm run test-node",
     "jsfmt": "jsfmt"
   },
   "gh-pages-deploy": {

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -12,7 +12,6 @@ var isUndefined = require('lodash/lang/isUndefined');
 var isString = require('lodash/lang/isString');
 var isFunction = require('lodash/lang/isFunction');
 var find = require('lodash/collection/find');
-var trimRight = require('lodash/string/trimRight');
 
 var extend = require('../functions/extend');
 var deepFreeze = require('../functions/deepFreeze');

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -755,6 +755,10 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   toggleHierarchicalFacetRefinement: function toggleHierarchicalFacetRefinement(facet, value) {
+    if (!this.isHierarchicalFacet(facet)) {
+      throw new Error(facet + ' is not defined in the hierarchicalFacets attribute of the helper configuration');
+    }
+
     var separator = this.getHierarchicalFacetSeparator(this.getHierarchicalFacetByName(facet));
 
     var mod = {};

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -757,26 +757,24 @@ SearchParameters.prototype = {
   toggleHierarchicalFacetRefinement: function toggleHierarchicalFacetRefinement(facet, value) {
     var separator = this.getHierarchicalFacetSeparator(this.getHierarchicalFacetByName(facet));
 
-    return this.mutateMe(function merge(newInstance) {
-      var mod = {};
+    var mod = {};
 
-      // up one level:
-      // - `beer > IPA` => `beer` or
-      // - `beer` => ``
-      if (newInstance.hierarchicalFacetsRefinements[facet] === value) {
-        if (value.indexOf(separator) === -1) {
-          // root level
-          mod[facet] = '';
-        } else {
-          mod[facet] = trimRight(value.slice(0, value.lastIndexOf(separator)));
-        }
+    // up one level:
+    // - `beer > IPA` => `beer` or
+    // - `beer` => ``
+    if (this.hierarchicalFacetsRefinements[facet] === value) {
+      if (value.indexOf(separator) === -1) {
+        // root level
+        mod[facet] = '';
       } else {
-        mod[facet] = value;
+        mod[facet] = trimRight(value.slice(0, value.lastIndexOf(separator)));
       }
+    } else {
+      mod[facet] = value;
+    }
 
-      newInstance.hierarchicalFacetsRefinements = extend({}, newInstance.hierarchicalFacetsRefinements, mod);
-
-      return newInstance;
+    return this.setQueryParameters({
+      hierarchicalFacetsRefinements: extend({}, this.hierarchicalFacetsRefinements, mod)
     });
   },
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -767,7 +767,7 @@ SearchParameters.prototype = {
         // root level
         mod[facet] = '';
       } else {
-        mod[facet] = trimRight(value.slice(0, value.lastIndexOf(separator)));
+        mod[facet] = value.slice(0, value.lastIndexOf(separator));
       }
     } else {
       mod[facet] = value;
@@ -1013,7 +1013,7 @@ SearchParameters.prototype = {
    * @return {string} returns the hierarchicalFacet.separator or `>` as default
    */
   getHierarchicalFacetSeparator: function(hierarchicalFacet) {
-    return hierarchicalFacet.separator || '>';
+    return hierarchicalFacet.separator || ' > ';
   },
 
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -369,7 +369,8 @@ SearchParameters.prototype = {
       numericRefinements: this._clearNumericRefinements(attribute),
       facetsRefinements: RefinementList.clearRefinement(this.facetsRefinements, attribute, 'conjunctiveFacet'),
       facetsExcludes: RefinementList.clearRefinement(this.facetsExcludes, attribute, 'exclude'),
-      disjunctiveFacetsRefinements: RefinementList.clearRefinement(this.disjunctiveFacetsRefinements, attribute, 'disjunctiveFacet')
+      disjunctiveFacetsRefinements: RefinementList.clearRefinement(this.disjunctiveFacetsRefinements, attribute, 'disjunctiveFacet'),
+      hierarchicalFacetsRefinements: RefinementList.clearRefinement(this.hierarchicalFacetsRefinements, attribute, 'hierarchicalFacet')
     });
   },
   /**

--- a/src/SearchResults/generate-hierarchical-tree.js
+++ b/src/SearchResults/generate-hierarchical-tree.js
@@ -61,7 +61,7 @@ function formatHierarchicalFacetValue(hierarchicalSeparator, currentRefinement) 
       name: trim(last(facetValue.split(hierarchicalSeparator))),
       path: facetValue,
       count: facetCount,
-      isRefined: currentRefinement === facetValue || currentRefinement.indexOf(facetValue + ' ' + hierarchicalSeparator) === 0,
+      isRefined: currentRefinement === facetValue || currentRefinement.indexOf(facetValue + hierarchicalSeparator) === 0,
       data: null
     };
   };

--- a/src/SearchResults/generate-hierarchical-tree.js
+++ b/src/SearchResults/generate-hierarchical-tree.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = generateTrees;
+
+var find = require('lodash/collection/find');
+var last = require('lodash/array/last');
+var map = require('lodash/collection/map');
+var reduce = require('lodash/collection/reduce');
+var sortByOrder = require('lodash/collection/sortByOrder');
+var trim = require('lodash/string/trim');
+
+function generateTrees(state) {
+  return function generate(hierarchicalFacetResult, hierarchicalFacetIndex) {
+    var hierarchicalFacet = state.hierarchicalFacets[hierarchicalFacetIndex];
+    var hierarchicalFacetRefinement = state.hierarchicalFacetsRefinements[hierarchicalFacet.name] || '';
+    var hierarchicalSeparator = state.getHierarchicalFacetSeparator(hierarchicalFacet);
+
+    return reduce(hierarchicalFacetResult, generateHierarchicalTree(hierarchicalSeparator, hierarchicalFacetRefinement), {
+      name: state.hierarchicalFacets[hierarchicalFacetIndex].name,
+      count: null, // root level, no count
+      isRefined: true, // root level, always refined
+      path: null, // root level, no path
+      data: null
+    });
+  };
+}
+
+function generateHierarchicalTree(hierarchicalSeparator, currentRefinement) {
+  return function generateTree(hierarchicalTree, hierarchicalFacetResult, currentHierarchicalLevel) {
+    var parent = hierarchicalTree;
+
+    if (currentHierarchicalLevel > 0) {
+      var level = 0;
+
+      parent = hierarchicalTree;
+
+      while (level < currentHierarchicalLevel) {
+        parent = parent && find(parent.data, {isRefined: true});
+        level++;
+      }
+    }
+
+    // we found a refined parent, let's add current level data under it
+    if (parent) {
+      parent.data = sortByOrder(
+        map(
+          hierarchicalFacetResult.data,
+          formatHierarchicalFacetValue(hierarchicalSeparator, currentRefinement)
+        ),
+        ['isRefined', 'name', 'count'], ['desc', 'asc', 'desc']
+      );
+    }
+
+    return hierarchicalTree;
+  };
+}
+
+function formatHierarchicalFacetValue(hierarchicalSeparator, currentRefinement) {
+  return function format(facetCount, facetValue) {
+    return {
+      name: trim(last(facetValue.split(hierarchicalSeparator))),
+      path: facetValue,
+      count: facetCount,
+      isRefined: currentRefinement === facetValue || currentRefinement.indexOf(facetValue + ' ' + hierarchicalSeparator) === 0,
+      data: null
+    };
+  };
+}

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -238,7 +238,6 @@ function SearchResults(state, algoliaResponse) {
 
   var facetsIndices = getIndices(state.facets);
   var disjunctiveFacetsIndices = getIndices(state.disjunctiveFacets);
-  var hierarchicalFacetsIndices = getIndices(state.hierarchicalFacets);
 
   // Since we send request only for disjunctive facets that have been refined,
   // we get the facets informations from the first, general, response.

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -246,7 +246,7 @@ function SearchResults(state, algoliaResponse) {
     var hierarchicalFacet;
 
     if (hierarchicalFacet = findMatchingHierarchicalFacetFromAttributeName(state.hierarchicalFacets, facetKey)) {
-      this.hierarchicalFacets[hierarchicalFacetsIndices[hierarchicalFacet]].push({
+      this.hierarchicalFacets[findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name})].push({
         attribute: facetKey,
         data: facetValueObject,
         exhaustive: mainSubResponse.exhaustiveFacetsCount
@@ -284,7 +284,7 @@ function SearchResults(state, algoliaResponse) {
       var position;
 
       if (hierarchicalFacet) {
-        position = hierarchicalFacetsIndices[hierarchicalFacet];
+        position = findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name});
         var attributeIndex = findIndex(this.hierarchicalFacets[position], {attribute: dfacet});
         this.hierarchicalFacets[position][attributeIndex].data = extend({}, this.hierarchicalFacets[position][attributeIndex].data, facetResults);
       } else {

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -5,8 +5,12 @@ var compact = require('lodash/array/compact');
 var indexOf = require('lodash/array/indexOf');
 var sum = require('lodash/collection/sum');
 var find = require('lodash/collection/find');
+var includes = require('lodash/collection/includes');
+var map = require('lodash/collection/map');
+var findIndex = require('lodash/array/findIndex');
 
 var extend = require('../functions/extend');
+var generateHierarchicalTree = require('./generate-hierarchical-tree');
 
 /**
  * @typedef SearchResults.Facet
@@ -28,6 +32,15 @@ function assignFacetStats(dest, facetStats, key) {
   if (facetStats && facetStats[key]) {
     dest.stats = facetStats[key];
   }
+}
+
+function findMatchingHierarchicalFacetFromAttributeName(hierarchicalFacets, hierarchicalAttributeName) {
+  return find(
+    hierarchicalFacets,
+    function facetKeyMatchesAttribute(hierarchicalFacet) {
+      return includes(hierarchicalFacet.attributes, hierarchicalAttributeName);
+    }
+  );
 }
 
 /**
@@ -209,6 +222,13 @@ function SearchResults(state, algoliaResponse) {
    */
   this.disjunctiveFacets = [];
   /**
+   * disjunctive facets results
+   * @member {SearchResults.Facet[]}
+   */
+  this.hierarchicalFacets = map(state.hierarchicalFacets, function initFutureTree() {
+    return [];
+  });
+  /**
    * other facets results
    * @member {SearchResults.Facet[]}
    */
@@ -218,56 +238,76 @@ function SearchResults(state, algoliaResponse) {
 
   var facetsIndices = getIndices(state.facets);
   var disjunctiveFacetsIndices = getIndices(state.disjunctiveFacets);
+  var hierarchicalFacetsIndices = getIndices(state.hierarchicalFacets);
 
   // Since we send request only for disjunctive facets that have been refined,
   // we get the facets informations from the first, general, response.
   forEach(mainSubResponse.facets, function(facetValueObject, facetKey) {
-    var isFacetDisjunctive = indexOf(state.disjunctiveFacets, facetKey) !== -1;
-    var position = isFacetDisjunctive ? disjunctiveFacetsIndices[facetKey] :
-      facetsIndices[facetKey];
+    var hierarchicalFacet;
 
-    if (isFacetDisjunctive) {
-      this.disjunctiveFacets[position] = {
-        name: facetKey,
+    if (hierarchicalFacet = findMatchingHierarchicalFacetFromAttributeName(state.hierarchicalFacets, facetKey)) {
+      this.hierarchicalFacets[hierarchicalFacetsIndices[hierarchicalFacet]].push({
+        attribute: facetKey,
         data: facetValueObject,
         exhaustive: mainSubResponse.exhaustiveFacetsCount
-      };
-      assignFacetStats(this.disjunctiveFacets[position], mainSubResponse.facets_stats, facetKey);
+      });
     } else {
-      this.facets[position] = {
-        name: facetKey,
-        data: facetValueObject,
-        exhaustive: mainSubResponse.exhaustiveFacetsCount
-      };
-      assignFacetStats(this.facets[position], mainSubResponse.facets_stats, facetKey);
+      var isFacetDisjunctive = indexOf(state.disjunctiveFacets, facetKey) !== -1;
+      var position = isFacetDisjunctive ? disjunctiveFacetsIndices[facetKey] :
+        facetsIndices[facetKey];
+
+      if (isFacetDisjunctive) {
+        this.disjunctiveFacets[position] = {
+          name: facetKey,
+          data: facetValueObject,
+          exhaustive: mainSubResponse.exhaustiveFacetsCount
+        };
+        assignFacetStats(this.disjunctiveFacets[position], mainSubResponse.facets_stats, facetKey);
+      } else {
+        this.facets[position] = {
+          name: facetKey,
+          data: facetValueObject,
+          exhaustive: mainSubResponse.exhaustiveFacetsCount
+        };
+        assignFacetStats(this.facets[position], mainSubResponse.facets_stats, facetKey);
+      }
     }
   }, this);
 
   // aggregate the refined disjunctive facets
   forEach(disjunctiveFacets, function(disjunctiveFacet, idx) {
     var result = algoliaResponse.results[idx + 1];
+    var hierarchicalFacet = state.getHierarchicalFacetByName(disjunctiveFacet);
 
     // There should be only item in facets.
     forEach(result.facets, function(facetResults, dfacet) {
-      var position = disjunctiveFacetsIndices[dfacet];
+      var position;
 
-      var dataFromMainRequest = mainSubResponse.facets && mainSubResponse.facets[dfacet] || {};
+      if (hierarchicalFacet) {
+        position = hierarchicalFacetsIndices[hierarchicalFacet];
+        var attributeIndex = findIndex(this.hierarchicalFacets[position], {attribute: dfacet});
+        this.hierarchicalFacets[position][attributeIndex].data = extend({}, this.hierarchicalFacets[position][attributeIndex].data, facetResults);
+      } else {
+        position = disjunctiveFacetsIndices[dfacet];
 
-      this.disjunctiveFacets[position] = {
-        name: dfacet,
-        data: extend({}, dataFromMainRequest, facetResults),
-        exhaustive: result.exhaustiveFacetsCount
-      };
-      assignFacetStats(this.disjunctiveFacets[position], result.facets_stats, dfacet);
+        var dataFromMainRequest = mainSubResponse.facets && mainSubResponse.facets[dfacet] || {};
 
-      if (state.disjunctiveFacetsRefinements[dfacet]) {
-        forEach(state.disjunctiveFacetsRefinements[dfacet], function(refinementValue) {
-          // add the disjunctive refinements if it is no more retrieved
-          if (!this.disjunctiveFacets[position].data[refinementValue] &&
-            indexOf(state.disjunctiveFacetsRefinements[dfacet], refinementValue) > -1) {
-            this.disjunctiveFacets[position].data[refinementValue] = 0;
-          }
-        }, this);
+        this.disjunctiveFacets[position] = {
+          name: dfacet,
+          data: extend({}, dataFromMainRequest, facetResults),
+          exhaustive: result.exhaustiveFacetsCount
+        };
+        assignFacetStats(this.disjunctiveFacets[position], result.facets_stats, dfacet);
+
+        if (state.disjunctiveFacetsRefinements[dfacet]) {
+          forEach(state.disjunctiveFacetsRefinements[dfacet], function(refinementValue) {
+            // add the disjunctive refinements if it is no more retrieved
+            if (!this.disjunctiveFacets[position].data[refinementValue] &&
+              indexOf(state.disjunctiveFacetsRefinements[dfacet], refinementValue) > -1) {
+              this.disjunctiveFacets[position].data[refinementValue] = 0;
+            }
+          }, this);
+        }
       }
     }, this);
   }, this);
@@ -287,6 +327,8 @@ function SearchResults(state, algoliaResponse) {
       this.facets[position].data[facetValue] = 0;
     }, this);
   }, this);
+
+  this.hierarchicalFacets = map(this.hierarchicalFacets, generateHierarchicalTree(state));
 
   this.facets = compact(this.facets);
   this.disjunctiveFacets = compact(this.disjunctiveFacets);

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -743,7 +743,7 @@ AlgoliaSearchHelper.prototype._getFacetFilters = function(facet) {
     // let's get the parent level facet values
     if (facet) {
       attributeToRefine = hierarchicalFacet.attributes[facetValue.split(separator).length - 2];
-      facetValue = trim(facetValue.slice(0, facetValue.lastIndexOf(separator)));
+      facetValue = facetValue.slice(0, facetValue.lastIndexOf(separator));
     } else {
       attributeToRefine = hierarchicalFacet.attributes[facetValue.split(separator).length - 1];
     }

--- a/test/spec/hierarchical-facets/breadcrumb.js
+++ b/test/spec/hierarchical-facets/breadcrumb.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: using getHierarchicalFacetBreadcrumb()', function(t) {
+  var algoliasearch = require('algoliasearch');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1', 'categories.lvl2', 'categories.lvl3']
+    }]
+  });
+
+  helper.toggleRefine('categories', 'beers > IPA > Flying dog');
+
+  t.deepEqual(
+    helper.getHierarchicalFacetBreadcrumb('categories'),
+    ['beers', 'IPA', 'Flying dog'],
+    'we get the hierarchical facet `categories` breadcrumb as an array'
+  );
+
+  t.end();
+});

--- a/test/spec/hierarchical-facets/custom-separator.js
+++ b/test/spec/hierarchical-facets/custom-separator.js
@@ -84,28 +84,28 @@ test('hierarchical facets: custom separator', function(t) {
   helper.once('result', function(content) {
     var call = search.getCall(0);
     var queries = call.args[0];
-    var firstQuery = queries[0];
-    var secondQuery = queries[1];
+    var hitsQuery = queries[0];
+    var parentFacetValuesQuery = queries[1];
 
     t.equal(queries.length, 2, 'we made two queries');
     t.ok(search.calledOnce, 'client.search was called once');
     t.deepEqual(
-      firstQuery.params.facets,
+      hitsQuery.params.facets,
       ['categories.lvl0', 'categories.lvl1'],
       'first query (hits) has `categories.lvl0, categories.lvl1` as facets'
     );
     t.deepEqual(
-      firstQuery.params.facetFilters,
+      hitsQuery.params.facetFilters,
       [['categories.lvl1:beers | IPA']],
       'first query (hits) has our `categories.lvl1` refinement facet filter'
     );
     t.deepEqual(
-      secondQuery.params.facets,
+      parentFacetValuesQuery.params.facets,
       ['categories.lvl1'],
       'second query (unrefined parent facet values) has `categories.lvl1` as facets'
     );
     t.deepEqual(
-      secondQuery.params.facetFilters,
+      parentFacetValuesQuery.params.facetFilters,
       [['categories.lvl0:beers']],
       'second query (unrefined parent facet values) has `categories.lvl0` (parent level) refined'
     );

--- a/test/spec/hierarchical-facets/custom-separator.js
+++ b/test/spec/hierarchical-facets/custom-separator.js
@@ -1,0 +1,115 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: custom separator', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1'],
+      separator: '|'
+    }]
+  });
+
+  helper.toggleRefine('categories', 'beers | IPA');
+
+  var search = sinon.stub(client, 'search');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}, {'objectID': 'two'}],
+      'nbHits': 2,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        'categories.lvl0': {'beers': 2},
+        'categories.lvl1': {'beers | IPA': 2}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'categories.lvl0': {'beers': 3},
+        'categories.lvl1': {'beers | IPA': 2, 'beers | Belgian': 1}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'categories',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'beers',
+      'path': 'beers',
+      'count': 3,
+      'isRefined': true,
+      'data': [{
+        'name': 'IPA',
+        'path': 'beers | IPA',
+        'count': 2,
+        'isRefined': true,
+        'data': null
+      }, {
+        'name': 'Belgian',
+        'path': 'beers | Belgian',
+        'count': 1,
+        'isRefined': false,
+        'data': null
+      }]
+    }]
+  }];
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+  helper.once('result', function(content) {
+    var call = search.getCall(0);
+    var queries = call.args[0];
+    var firstQuery = queries[0];
+    var secondQuery = queries[1];
+
+    t.equal(queries.length, 2, 'we made two queries');
+    t.ok(search.calledOnce, 'client.search was called once');
+    t.deepEqual(
+      firstQuery.params.facets,
+      ['categories.lvl0', 'categories.lvl1'],
+      'first query (hits) has `categories.lvl0, categories.lvl1` as facets'
+    );
+    t.deepEqual(
+      firstQuery.params.facetFilters,
+      [['categories.lvl1:beers | IPA']],
+      'first query (hits) has our `categories.lvl1` refinement facet filter'
+    );
+    t.deepEqual(
+      secondQuery.params.facets,
+      ['categories.lvl1'],
+      'second query (unrefined parent facet values) has `categories.lvl1` as facets'
+    );
+    t.deepEqual(
+      secondQuery.params.facetFilters,
+      [['categories.lvl0:beers']],
+      'second query (unrefined parent facet values) has `categories.lvl0` (parent level) refined'
+    );
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.end();
+  });
+});

--- a/test/spec/hierarchical-facets/no-refinement.js
+++ b/test/spec/hierarchical-facets/no-refinement.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: no refinement', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0']
+    }]
+  });
+
+  var search = sinon.stub(client, 'search');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}, {'objectID': 'two'}],
+      'nbHits': 5,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        'categories.lvl0': {'beers': 2, 'fruits': 3}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'categories',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'beers',
+      'path': 'beers',
+      'count': 2,
+      'isRefined': false,
+      'data': null
+    }, {
+      'name': 'fruits',
+      'path': 'fruits',
+      'count': 3,
+      'isRefined': false,
+      'data': null
+    }]
+  }];
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+  helper.once('result', function(content) {
+    var call = search.getCall(0);
+    var queries = call.args[0];
+    var firstQuery = queries[0];
+
+    t.equal(queries.length, 1, 'we made one query');
+    t.ok(search.calledOnce, 'client.search was called once');
+    t.deepEqual(
+      firstQuery.params.facets,
+      ['categories.lvl0'],
+      'first query (hits) has `categories.lvl0` as facets'
+    );
+    t.equal(
+      firstQuery.params.facetFilters,
+      undefined,
+      'first query (hits) has no facet refinement refinement'
+    );
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.end();
+  });
+});

--- a/test/spec/hierarchical-facets/no-refinement.js
+++ b/test/spec/hierarchical-facets/no-refinement.js
@@ -62,17 +62,17 @@ test('hierarchical facets: no refinement', function(t) {
   helper.once('result', function(content) {
     var call = search.getCall(0);
     var queries = call.args[0];
-    var firstQuery = queries[0];
+    var hitsQuery = queries[0];
 
     t.equal(queries.length, 1, 'we made one query');
     t.ok(search.calledOnce, 'client.search was called once');
     t.deepEqual(
-      firstQuery.params.facets,
+      hitsQuery.params.facets,
       ['categories.lvl0'],
       'first query (hits) has `categories.lvl0` as facets'
     );
     t.equal(
-      firstQuery.params.facetFilters,
+      hitsQuery.params.facetFilters,
       undefined,
       'first query (hits) has no facet refinement refinement'
     );

--- a/test/spec/hierarchical-facets/one-level.js
+++ b/test/spec/hierarchical-facets/one-level.js
@@ -75,28 +75,28 @@ test('hierarchical facets: only one level deep', function(t) {
   helper.once('result', function(content) {
     var call = search.getCall(0);
     var queries = call.args[0];
-    var firstQuery = queries[0];
-    var secondQuery = queries[1];
+    var hitsQuery = queries[0];
+    var parentFacetValuesQuery = queries[1];
 
     t.equal(queries.length, 2, 'we made two queries');
     t.ok(search.calledOnce, 'client.search was called once');
     t.deepEqual(
-      firstQuery.params.facets,
+      hitsQuery.params.facets,
       ['categories.lvl0'],
       'first query (hits) has `categories.lvl0` as facets'
     );
     t.deepEqual(
-      firstQuery.params.facetFilters,
+      hitsQuery.params.facetFilters,
       [['categories.lvl0:beers']],
       'first query (hits) has our `categories.lvl0` refinement facet filter'
     );
     t.deepEqual(
-      secondQuery.params.facets,
+      parentFacetValuesQuery.params.facets,
       ['categories.lvl0'],
       'second query (unrefined parent facet values) has `categories.lvl0` as facets'
     );
     t.equal(
-      secondQuery.params.facetFilters,
+      parentFacetValuesQuery.params.facetFilters,
       undefined,
       'second query (unrefined parent facet values) has no facet refinement since we are at the root level'
     );

--- a/test/spec/hierarchical-facets/one-level.js
+++ b/test/spec/hierarchical-facets/one-level.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: only one level deep', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0']
+    }]
+  });
+
+  helper.toggleRefine('categories', 'beers');
+
+  var search = sinon.stub(client, 'search');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}, {'objectID': 'two'}],
+      'nbHits': 2,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        'categories.lvl0': {'beers': 2}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'categories.lvl0': {'beers': 2, 'fruits': 3}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'categories',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'beers',
+      'path': 'beers',
+      'count': 2,
+      'isRefined': true,
+      'data': null
+    }, {
+      'name': 'fruits',
+      'path': 'fruits',
+      'count': 3,
+      'isRefined': false,
+      'data': null
+    }]
+  }];
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+  helper.once('result', function(content) {
+    var call = search.getCall(0);
+    var queries = call.args[0];
+    var firstQuery = queries[0];
+    var secondQuery = queries[1];
+
+    t.equal(queries.length, 2, 'we made two queries');
+    t.ok(search.calledOnce, 'client.search was called once');
+    t.deepEqual(
+      firstQuery.params.facets,
+      ['categories.lvl0'],
+      'first query (hits) has `categories.lvl0` as facets'
+    );
+    t.deepEqual(
+      firstQuery.params.facetFilters,
+      [['categories.lvl0:beers']],
+      'first query (hits) has our `categories.lvl0` refinement facet filter'
+    );
+    t.deepEqual(
+      secondQuery.params.facets,
+      ['categories.lvl0'],
+      'second query (unrefined parent facet values) has `categories.lvl0` as facets'
+    );
+    t.equal(
+      secondQuery.params.facetFilters,
+      undefined,
+      'second query (unrefined parent facet values) has no facet refinement since we are at the root level'
+    );
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.end();
+  });
+});

--- a/test/spec/hierarchical-facets/simple.js
+++ b/test/spec/hierarchical-facets/simple.js
@@ -92,7 +92,7 @@ test('hierarchical facets: simple usage', function(t) {
     var call = search.getCall(0);
     var queries = call.args[0];
     var hitsQuery = queries[0];
-    var disjunctiveQuery = queries[1];
+    var parentFacetValuesQuery = queries[1];
 
     t.equal(queries.length, 2, 'we made two queries');
     t.ok(search.calledOnce, 'client.search was called once');
@@ -107,12 +107,12 @@ test('hierarchical facets: simple usage', function(t) {
       'first query (hits) has our `categories.lvl2` refinement facet filter'
     );
     t.deepEqual(
-      disjunctiveQuery.params.facets,
+      parentFacetValuesQuery.params.facets,
       ['categories.lvl2'],
       'second query (unrefined parent facet values) has `categories.lvl2` as facets'
     );
     t.deepEqual(
-      disjunctiveQuery.params.facetFilters,
+      parentFacetValuesQuery.params.facetFilters,
       [['categories.lvl1:beers > IPA']],
       'second query (unrefined parent facet values) has `categories.lvl1` (parent level) refined'
     );

--- a/test/spec/hierarchical-facets/simple.js
+++ b/test/spec/hierarchical-facets/simple.js
@@ -1,0 +1,123 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: simple usage', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1', 'categories.lvl2', 'categories.lvl3']
+    }]
+  });
+
+  helper.toggleRefine('categories', 'beers > IPA > Flying dog');
+
+  var search = sinon.stub(client, 'search');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        'categories.lvl0': {'beers': 1},
+        'categories.lvl1': {'beers > IPA': 1},
+        'categories.lvl2': {'beers > IPA > Flying dog': 1}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'categories.lvl0': {'beers': 2},
+        'categories.lvl1': {'beers > IPA': 2},
+        'categories.lvl2': {'beers > IPA > Flying dog': 1, 'beers > IPA > Anchor steam': 1}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'categories',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'beers',
+      'path': 'beers',
+      'count': 2,
+      'isRefined': true,
+      'data': [{
+        'name': 'IPA',
+        'path': 'beers > IPA',
+        'count': 2,
+        'isRefined': true,
+        'data': [{
+          'name': 'Flying dog',
+          'path': 'beers > IPA > Flying dog',
+          'count': 1,
+          'isRefined': true,
+          'data': null
+        }, {
+          'name': 'Anchor steam',
+          'path': 'beers > IPA > Anchor steam',
+          'count': 1,
+          'isRefined': false,
+          'data': null
+        }]
+      }]
+    }]
+  }];
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+  helper.once('result', function(content) {
+    var call = search.getCall(0);
+    var queries = call.args[0];
+    var hitsQuery = queries[0];
+    var disjunctiveQuery = queries[1];
+
+    t.equal(queries.length, 2, 'we made two queries');
+    t.ok(search.calledOnce, 'client.search was called once');
+    t.deepEqual(
+      hitsQuery.params.facets,
+      ['categories.lvl0', 'categories.lvl1', 'categories.lvl2', 'categories.lvl3'],
+      'first query (hits) has `categories.lvl0, categories.lvl1, categories.lvl2, categories.lvl3` as facets'
+    );
+    t.deepEqual(
+      hitsQuery.params.facetFilters,
+      [['categories.lvl2:beers > IPA > Flying dog']],
+      'first query (hits) has our `categories.lvl2` refinement facet filter'
+    );
+    t.deepEqual(
+      disjunctiveQuery.params.facets,
+      ['categories.lvl2'],
+      'second query (unrefined parent facet values) has `categories.lvl2` as facets'
+    );
+    t.deepEqual(
+      disjunctiveQuery.params.facetFilters,
+      [['categories.lvl1:beers > IPA']],
+      'second query (unrefined parent facet values) has `categories.lvl1` (parent level) refined'
+    );
+    // console.log(JSON.stringify(content.hierarchicalFacets, null, 2))
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.end();
+  });
+});

--- a/test/spec/hierarchical-facets/two-facets.js
+++ b/test/spec/hierarchical-facets/two-facets.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: two hierarchical facets', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-simple-appId';
+  var apiKey = 'hierarchical-simple-apiKey';
+  var indexName = 'hierarchical-simple-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'beers',
+      attributes: ['beers.lvl0']
+    }, {
+      name: 'fruits',
+      attributes: ['fruits.lvl0']
+    }]
+  });
+
+  helper.toggleRefine('beers', 'IPA');
+  helper.toggleRefine('fruits', 'oranges');
+
+  var search = sinon.stub(client, 'search');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 7,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        'beers.lvl0': {'IPA': 2},
+        'fruits.lvl0': {'oranges': 5}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'beers.lvl0': {'IPA': 2, 'Belgian': 3}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'fruits.lvl0': {'oranges': 5, 'apples': 4}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'beers',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'IPA',
+      'path': 'IPA',
+      'count': 2,
+      'isRefined': true,
+      'data': null
+    }, {
+      'name': 'Belgian',
+      'path': 'Belgian',
+      'count': 3,
+      'isRefined': false,
+      'data': null
+    }]
+  }, {
+    'name': 'fruits',
+    'path': null,
+    'count': null,
+    'isRefined': true,
+    'data': [{
+      'name': 'oranges',
+      'path': 'oranges',
+      'count': 5,
+      'isRefined': true,
+      'data': null
+    }, {
+      'name': 'apples',
+      'path': 'apples',
+      'count': 4,
+      'isRefined': false,
+      'data': null
+    }]
+  }];
+
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+  helper.once('result', function(content) {
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.end();
+  });
+});

--- a/test/spec/hierarchical-facets/unknown-facet.js
+++ b/test/spec/hierarchical-facets/unknown-facet.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: throw on unknown facet', function(t) {
+  var bind = require('lodash/function/bind');
+  var algoliasearch = require('algoliasearch');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-throw-appId';
+  var apiKey = 'hierarchical-throw-apiKey';
+  var indexName = 'hierarchical-throw-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0']
+    }]
+  });
+
+  t.throws(
+    bind(helper.toggleRefine, helper, 'unknownFacet', 'beers'),
+    'Refine on an unknown hierarchical facet throws'
+  );
+
+  t.end();
+});

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -23,7 +23,11 @@ test('Search should call the algolia client according to the number of refinemen
 
   helper.on('result', function(data) {
     // shame deepclone, to remove any associated methods coming from the results
-    t.deepEqual(JSON.parse(JSON.stringify(data)), JSON.parse(JSON.stringify(testData.responseHelper)), 'should be equal');
+    t.deepEqual(
+      JSON.parse(JSON.stringify(data)),
+      JSON.parse(JSON.stringify(testData.responseHelper)),
+      'should be equal'
+    );
     t.ok(mock.verify(), 'Mock constraints should be verified!');
     t.end();
   });

--- a/test/spec/search.testdata.js
+++ b/test/spec/search.testdata.js
@@ -360,6 +360,7 @@ var responseHelper = {
       'exhaustive': false
     }
   ],
+  'hierarchicalFacets': [],
   'facets': []
 };
 


### PR DESCRIPTION
I have implemented the hierarchical facets as proposed in #137.

The available API is: (different from proposal)

Given records like this:

```json
{
  "name": "Flying dog easy IPA",
  "categories": {
    "lvl0": "beers",
    "lvl1": "beers > IPA",
    "lvl2": "beers > IPA > Flying dog"
  }
}
```

When using the helper:
```js
var helper = algoliasearchHelper(client, indexName, {
  hierarchicalFacets: [{
    name: 'categories', // mandatory
    attributes: ['categories.lvl0', 'categories.lvl1', 'categories.lvl2'] // mandatory, because we cannot guess what's the maximum level is (different from proposal)
    separator: '>' // optionnal, default to '>'
  }]
});

helper.toggleRefine('beers > IPA > Flying dog');

helper.on('result', function(content) {
  console.log(content.hierarchicalFacets);
  // [{
  //   'name': 'categories',
  //   'count': null,
  //   'isRefined': true,
  //   'path': null,
  //   'data': [{
  //     'name': 'beers',
  //     'path': 'beers',
  //     'count': 2,
  //     'isRefined': true,
  //     'data': [{
  //       'name': 'IPA',
  //       'path': 'beers > IPA',
  //       'count': 2,
  //       'isRefined': true,
  //       'data': [{
  //         'name': 'Flying dog',
  //         'path': 'beers > IPA > Flying dog',
  //         'count': 1,
  //         'isRefined': true,
  //         'data': null
  //       }, {
  //         'name': 'Anchor steam',
  //         'path': 'beers > IPA > Anchor steam',
  //         'count': 1,
  //         'isRefined': false,
  //         'data': null
  //       }]
  //     }]
  //   }]
  // }]
});

helper.search();
```

We always get the parent's current level values: if you refine on `beers > IPA > Flying dog`:
 - the hits will be only `Flying dog` beers
 - you will have a listing of all `Flying dog` beers and a listing of all `IPA` beers

I updated the original POC demo to use this new build (locally): it works.

Every reviewer gets one [Flying dog beer](http://flyingdogbrewery.com/beers/).

![giphy-beer](https://cloud.githubusercontent.com/assets/123822/8801889/e3d9276a-2fbd-11e5-8093-dd8203308e13.gif)