### PR TITLE
fix: throw when unknown parameter

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -325,6 +325,12 @@ function SearchParameters(newParameters) {
    * @member {string}
    */
   this.insideBoundingBox = params.insideBoundingBox;
+
+  forEach(params, function checkForUnknownParameter(paramValue, paramName) {
+    if (!this.hasOwnProperty(paramName)) {
+      console.error('Unsupported SearchParameter: `' + paramName + '` (this will throw in the next version)');
+    }
+  }, this);
 }
 
 /**

--- a/test/spec/unknown-parameter.js
+++ b/test/spec/unknown-parameter.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var test = require('tape');
+
+// Can be activated in V3, right now we only console.error
+test.skip('it throws when providing an unknown parameter', function(t) {
+  t.plan(1);
+
+  var algoliasearchHelper = require('../../');
+
+  try {
+    algoliasearchHelper({}, 'unknown-parameter', {
+      IDoNotExistsInRealLife: 'Do you?'
+    });
+  } catch (e) {
+    t.equal(e.message, 'Unsupported SearchParameter: `IDoNotExistsInRealLife`');
+  }
+});


### PR DESCRIPTION
Not sure we should merge this or should we wait for V3.. Because this
could break a good number of implementations..