### PR TITLE
fix(pagination): adds doc on reset behavior, changes the name of setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,14 +642,37 @@ helper.clearTags().search();
 #### Get the current page
 
 ```js
-helper.getCurrentPage();
+helper.getPage();
 ```
 
 #### Change page
 
 ```js
-helper.setCurrentPage(3).search();
+helper.setPage(3).search();
 ```
+
+#### Automatic reset to page 0
+
+During a search, changing the parameters will update the result set, which can then change
+the number of pages in the result set. Therefore, the behavior has been standardized so
+that any operation that may change the number of page will reset the pagination to page 0.
+
+This may lead to some unexpected behavior. For example:
+
+```js
+helper.setPage(4);
+helper.getPage(); // 4
+helper.setQuery('foo');
+helper.getPage(); // 0
+```
+
+Non exhaustive list of operations that trigger a reset:
+ - refinements (conjunctive, exclude, disjunctive, hierarchical, numeric)
+ - tags 
+ - index (setIndex)
+ - setQuery
+ - setHitsPerPage
+ - setTypoTolerance
 
 ### Index
 

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -358,7 +358,7 @@ AlgoliaSearchHelper.prototype.toggleTag = function(tag) {
  * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.nextPage = function() {
-  return this.setCurrentPage(this.state.page + 1);
+  return this.setPage(this.state.page + 1);
 };
 
 /**
@@ -366,8 +366,25 @@ AlgoliaSearchHelper.prototype.nextPage = function() {
  * @return {AlgoliaSearchHelper}
  */
 AlgoliaSearchHelper.prototype.previousPage = function() {
-  return this.setCurrentPage(this.state.page - 1);
+  return this.setPage(this.state.page - 1);
 };
+
+function setCurrentPage(page) {
+  if (page < 0) throw new Error('Page requested below 0.');
+
+  this.state = this.state.setPage(page);
+  this._change();
+  return this;
+}
+
+/**
+ * Change the current page
+ * @deprecated
+ * @param  {number} page The page number
+ * @return {AlgoliaSearchHelper}
+ * @fires change
+ */
+AlgoliaSearchHelper.prototype.setCurrentPage = setCurrentPage;
 
 /**
  * Change the current page
@@ -375,13 +392,7 @@ AlgoliaSearchHelper.prototype.previousPage = function() {
  * @return {AlgoliaSearchHelper}
  * @fires change
  */
-AlgoliaSearchHelper.prototype.setCurrentPage = function(page) {
-  if (page < 0) throw new Error('Page requested below 0.');
-
-  this.state = this.state.setPage(page);
-  this._change();
-  return this;
-};
+AlgoliaSearchHelper.prototype.setPage = setCurrentPage;
 
 /**
  * Configure the underlying index name
@@ -604,13 +615,21 @@ AlgoliaSearchHelper.prototype.getIndex = function() {
   return this.state.index;
 };
 
+function getCurrentPage() {
+  return this.state.page;
+}
+
+/**
+ * Get the currently selected page
+ * @deprecated
+ * @return {number} the current page
+ */
+AlgoliaSearchHelper.prototype.getCurrentPage = getCurrentPage;
 /**
  * Get the currently selected page
  * @return {number} the current page
  */
-AlgoliaSearchHelper.prototype.getCurrentPage = function() {
-  return this.state.page;
-};
+AlgoliaSearchHelper.prototype.getPage = getCurrentPage;
 
 /**
  * Get all the filtering tags


### PR DESCRIPTION
The `helper.setCurrentPage` is deprecated in favor of `helper.setPage`