### PR TITLE
chore: Removes console.dir

### DIFF
--- a/src/SearchParameters/filterState.js
+++ b/src/SearchParameters/filterState.js
@@ -56,7 +56,6 @@ function filterState(state, filters) {
     }
   );
 
-  console.dir(partialState);
   return partialState;
 }
 


### PR DESCRIPTION
Forgot previous console.dir in the code.