### PR TITLE
feat(shortener): public with a set method

### DIFF
--- a/src/SearchParameters/shortener.js
+++ b/src/SearchParameters/shortener.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Module handling the shortened versions of the query
+ * string parameters
+ * @module algoliasearchHelper.url.shortener
+ */
+
 var invert = require('lodash/object/invert');
 var keys = require('lodash/object/keys');
 
@@ -59,13 +65,14 @@ var keys2Short = {
 };
 
 var short2Keys = invert(keys2Short);
+var ENCODED_PARAMETERS = keys(short2Keys);
 
 module.exports = {
   /**
    * All the keys of the state, encoded.
    * @const
    */
-  ENCODED_PARAMETERS: keys(short2Keys),
+  ENCODED_PARAMETERS: ENCODED_PARAMETERS,
   /**
    * Decode a shorten attribute
    * @param {string} shortKey the shorten attribute
@@ -81,5 +88,22 @@ module.exports = {
    */
   encode: function(key) {
     return keys2Short[key];
+  },
+  /**
+   * Set an attribute / short attribute pair
+   * @param {string} key the attribute
+   * @param {string} shortKey the shorten attribute
+   */
+  set: function(key, shortKey) {
+    var oldShort = keys2Short[key];
+    var idx = ENCODED_PARAMETERS.indexOf(oldShort);
+    if (idx === -1) {
+      ENCODED_PARAMETERS.push(shortKey);
+    } else {
+      ENCODED_PARAMETERS[idx] = shortKey;
+      delete short2Keys[oldShort];
+    }
+    keys2Short[key] = shortKey;
+    short2Keys[shortKey] = key;
   }
 };

--- a/src/url.js
+++ b/src/url.js
@@ -35,17 +35,22 @@ function recursiveEncode(input) {
   return input;
 }
 
-var refinementsParameters = ['dFR', 'fR', 'nR', 'hFR', 'tR'];
 var stateKeys = shortener.ENCODED_PARAMETERS;
-function sortQueryStringValues(prefixRegexp, a, b) {
+function sortQueryStringValues(
+  prefixRegexp,
+  queryParameter,
+  refinementsParameters,
+  a,
+  b
+) {
   if (prefixRegexp !== null) {
     a = a.replace(prefixRegexp, '');
     b = b.replace(prefixRegexp, '');
   }
 
   if (stateKeys.indexOf(a) !== -1 || stateKeys.indexOf(b) !== -1) {
-    if (a === 'q') return -1;
-    if (b === 'q') return 1;
+    if (a === queryParameter) return -1;
+    if (b === queryParameter) return 1;
 
     var isARefinements = refinementsParameters.indexOf(a) !== -1;
     var isBRefinements = refinementsParameters.indexOf(b) !== -1;
@@ -58,6 +63,12 @@ function sortQueryStringValues(prefixRegexp, a, b) {
 
   return a.localeCompare(b);
 }
+
+/**
+ * Shortener tools used inside this module
+ * @type {object}
+ */
+exports.shortener = shortener;
 
 /**
  * Read a query string and return an object containing the state
@@ -127,6 +138,14 @@ exports.getUnrecognizedParametersInQueryString = function(queryString, options) 
  *    won't be prefixed.
  * @return {string} the query string
  */
+
+var longRefinementsParameters = [
+  'disjunctiveFacetsRefinements',
+  'facetsRefinements',
+  'numericRefinements',
+  'hierarchicalFacetsRefinements',
+  'tagRefinements'
+];
 exports.getQueryStringFromState = function(state, options) {
   var moreAttributes = options && options.moreAttributes;
   var prefixForParameters = options && options.prefix || '';
@@ -141,7 +160,14 @@ exports.getQueryStringFromState = function(state, options) {
   );
 
   var prefixRegexp = prefixForParameters === '' ? null : new RegExp('^' + prefixForParameters);
-  var sort = bind(sortQueryStringValues, null, prefixRegexp);
+  var shortRefinementsParameters = map(longRefinementsParameters, shortener.encode);
+  var sort = bind(
+    sortQueryStringValues,
+    null,
+    prefixRegexp,
+    shortener.encode('query'),
+    shortRefinementsParameters
+  );
   if (moreAttributes) {
     var stateQs = qs.stringify(encodedState, {encode: false, sort: sort});
     var moreQs = qs.stringify(moreAttributes, {encode: false});

--- a/test/spec/SearchParameters/shortener.js
+++ b/test/spec/SearchParameters/shortener.js
@@ -23,3 +23,69 @@ test('Should encode all the properties of AlgoliaSearchHelper properly', functio
   );
   t.end();
 });
+
+test('Should be able to set a key to an another short value', function(t) {
+  var old = shortener.ENCODED_PARAMETERS[0];
+  var key = shortener.decode(old);
+  var now = 'abc';
+  var oldLength = shortener.ENCODED_PARAMETERS.length;
+
+  shortener.set(key, now);
+
+  t.equals(
+    shortener.encode(key),
+    now,
+    'Encoding the key should return the new one'
+  );
+  t.equals(
+    shortener.decode(now),
+    key,
+    'Decoding the new one should return the key'
+  );
+  t.equals(
+    shortener.decode(old),
+    undefined,
+    'Decoding the old one should return undefined'
+  );
+  t.equals(
+    shortener.ENCODED_PARAMETERS.length,
+    oldLength,
+    'ENCODED_PARAMETERS should have the same size'
+  );
+  t.equals(
+    shortener.ENCODED_PARAMETERS[0],
+    now,
+    'ENCODED_PARAMETERS\'s first value should have been replaced'
+  );
+  t.end();
+});
+
+test('Should be able to add a new key', function(t) {
+  var key = 'thisKeyShouldNeverBePresentInTheCode';
+  var now = 'tKSNBPITC';
+  var oldLength = shortener.ENCODED_PARAMETERS.length;
+
+  shortener.set(key, now);
+
+  t.equals(
+    shortener.encode(key),
+    now,
+    'Encoding the key should return the new one'
+  );
+  t.equals(
+    shortener.decode(now),
+    key,
+    'Decoding the new one should return the key'
+  );
+  t.equals(
+    shortener.ENCODED_PARAMETERS.length,
+    oldLength + 1,
+    'ENCODED_PARAMETERS should have grown'
+  );
+  t.equals(
+    shortener.ENCODED_PARAMETERS[oldLength],
+    now,
+    'ENCODED_PARAMETERS\'s last value should be the new one'
+  );
+  t.end();
+});


### PR DESCRIPTION
I've highlighted the reason for this PR there: https://github.com/algolia/instantsearch.js/issues/838 .  
Here is the example provided:

> - Zendesk's `/search` page accepts a `query` parameter.
> - I want to keep the default back-end search (which uses `query`) to have decent SEO on a query
> - However, by activating instantsearch, I end up with two parameters in the url `/search?query=a&q=a`
> - When I change the state the url becomes `/search?query=a&q=abc`.
>   If someone shares this URL, the back-end search will return results for `a` and the front-end results for `abc`, which is pretty uncool.
> 
> If I could change the "shortened" version of `query` from `q` to `query`, everything would be ultra simple.

New API:
```js
import algoliasearchHelper from 'algoliasearch-helper';
algoliasearchHelper.url.shortener.set('query', 'queryParam');
// `query` is  now globally mapped to `queryParam`
```

