### PR TITLE
fix: add undocumented offset and length params

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -325,6 +325,10 @@ function SearchParameters(newParameters) {
    * @member {string}
    */
   this.insideBoundingBox = params.insideBoundingBox;
+
+  // Undocumented parameters, still needed otherwise we fail
+  this.offset = params.offset;
+  this.length = params.length;
 }
 
 /**


### PR DESCRIPTION
This is to allow some of our clients using these params to send them to our servers.