### PR TITLE
Fix/hierarchical facets order

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -277,11 +277,14 @@ function SearchResults(state, algoliaResponse) {
     var hierarchicalFacet = findMatchingHierarchicalFacetFromAttributeName(state.hierarchicalFacets, facetKey);
 
     if (hierarchicalFacet) {
-      this.hierarchicalFacets[findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name})].push({
+      // Place the hierarchicalFacet data at the correct index depending on the attributes order that was defined at the
+      // helper initialization
+      var facetIndex = hierarchicalFacet.attributes.indexOf(facetKey);
+      this.hierarchicalFacets[findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name})][facetIndex] = {
         attribute: facetKey,
         data: facetValueObject,
         exhaustive: mainSubResponse.exhaustiveFacetsCount
-      });
+      };
     } else {
       var isFacetDisjunctive = indexOf(state.disjunctiveFacets, facetKey) !== -1;
       var isFacetConjunctive = indexOf(state.facets, facetKey) !== -1;
@@ -307,6 +310,9 @@ function SearchResults(state, algoliaResponse) {
       }
     }
   }, this);
+
+  // Make sure we do not keep wholes within the hierarchical facets
+  this.hierarchicalFacets = compact(this.hierarchicalFacets);
 
   // aggregate the refined disjunctive facets
   forEach(disjunctiveFacets, function(disjunctiveFacet) {

--- a/test/spec/hierarchical-facets/attributes-order.js
+++ b/test/spec/hierarchical-facets/attributes-order.js
@@ -1,0 +1,103 @@
+// This file tests a specific bug that occurs when the API returns facets data for hierarchical attributes in a
+// different order than the declared attributes order at the helper initialization
+'use strict';
+
+var test = require('tape');
+
+test('hierarchical facets: attributes order', function(t) {
+  var algoliasearch = require('algoliasearch');
+  var sinon = require('sinon');
+
+  var algoliasearchHelper = require('../../../');
+
+  var appId = 'hierarchical-toggleRefine-appId';
+  var apiKey = 'hierarchical-toggleRefine-apiKey';
+  var indexName = 'hierarchical-toggleRefine-indexName';
+
+  var client = algoliasearch(appId, apiKey);
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1']
+    }]
+  });
+
+  var search = sinon.stub(client, 'search');
+  helper.toggleRefinement('categories', 'beers');
+
+  var algoliaResponse = {
+    'results': [{
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 3,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 20,
+      'facets': {
+        // /!\ Note that lvl1 comes *before* lvl0 here
+        'categories.lvl1': {'beers > IPA': 6, 'beers > 1664': 3},
+        'categories.lvl0': {'beers': 9}
+      }
+    }, {
+      'query': 'a',
+      'index': indexName,
+      'hits': [{'objectID': 'one'}],
+      'nbHits': 1,
+      'page': 0,
+      'nbPages': 1,
+      'hitsPerPage': 1,
+      'facets': {
+        'categories.lvl0': {'beers': 9, 'fruits': 5, 'sales': 20}
+      }
+    }]
+  };
+
+  var expectedHelperResponse = [{
+    'name': 'categories',
+    'count': null,
+    'isRefined': true,
+    'path': null,
+    'data': [{
+      'name': 'beers',
+      'path': 'beers',
+      'count': 9,
+      'isRefined': true,
+      'data': [{
+        'name': '1664',
+        'path': 'beers > 1664',
+        'count': 3,
+        'isRefined': false,
+        'data': null
+      }, {
+        'name': 'IPA',
+        'path': 'beers > IPA',
+        'count': 6,
+        'isRefined': false,
+        'data': null
+      }]
+    }, {
+      'name': 'fruits',
+      'path': 'fruits',
+      'count': 5,
+      'isRefined': false,
+      'data': null
+    }, {
+      'name': 'sales',
+      'path': 'sales',
+      'count': 20,
+      'isRefined': false,
+      'data': null
+    }]
+  }];
+
+  search.yieldsAsync(null, algoliaResponse);
+  helper.setQuery('a').search();
+
+  helper.once('result', function(content) {
+    t.deepEqual(content.hierarchicalFacets, expectedHelperResponse);
+    t.deepEqual(content.getFacetByName('categories'), expectedHelperResponse[0]);
+
+    t.end();
+  });
+});


### PR DESCRIPTION
When using hierarchical facets, attributes composing the hierarchy tree are declared in a specific order:

```js
var helper = algoliasearchHelper(client, indexName, {
    hierarchicalFacets: [{
      name: 'categories',
      attributes: ['categories.lvl0', 'categories.lvl1']
    }]
});
```

It can happen (at least it happened to me!) that the API will return facets data for those attributes in a different order than the expected one:

```json
{
    "results": [{
      ... 
      "facets": {
        "categories.lvl1": { "beers > IPA": 6, "beers > 1664": 3 },
        "categories.lvl0": { "beers": 9 }
      }
    }, 
    ...
  ]
};
```
Note that lvl1 comes *before* lvl0 here!

The current code iterates on each key of `facets`, pushing each facet data to the `SearchResults.hierarchicalFacets` array in the order of the keys... which will later silently break the generation of the hierarchical facets tree!

This PR uses the declared attributes order for the hierarchical facet to make sure the facets data is correctly ordered.