### PR TITLE
FIX #208, getFacetValues with no values for the facet should not throw.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 CHANGELOG
 
+UNRELEASED
+  * FIX: #208, getFacetValues should return an empty array if the facet is
+  defined but there are no returned values for it (and not throw an exception)
+
 2.3.3 - 2015-09-09
   * FIX: hasRefinements fix, should check facet, disjunctive, hierarchical, numeric
 

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -420,6 +420,8 @@ SearchResults.prototype.getFacetByName = function(name) {
     find(this.hierarchicalFacets, predicate);
 };
 
+var EMPTY_NORMALIZED_FACET_VALUES = (function() { var a = []; a.facetType = 'conjunctive'; return a; })();
+var EMPTY_NORMALIZED_DISJUNCTIVE_VALUES = (function() { var a = []; a.facetType = 'disjunctive'; return a; })();
 /**
  * Get the facet values of a specified attribute from a SearchResults object.
  * @param {SearchResults} results the search results to search in
@@ -431,6 +433,8 @@ function extractNormalizedFacetValues(results, attribute) {
   var predicate = {name: attribute};
   if (results._state.isConjunctiveFacet(attribute)) {
     var facet = find(results.facets, predicate);
+    if (!facet) return EMPTY_NORMALIZED_FACET_VALUES;
+
     var facetValues = map(facet.data, function(v, k) {
       return {
         name: k,
@@ -442,6 +446,8 @@ function extractNormalizedFacetValues(results, attribute) {
     return facetValues;
   } else if (results._state.isDisjunctiveFacet(attribute)) {
     var disjunctiveFacet = find(results.disjunctiveFacets, predicate);
+    if (!disjunctiveFacet) return EMPTY_NORMALIZED_DISJUNCTIVE_VALUES;
+
     var disjunctiveFacetValues = map(disjunctiveFacet.data, function(v, k) {
       return {
         name: k,

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var test = require('tape');
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -3,7 +3,8 @@
 var bind = require('lodash/function/bind');
 var random = require('lodash/number/random');
 var test = require('tape');
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 

--- a/test/integration-spec/helper.highlight.js
+++ b/test/integration-spec/helper.highlight.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var test = require('tape');
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.highlight.js
+++ b/test/integration-spec/helper.highlight.js
@@ -3,7 +3,8 @@
 var bind = require('lodash/function/bind');
 var random = require('lodash/number/random');
 var test = require('tape');
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 

--- a/test/integration-spec/helper.numerics.js
+++ b/test/integration-spec/helper.numerics.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var test = require('tape');
-var map = require('lodash/collection/map');
-
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
+var map = require('lodash/collection/map');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.numerics.js
+++ b/test/integration-spec/helper.numerics.js
@@ -5,7 +5,8 @@ var random = require('lodash/number/random');
 var test = require('tape');
 var map = require('lodash/collection/map');
 
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 

--- a/test/integration-spec/helper.results.getFacetValues.js
+++ b/test/integration-spec/helper.results.getFacetValues.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var test = require('tape');
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.results.getFacetValues.js
+++ b/test/integration-spec/helper.results.getFacetValues.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
+var test = require('tape');
+var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var utils = require('../integration-utils.js');
+var setup = utils.setup;
+
+if (!utils.shouldRun) {
+  test = test.skip;
+}
+var indexName = '_travis-algoliasearch-helper-js-' +
+  (process.env.TRAVIS_BUILD_NUMBER || 'DEV') +
+  'helper_searchonce' + random(0, 5000);
+
+test(
+  '[INT][GETFACETVALUES] When the results are empty, getFacetValues should not crash',
+  function(t) {
+    setup(indexName, function(client) {
+      return client;
+    }).then(function(client) {
+      var helper = algoliasearchHelper(
+        client,
+        indexName,
+        {
+          facets: ['f'],
+          disjunctiveFacets: ['df'],
+          hierarchicalFacets: [{
+            name: 'products',
+            attributes: ['categories.lvl0', 'categories.lvl1']
+          }]
+        }
+      );
+      helper.on('result', function(rs) {
+        t.deepEqual(rs.getFacetValues('f'), [], '');
+        t.deepEqual(rs.getFacetValues('df'), [], '');
+        t.deepEqual(
+          rs.getFacetValues('products'),
+          {count: null, data: null, isRefined: true, name: 'products', path: null},
+          ''
+        );
+        t.end();
+      });
+      helper.search();
+    }).then(null, bind(t.error, t));
+  });

--- a/test/integration-spec/helper.results.getFacetValues.js
+++ b/test/integration-spec/helper.results.getFacetValues.js
@@ -3,7 +3,8 @@
 var bind = require('lodash/function/bind');
 var random = require('lodash/number/random');
 var test = require('tape');
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 

--- a/test/integration-spec/helper.searchOnce.js
+++ b/test/integration-spec/helper.searchOnce.js
@@ -4,7 +4,8 @@ var bind = require('lodash/function/bind');
 var random = require('lodash/number/random');
 var find = require('lodash/collection/find');
 var test = require('tape');
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 

--- a/test/integration-spec/helper.searchOnce.js
+++ b/test/integration-spec/helper.searchOnce.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var find = require('lodash/collection/find');
-var test = require('tape');
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var find = require('lodash/collection/find');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var bind = require('lodash/function/bind');
-var random = require('lodash/number/random');
-var test = require('tape');
-var map = require('lodash/collection/map');
-
-var algoliasearchHelper = process.browser &&
-  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var map = require('lodash/collection/map');
+var bind = require('lodash/function/bind');
+var random = require('lodash/number/random');
 
 if (!utils.shouldRun) {
   test = test.skip;

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -5,12 +5,17 @@ var random = require('lodash/number/random');
 var test = require('tape');
 var map = require('lodash/collection/map');
 
-var algoliasearchHelper = process.browser ? window.algoliasearchHelper : require('../../');
+var algoliasearchHelper = process.browser &&
+  process.env.TRAVIS_BUILD_NUMBER ? window.algoliasearchHelper : require('../../');
 var utils = require('../integration-utils.js');
 var setup = utils.setup;
 
 if (!utils.shouldRun) {
   test = test.skip;
+}
+
+function hitsToParsedID(h) {
+  return parseInt(h.objectID, 10);
 }
 
 test('[INT][TAGS]Test tags operations on the helper and their results on the algolia API', function(t) {
@@ -42,7 +47,6 @@ test('[INT][TAGS]Test tags operations on the helper and their results on the alg
 
     helper.on('result', function(content) {
       calls++;
-      var hitsToParsedID = function(h) { return parseInt(h.objectID, 10); };
 
       if (calls === 1) {
         t.equal(content.hits.length, 4, 'No tags: 3 results');

--- a/test/integration-utils.js
+++ b/test/integration-utils.js
@@ -35,6 +35,7 @@ if (!process.browser) {
 }
 
 module.exports = {
+  isCIBrowser: process.browser && process.env.TRAVIS_BUILD_NUMBER,
   setup: setup,
   shouldRun: shouldRun
 };


### PR DESCRIPTION
Instead it should gracefully return an empty array (the behavior was
correctly defined for the hierarchical facets)