### PR TITLE
fix(deps): Removes `algoliasearch` from the dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,5 @@
     "lodash": "^3.10.1",
     "lodash-compat": "^3.10.1",
     "qs": "5.1.0"
-  },
-  "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 4"
   }
 }


### PR DESCRIPTION
We never `requires` it, we expect it passed as an argument, so we
should be able to safely remove it from the dependencies. It is not
needed to build.