### PR TITLE
Fix #116 : a facet declared incorrectly should throw exceptions 

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -484,6 +484,9 @@ SearchParameters.prototype = {
    * @return {string[]} list of refinements
    */
   getConjunctiveRefinements: function(facetName) {
+    if (!this.isConjunctiveFacet(facetName)) {
+      throw new Error(facetName + ' is not defined in the facets attribute of the helper configuration');
+    }
     return this.facetsRefinements[facetName] || [];
   },
   /**
@@ -503,6 +506,9 @@ SearchParameters.prototype = {
    * @return {string[]} list of refinements
    */
   getExcludeRefinements: function(facetName) {
+    if (!this.isConjunctiveFacet(facetName)) {
+      throw new Error(facetName + ' is not defined in the facets attribute of the helper configuration');
+    }
     return this.facetsExcludes[facetName] || [];
   },
   /**
@@ -800,6 +806,9 @@ SearchParameters.prototype = {
    * @return {boolean} returns true if refined
    */
   isFacetRefined: function isFacetRefined(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     return RefinementList.isRefined(this.facetsRefinements, facet, value);
   },
   /**
@@ -812,6 +821,9 @@ SearchParameters.prototype = {
    * @return {boolean} returns true if refined
    */
   isExcludeRefined: function isExcludeRefined(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     return RefinementList.isRefined(this.facetsExcludes, facet, value);
   },
   /**
@@ -824,6 +836,9 @@ SearchParameters.prototype = {
    * @return {boolean}
    */
   isDisjunctiveFacetRefined: function isDisjunctiveFacetRefined(facet, value) {
+    if (!this.isDisjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the disjunctiveFacets attribute of the helper configuration');
+    }
     return RefinementList.isRefined(this.disjunctiveFacetsRefinements, facet, value);
   },
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -492,6 +492,9 @@ SearchParameters.prototype = {
    * @return {string[]} list of refinements
    */
   getDisjunctiveRefinements: function(facetName) {
+    if (!this.isDisjunctiveFacet(facetName)) {
+      throw new Error(facetName + ' is not defined in the disjunctiveFacets attribute of the helper configuration');
+    }
     return this.disjunctiveFacetsRefinements[facetName] || [];
   },
   /**
@@ -571,6 +574,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   addFacetRefinement: function addFacetRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     if (RefinementList.isRefined(this.facetsRefinements, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -586,6 +592,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   addExcludeRefinement: function addExcludeRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     if (RefinementList.isRefined(this.facetsExcludes, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -601,6 +610,10 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   addDisjunctiveFacetRefinement: function addDisjunctiveFacetRefinement(facet, value) {
+    if (!this.isDisjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the disjunctiveFacets attribute of the helper configuration');
+    }
+
     if (RefinementList.isRefined(this.disjunctiveFacetsRefinements, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -633,6 +646,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   removeFacetRefinement: function removeFacetRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     if (!RefinementList.isRefined(this.facetsRefinements, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -648,6 +664,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   removeExcludeRefinement: function removeExcludeRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
     if (!RefinementList.isRefined(this.facetsExcludes, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -663,6 +682,9 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   removeDisjunctiveFacetRefinement: function removeDisjunctiveFacetRefinement(facet, value) {
+    if (!this.isDisjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the disjunctiveFacets attribute of the helper configuration');
+    }
     if (!RefinementList.isRefined(this.disjunctiveFacetsRefinements, facet, value)) return this;
 
     return this.setQueryParameters({
@@ -694,6 +716,10 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   toggleFacetRefinement: function toggleFacetRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
+
     return this.setQueryParameters({
       page: 0,
       facetsRefinements: RefinementList.toggleRefinement(this.facetsRefinements, facet, value)
@@ -707,6 +733,10 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   toggleExcludeFacetRefinement: function toggleExcludeFacetRefinement(facet, value) {
+    if (!this.isConjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the facets attribute of the helper configuration');
+    }
+
     return this.setQueryParameters({
       page: 0,
       facetsExcludes: RefinementList.toggleRefinement(this.facetsExcludes, facet, value)
@@ -720,6 +750,10 @@ SearchParameters.prototype = {
    * @return {SearchParameters}
    */
   toggleDisjunctiveFacetRefinement: function toggleDisjunctiveFacetRefinement(facet, value) {
+    if (!this.isDisjunctiveFacet(facet)) {
+      throw new Error(facet + ' is not defined in the disjunctiveFacets attribute of the helper configuration');
+    }
+
     return this.setQueryParameters({
       page: 0,
       disjunctiveFacetsRefinements: RefinementList.toggleRefinement(this.disjunctiveFacetsRefinements, facet, value)

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -220,8 +220,8 @@ AlgoliaSearchHelper.prototype.toggleRefine = function(facet, value) {
   } else if (this.state.isDisjunctiveFacet(facet)) {
     this.state = this.state.toggleDisjunctiveFacetRefinement(facet, value);
   } else {
-    throw new Error("Can't refine the undeclared facet '" + facet +
-      "'; it should be added to the helper options 'facets' or 'disjunctiveFacets'");
+    throw new Error('Cannot refine the undeclared facet ' + facet +
+      '; it should be added to the helper options facets or disjunctiveFacets');
   }
 
   this._change();
@@ -340,7 +340,9 @@ AlgoliaSearchHelper.prototype.isRefined = function(facet, value) {
     return this.state.isDisjunctiveFacetRefined(facet, value);
   }
 
-  return false;
+  throw new Error(facet +
+    ' is not properly defined in this helper configuration' +
+    '(use the facets or disjunctiveFacets keys to configure it)');
 };
 
 /**
@@ -350,8 +352,13 @@ AlgoliaSearchHelper.prototype.isRefined = function(facet, value) {
  */
 AlgoliaSearchHelper.prototype.hasRefinements = function(attribute) {
   var attributeHasNumericRefinements = !isEmpty(this.state.getNumericRefinements(attribute));
+  var isFacetDeclared = this.state.isConjunctiveFacet(attribute) || this.state.isDisjunctiveFacet(attribute);
 
-  return attributeHasNumericRefinements || this.isRefined(attribute);
+  if (!attributeHasNumericRefinements && isFacetDeclared) {
+    return this.state.isFacetRefined(attribute);
+  }
+
+  return attributeHasNumericRefinements;
 };
 
 /**
@@ -433,6 +440,15 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
         type: 'conjunctive'
       });
     });
+
+    var excludeRefinements = this.state.getExcludeRefinements(facetName);
+
+    forEach(excludeRefinements, function(r) {
+      refinements.push({
+        value: r,
+        type: 'exclude'
+      });
+    });
   } else if (this.state.isDisjunctiveFacet(facetName)) {
     var disjRefinements = this.state.getDisjunctiveRefinements(facetName);
 
@@ -443,15 +459,6 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
       });
     });
   }
-
-  var excludeRefinements = this.state.getExcludeRefinements(facetName);
-
-  forEach(excludeRefinements, function(r) {
-    refinements.push({
-      value: r,
-      type: 'exclude'
-    });
-  });
 
   var numericRefinements = this.state.getNumericRefinements(facetName);
 

--- a/test/spec/SearchParameters.noChanges.js
+++ b/test/spec/SearchParameters.noChanges.js
@@ -94,7 +94,7 @@ test('[No changes] addFacetRefinement', function(t) {
 
 test('[No changes] removeDisjunctiveFacetRefinement', function(t) {
   var state = SearchParameters.make({
-    facets: ['facet']
+    disjunctiveFacets: ['facet']
   });
 
   t.equal(state.removeDisjunctiveFacetRefinement('facet', 'value'), state, 'removeDisjunctiveFacetRefinement should return the same instance');

--- a/test/spec/helper.clears.js
+++ b/test/spec/helper.clears.js
@@ -9,7 +9,7 @@ var isUndefined = require('lodash/lang/isUndefined');
 
 var fixture = function fixture() {
   var helper = algoliasearchHelper(undefined, 'Index', {
-    facets: ['facet1', 'facet2', 'both_facet'],
+    facets: ['facet1', 'facet2', 'both_facet', 'excluded1', 'excluded2'],
     disjunctiveFacets: ['disjunctiveFacet1', 'disjunctiveFacet2', 'both_facet']
   });
 

--- a/test/spec/helper.distinct.js
+++ b/test/spec/helper.distinct.js
@@ -6,7 +6,10 @@ var forEach = require('lodash/collection/forEach');
 var algoliasearchHelper = require('../../index.js');
 
 test('Distinct not set', function(t) {
-  var helper = algoliasearchHelper(null, null, {});
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facetConj'],
+    disjunctiveFacets: ['facet']
+  });
   var state0 = helper.state;
 
   var disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
@@ -38,7 +41,7 @@ test('Distinct not set', function(t) {
   });
 
   helper.setState(state0);
-  helper.addRefine('facet', 'value');
+  helper.addRefine('facetConj', 'value');
   disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
   t.equal(disjunctiveFacetSearchParam.distinct, undefined, '[disjunctive][conjunctive refinement] distinct should be undefined');
   facetSearchParam = helper._getHitsSearchParams();
@@ -61,7 +64,10 @@ test('Distinct not set', function(t) {
 });
 
 test('Distinct set to true', function(t) {
-  var helper = algoliasearchHelper(null, null, {}).setQueryParameter('distinct', true);
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facetConj'],
+    disjunctiveFacets: ['facet']
+  }).setQueryParameter('distinct', true);
   var state0 = helper.state;
 
   var disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
@@ -87,7 +93,7 @@ test('Distinct set to true', function(t) {
   t.equal(facetSearchParam.distinct, true, '[hits][disjunctive refinement] distinct should be true');
 
   helper.setState(state0);
-  helper.addRefine('facet', 'value');
+  helper.addRefine('facetConj', 'value');
   disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
   t.equal(disjunctiveFacetSearchParam.distinct, true, '[disjunctive][conjunctive refinement] distinct should be true');
   facetSearchParam = helper._getHitsSearchParams();
@@ -104,7 +110,10 @@ test('Distinct set to true', function(t) {
 });
 
 test('Distinct to false', function(t) {
-  var helper = algoliasearchHelper(null, null, {}).setQueryParameter('distinct', false);
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facetConj'],
+    disjunctiveFacets: ['facet']
+  }).setQueryParameter('distinct', false);
   var state0 = helper.state;
 
   var disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
@@ -130,7 +139,7 @@ test('Distinct to false', function(t) {
   t.equal(facetSearchParam.distinct, false, '[hits][disjunctive refinement] distinct should be false');
 
   helper.setState(state0);
-  helper.addRefine('facet', 'value');
+  helper.addRefine('facetConj', 'value');
   disjunctiveFacetSearchParam = helper._getDisjunctiveFacetSearchParams();
   t.equal(disjunctiveFacetSearchParam.distinct, false, '[disjunctive][conjunctive refinement] distinct should be false');
   facetSearchParam = helper._getHitsSearchParams();

--- a/test/spec/helper.excludes.js
+++ b/test/spec/helper.excludes.js
@@ -4,7 +4,9 @@ var test = require('tape');
 var algoliasearchHelper = require('../../index');
 
 test('addExclude should add an exclusion', function(t) {
-  var helper = algoliasearchHelper(null, null, null);
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facet']
+  });
 
   helper._search = function() {};
 
@@ -20,7 +22,9 @@ test('addExclude should add an exclusion', function(t) {
 });
 
 test('removeExclude should remove an exclusion', function(t) {
-  var helper = algoliasearchHelper(null, null, null);
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facet']
+  });
 
   helper._search = function() {};
 
@@ -42,7 +46,9 @@ test('removeExclude should remove an exclusion', function(t) {
 });
 
 test('isExcluded should report exclusion correctly', function(t) {
-  var helper = algoliasearchHelper(null, null, null);
+  var helper = algoliasearchHelper(null, null, {
+    facets: ['facet']
+  });
 
   helper._search = function() {};
 

--- a/test/spec/helper.incorrectFacetDefinition.js
+++ b/test/spec/helper.incorrectFacetDefinition.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var test = require('tape');
+var algoliasearchHelper = require('../../index');
+
+var _ = require('lodash');
+
+test('Conjuctive facet should be declared to be refined', function(t) {
+  var h = algoliasearchHelper('', '', {});
+
+  t.throws(_.bind(h.addRefine, h, 'undeclaredFacet', 'value'), 'Adding a facet refinement should not be possible');
+  t.throws(_.bind(h.removeRefine, h, 'undeclaredFacet', 'value'), 'Remove a facet refinement should not be possible');
+  t.throws(_.bind(h.isRefined, h, 'undeclaredFacet', 'value'), 'Checking if a facet is refined should not be possible');
+
+  t.end();
+});
+
+test('Conjuctive facet should be declared to be excluded', function(t) {
+  var h = algoliasearchHelper('', '', {});
+
+  t.throws(_.bind(h.addExclude, h, 'undeclaredFacet', 'value'), 'Adding a facet refinement should not be possible');
+  t.throws(_.bind(h.removeExclude, h, 'undeclaredFacet', 'value'), 'Remove a facet refinement should not be possible');
+  t.throws(_.bind(h.isExcluded, h, 'undeclaredFacet', 'value'), 'Checking if a facet is refined should not be possible');
+
+  t.end();
+});
+
+test('Conjuctive facet should be declared to be refine', function(t) {
+  var h = algoliasearchHelper('', '', {});
+
+  t.throws(_.bind(h.addDisjunctiveRefine, h, 'undeclaredFacet', 'value'), 'Adding a facet refinement should not be possible');
+  t.throws(_.bind(h.removeDisjunctiveRefine, h, 'undeclaredFacet', 'value'), 'Remove a facet refinement should not be possible');
+  t.throws(_.bind(h.isRefined, h, 'undeclaredFacet', 'value'), 'Checking if a facet is refined should not be possible');
+
+  t.end();
+});

--- a/test/spec/helper.pages.js
+++ b/test/spec/helper.pages.js
@@ -60,11 +60,11 @@ test('pages should be reset if the mutation might change the number of pages', f
   testMutation(t, ' addExclude', partial(helper.addExclude, 'facet1', 'val2'));
   testMutation(t, ' removeExclude', partial(helper.removeExclude, 'facet1', 'val2'));
 
-  testMutation(t, ' addRefine', partial(helper.addRefine, 'f1', 'val'));
-  testMutation(t, ' removeRefine', partial(helper.removeRefine, 'f1', 'val'));
+  testMutation(t, ' addRefine', partial(helper.addRefine, 'f2', 'val'));
+  testMutation(t, ' removeRefine', partial(helper.removeRefine, 'f2', 'val'));
 
-  testMutation(t, ' addDisjunctiveRefine', partial(helper.addDisjunctiveRefine, 'f2', 'val'));
-  testMutation(t, ' removeDisjunctiveRefine', partial(helper.removeDisjunctiveRefine, 'f2', 'val'));
+  testMutation(t, ' addDisjunctiveRefine', partial(helper.addDisjunctiveRefine, 'f1', 'val'));
+  testMutation(t, ' removeDisjunctiveRefine', partial(helper.removeDisjunctiveRefine, 'f1', 'val'));
 
   testMutation(t, ' toggleRefine', partial(helper.toggleRefine, 'f1', 'v1'));
   testMutation(t, ' toggleExclude', partial(helper.toggleExclude, 'facet1', '55'));

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -119,8 +119,8 @@ test('IsRefined should return true if the (facet, value ) is refined.', function
   t.equal(helper.isRefined('facet1', 'boom'), true, 'the facet + value is refined >> true');
 
   t.equal(helper.isRefined('facet1', 'booohh'), false, 'value not refined but is a facet');
-  t.equal(helper.isRefined('notAFacet', 'maoooh'), false, "not refined because it's not a facet");
-  t.equal(helper.isRefined(null, null), false, 'not even valid values');
+  t.throws(_.bind(helper.isRefined, helper, 'notAFacet', 'maoooh'), 'should throw as it is not a facet');
+  t.throws(_.bind(helper.isRefined, helper, null, null), 'not valid values');
 
   t.end();
 });
@@ -138,10 +138,11 @@ test('isRefined(facet)/hasRefinements should return true if the facet is refined
   t.equal(helper.isRefined('facet1'), true, 'the facet is refined >> true');
   t.equal(helper.hasRefinements('facet1'), true, 'the facet is refined >> true');
 
-  t.equal(helper.isRefined('notAFacet'), false, 'not a facet');
-  t.equal(helper.hasRefinements('notAFacet'), false, 'not a facet');
-  t.equal(helper.isRefined(null), false, 'not even valid values');
-  t.equal(helper.hasRefinements(null), false, 'not even valid values');
+  t.throws(_.bind(helper.isRefined, helper, 'notAFacet'), 'not a facet');
+  // in complete honesty we should be able to detect numeric facets but we can't
+  // t.throws(helper.hasRefinements.bind(helper, 'notAFacet'), 'not a facet');
+  t.throws(_.bind(helper.isRefined, null), 'not even valid values');
+  t.throws(_.bind(helper.hasRefinements, null), 'not even valid values');
 
   t.end();
 });

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -5,10 +5,12 @@ var _ = require('lodash');
 var algoliasearchHelper = require('../../index');
 
 test('Adding refinments should add an entry to the refinments attribute', function(t) {
-  var helper = algoliasearchHelper({}, 'index', {});
-
   var facetName = 'facet1';
   var facetValue = '42';
+
+  var helper = algoliasearchHelper({}, 'index', {
+    facets: [facetName]
+  });
 
   t.ok(_.isEmpty(helper.state.facetsRefinements), 'should be empty at first');
   helper.addRefine(facetName, facetValue);
@@ -86,9 +88,12 @@ test('Removing several refinements for a single attribute should be handled', fu
 });
 
 test('isDisjunctiveRefined', function(t) {
-  var helper = algoliasearchHelper(null, null, {});
-
   var facet = 'MyFacet';
+
+  var helper = algoliasearchHelper(null, null, {
+    disjunctiveFacets: [facet]
+  });
+
   var value = 'MyValue';
 
   t.equal(helper.isDisjunctiveRefined(facet, value), false,


### PR DESCRIPTION
For example if a facet is declared as disjunctive and we use `addRefine` with it then it should throw an exception.