### PR TITLE
fix(request-builder): Makes queries less ambiguous for client fix #205

### DIFF
--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -19,7 +19,6 @@ var requestBuilder = {
     // One query for the hits
     queries.push({
       indexName: index,
-      query: state.query,
       params: this._getHitsSearchParams(state)
     });
 
@@ -27,7 +26,6 @@ var requestBuilder = {
     forEach(state.getRefinedDisjunctiveFacets(), function(refinedFacet) {
       queries.push({
         indexName: index,
-        query: state.query,
         params: this._getDisjunctiveFacetSearchParams(state, refinedFacet)
       });
     }, this);
@@ -42,7 +40,6 @@ var requestBuilder = {
       if (currentRefinement.length > 0 && currentRefinement[0].split(state._getHierarchicalFacetSeparator(hierarchicalFacet)).length > 1) {
         queries.push({
           indexName: index,
-          query: state.query,
           params: this._getDisjunctiveFacetSearchParams(state, refinedFacet, true)
         });
       }

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -65,6 +65,12 @@ test('Search should call the algolia client according to the number of refinemen
       expectedCityValuesFn,
       'Facet values for "city" should be correctly ordered using a sort function');
 
+    var queries = mock.expectations.search[0].args[0][0];
+    for (var i = 0; i < queries.length; i++) {
+      var query = queries[i];
+      t.equal(query.query, undefined);
+      t.equal(query.params.query, '');
+    }
     t.ok(mock.verify(), 'Mock constraints should be verified!');
 
     t.end();


### PR DESCRIPTION
Query parameter was sent twice in the query params.