### PR TITLE
Feat/optionalTagFilters & optionalFacetFilters

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -159,9 +159,7 @@ function SearchParameters(newParameters) {
   this.tagFilters = params.tagFilters;
 
   /**
-   * Contains the tag filters in the raw format of the Algolia API. Setting this
-   * parameter is not compatible with the of the add/remove/toggle methods of the
-   * tag api.
+   * Contains the  optional tag filters in the raw format of the Algolia API.
    * @private
    * @see https://www.algolia.com/doc/rest#param-tagFilters
    * @member {string}
@@ -169,9 +167,7 @@ function SearchParameters(newParameters) {
   this.optionalTagFilters = params.optionalTagFilters;
 
   /**
-   * Contains the tag filters in the raw format of the Algolia API. Setting this
-   * parameter is not compatible with the of the add/remove/toggle methods of the
-   * tag api.
+   * Contains the optional facet filters in the raw format of the Algolia API.
    * @private
    * @see https://www.algolia.com/doc/rest#param-tagFilters
    * @member {string}

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -158,6 +158,26 @@ function SearchParameters(newParameters) {
    */
   this.tagFilters = params.tagFilters;
 
+  /**
+   * Contains the tag filters in the raw format of the Algolia API. Setting this
+   * parameter is not compatible with the of the add/remove/toggle methods of the
+   * tag api.
+   * @private
+   * @see https://www.algolia.com/doc/rest#param-tagFilters
+   * @member {string}
+   */
+  this.optionalTagFilters = params.optionalTagFilters;
+
+  /**
+   * Contains the tag filters in the raw format of the Algolia API. Setting this
+   * parameter is not compatible with the of the add/remove/toggle methods of the
+   * tag api.
+   * @private
+   * @see https://www.algolia.com/doc/rest#param-tagFilters
+   * @member {string}
+   */
+  this.optionalFacetFilters = params.optionalFacetFilters;
+
 
   // Misc. parameters
   /**

--- a/src/SearchParameters/shortener.js
+++ b/src/SearchParameters/shortener.js
@@ -50,7 +50,9 @@ var keys2Short = {
   synonyms: 's',
   tagFilters: 'tF',
   tagRefinements: 'tR',
-  typoTolerance: 'tT'
+  typoTolerance: 'tT',
+  optionalTagFilters: 'oTF',
+  optionalFacetFilters: 'oFF'
 };
 
 var short2Keys = invert(keys2Short);


### PR DESCRIPTION
Just a basic support for raw parameters as a quick fix to #262.

Should we add more support for those?
I'm thinking:

* `clearOptionalTags` to mimic `clearTags`
* `clearOptionalFacets` maybe?
* `addOptionalFacet`/`addOptionalFacets` or something similar to be able to pass an array of facet filters?
