### PR TITLE
fix(hierarchicalWidget): Error when faceted and no results

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -320,6 +320,12 @@ function SearchResults(state, algoliaResponse) {
       if (hierarchicalFacet) {
         position = findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name});
         var attributeIndex = findIndex(this.hierarchicalFacets[position], {attribute: dfacet});
+
+        // previous refinements and no results so not able to find it
+        if (attributeIndex === -1) {
+          return;
+        }
+
         this.hierarchicalFacets[position][attributeIndex].data = merge({}, this.hierarchicalFacets[position][attributeIndex].data, facetResults);
       } else {
         position = disjunctiveFacetsIndices[dfacet];

--- a/test/spec/hierarchical-facets/refined-no-result.js
+++ b/test/spec/hierarchical-facets/refined-no-result.js
@@ -41,7 +41,9 @@ test('hierarchical facets: simple usage', function(t) {
       'page': 0,
       'nbPages': 0,
       'hitsPerPage': 1,
-      'facets': {}
+      'facets': {
+        'categories.lvl0': {'beers': 20, 'fruits': 5, 'sales': 20}
+      }
     }, {
       'query': 'badquery',
       'index': indexName,
@@ -60,7 +62,7 @@ test('hierarchical facets: simple usage', function(t) {
   helper.setQuery('badquery').search();
 
   helper.once('result', function(content) {
-    t.deepEqual(content.hierarchicalFacets, [{name: 'categories', count: null, isRefined: true, path: null, data: null}], 'lol');
+    t.deepEqual(content.hierarchicalFacets, [{name: 'categories', count: null, isRefined: true, path: null, data: null}], 'Good facets values');
     t.end();
   });
 });


### PR DESCRIPTION
This one occurs when no results with query + refinements and the second query with query without refinement returns result.