### PR TITLE
fix(SearchParameters)Supports for unknown parameters

### DIFF
--- a/src/functions/warnOnce.js
+++ b/src/functions/warnOnce.js
@@ -1,0 +1,23 @@
+'use strict';
+var bind = require('lodash/function/bind');
+
+try {
+  var warn;
+
+  if (typeof window !== 'undefined') warn = window.console && bind(window.console.warn, console);
+  else warn = bind(console.warn, console); // eslint-disable-line no-console
+
+  var warnOnce = (function(w) {
+    var previousMessages = [];
+    return function warnOnlyOnce(m) {
+      if (previousMessages.indexOf(m) === -1) {
+        w(m);
+        previousMessages.push(m);
+      }
+    };
+  })(warn);
+
+  module.exports = warnOnce;
+} catch (e) {
+  module.exports = function() {};
+}

--- a/test/spec/SearchParameters/constructorFn.js
+++ b/test/spec/SearchParameters/constructorFn.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var test = require('tape');
+var forOwn = require('lodash/object/forOwn');
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('Constructor should accept an object with known keys', function(t) {
+  var legitConfig = {
+    'query': '',
+    'disjunctiveFacets': [
+      'customerReviewCount',
+      'category',
+      'salePrice_range',
+      'manufacturer'
+    ],
+    'maxValuesPerFacet': 30,
+    'page': 0,
+    'hitsPerPage': 10,
+    'facets': [
+      'type',
+      'shipping'
+    ]
+  };
+  var params = new SearchParameters(legitConfig);
+  forOwn(legitConfig, function(v, k) {
+    t.deepEqual(params[k], v);
+  });
+
+  t.end();
+});
+
+test('Constructor should accept an object with unknown keys', function(t) {
+  var betaConfig = {
+    'query': '',
+    'disjunctiveFacets': [
+      'customerReviewCount',
+      'category',
+      'salePrice_range',
+      'manufacturer'
+    ],
+    'maxValuesPerFacet': 30,
+    'page': 0,
+    'hitsPerPage': 10,
+    'facets': [
+      'type',
+      'shipping'
+    ],
+    'betaParameter': true,
+    'otherBetaParameter': ['alpha', 'omega']
+  };
+  var params = new SearchParameters(betaConfig);
+  forOwn(betaConfig, function(v, k) {
+    t.deepEqual(params[k], v);
+  });
+
+  t.end();
+});
+
+test('Factory should accept an object with known keys', function(t) {
+  var legitConfig = {
+    'query': '',
+    'disjunctiveFacets': [
+      'customerReviewCount',
+      'category',
+      'salePrice_range',
+      'manufacturer'
+    ],
+    'maxValuesPerFacet': 30,
+    'page': 0,
+    'hitsPerPage': 10,
+    'facets': [
+      'type',
+      'shipping'
+    ]
+  };
+  var params = SearchParameters.make(legitConfig);
+  forOwn(legitConfig, function(v, k) {
+    t.deepEqual(params[k], v);
+  });
+
+  t.end();
+});
+
+test('Constructor should accept an object with unknown keys', function(t) {
+  var betaConfig = {
+    'query': '',
+    'disjunctiveFacets': [
+      'customerReviewCount',
+      'category',
+      'salePrice_range',
+      'manufacturer'
+    ],
+    'maxValuesPerFacet': 30,
+    'page': 0,
+    'hitsPerPage': 10,
+    'facets': [
+      'type',
+      'shipping'
+    ],
+    'betaParameter': true,
+    'otherBetaParameter': ['alpha', 'omega']
+  };
+  var params = SearchParameters.make(betaConfig);
+  forOwn(betaConfig, function(v, k) {
+    t.deepEqual(params[k], v);
+  });
+
+  t.end();
+});

--- a/test/spec/SearchParameters/setQueryParameter.js
+++ b/test/spec/SearchParameters/setQueryParameter.js
@@ -43,15 +43,16 @@ test('setQueryParameter should not create a new instance if the update is non ef
   t.end();
 });
 
-test('setQueryParameter should throw an error when trying to add an unknown parameter', function(t) {
-  var bind = require('lodash/function/bind');
+test(
+  'setQueryParameter should not throw an error when trying to add an unknown parameter, and actually add it',
+  function(t) {
+    var state0 = new SearchParameters();
 
-  var sp = new SearchParameters({
-    facets: ['facet']
-  });
+    var state1 = state0.setQueryParameter('betaParameter', 'configValue');
+    // manual test that the warnonce message actually display message once
+    state0.setQueryParameter('betaParameter', 'configValue');
+    t.deepEquals(state1.betaParameter, 'configValue');
 
-  t.throws(bind(sp.setQueryParameter, sp, 'unknown', ''),
-    'Unknown parameter should throw an exception');
-
-  t.end();
-});
+    t.end();
+  }
+);

--- a/test/spec/SearchParameters/setQueryParameters.js
+++ b/test/spec/SearchParameters/setQueryParameters.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var test = require('tape');
+var forOwn = require('lodash/object/forOwn');
 var SearchParameters = require('../../../src/SearchParameters');
 
 test('setQueryParameters should be able to mix an actual state with a new set of parameters', function(t) {
@@ -25,10 +26,8 @@ test('setQueryParameters should be able to mix an actual state with a new set of
   t.end();
 });
 
-test('setQueryParameters should not add unknown properties', function(t) {
-  var partial = require('lodash/function/partial');
-
-  var originalSP = new SearchParameters({
+test('setQueryParameters should add unknown properties', function(t) {
+  var state0 = new SearchParameters({
     facets: ['a', 'b'],
     ignorePlurals: false,
     attributesToHighlight: ''
@@ -39,8 +38,11 @@ test('setQueryParameters should not add unknown properties', function(t) {
     facet: ['city', 'country']
   };
 
-  t.throws(partial(originalSP.setQueryParameters, params),
-    'The new searchParameters should be strictly equal');
+  var state1 = state0.setQueryParameters(params);
+
+  forOwn(params, function(v, k) {
+    t.deepEquals(state1[k], v);
+  });
 
   t.end();
 });


### PR DESCRIPTION
Will warn once on unknown parameters.
Fixes #200 but instead of throwing, it will accept all parameters, just warn.