### PR TITLE
Performance refactor of SearchParameters._parseNumbers

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -54,6 +54,10 @@
         }
       }
     },
+    "bench": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/bench/-/bench-0.3.6.tgz"
+    },
     "browserify": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-12.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "algoliasearch": "^3.13.0",
+    "bench": "^0.3.6",
     "browserify": "^12.0.1",
     "browzers": "^1.3.0",
     "bulk-require": "^0.2.1",

--- a/test/spec/SearchParameters/_parseNumbers.js
+++ b/test/spec/SearchParameters/_parseNumbers.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var test = require('tape');
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('_parseNumbers should convert to number all specified root keys', function(t) {
+  var partialState = {
+    aroundPrecision: '42',
+    aroundRadius: '42',
+    getRankingInfo: '42',
+    minWordSizefor2Typos: '42',
+    minWordSizefor1Typo: '42',
+    page: '42',
+    maxValuesPerFacet: '42',
+    distinct: '42',
+    minimumAroundRadius: '42',
+    hitsPerPage: '42',
+    minProximity: '42'
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.equal(actual.aroundPrecision, 42, 'aroundPrecision should be converted to number');
+  t.equal(actual.aroundRadius, 42, 'aroundRadius should be converted to number');
+  t.equal(actual.getRankingInfo, 42, 'getRankingInfo should be converted to number');
+  t.equal(actual.minWordSizefor2Typos, 42, 'minWordSizeFor2Typos should be converted to number');
+  t.equal(actual.minWordSizefor1Typo, 42, 'minWordSizeFor1Typo should be converted to number');
+  t.equal(actual.page, 42, 'page should be converted to number');
+  t.equal(actual.maxValuesPerFacet, 42, 'maxValuesPerFacet should be converted to number');
+  t.equal(actual.distinct, 42, 'distinct should be converted to number');
+  t.equal(actual.minimumAroundRadius, 42, 'minimumAroundRadius should be converted to number');
+  t.equal(actual.hitsPerPage, 42, 'hitsPerPage should be converted to number');
+  t.equal(actual.minProximity, 42, 'minProximity should be converted to number');
+
+  t.end();
+});
+
+test('_parseNumbers should not convert undefined to NaN', function(t) {
+  var partialState = {
+    aroundPrecision: undefined
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.equal(actual.aroundPrecision, undefined);
+
+  t.end();
+});
+
+test('_parseNumbers should convert numericRefinements values', function(t) {
+  var partialState = {
+    numericRefinements: {
+      foo: {
+        '>=': ['4.8', '15.16'],
+        '=': ['23.42']
+      }
+    }
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.deepEqual(actual.numericRefinements.foo['>='], [4.8, 15.16], 'should convert foo >=');
+  t.deepEqual(actual.numericRefinements.foo['='], [23.42], 'should convert foo =');
+
+  t.end();
+});
+
+test('_parseNumbers should convert nested numericRefinements values', function(t) {
+  var partialState = {
+    numericRefinements: {
+      foo: {
+        '>=': [
+          ['4.8'], '15.16'
+        ],
+        '=': ['23.42']
+      }
+    }
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.deepEqual(actual.numericRefinements.foo['>='], [
+    [4.8], 15.16
+  ], 'should convert foo >=');
+  t.deepEqual(actual.numericRefinements.foo['='], [23.42], 'should convert foo =');
+
+  t.end();
+});


### PR DESCRIPTION
I had a perf issue on instantsearch. When enabling the `urlSync`, typing in the input was really slow and sluggish. After a bit of digging, it turns out that the issue was coming from the fact that I had to fetch more than 1000 facet values and that the widget was generating a unique url for each of them.

After looking at the Chrome CPU profiling, I found that most of the time was spent in `SearchParameters._parseNumbers` in the helper.
![image](https://cloud.githubusercontent.com/assets/283419/13775305/2069038e-eaa4-11e5-8ced-309c6f5d448b.png)

I started by putting a few tests on the method, than starting refactoring. Mostly, I used the lodash `cloneDeep` method instead of `merge`, `mapValues` instead of a custom-made loop and exported a bit of logic into a recursive method.

My empirical tests showed that it was faster, but I also added a performance benchmark in `./test/perf/SearchParameters/_parseNumbers.js` that you can run with `npm run test:perf`. Here is the output:

```
Scores: (bigger is better)

parseNumbers with cloneDeep
Raw:
 > 87.47514910536779
 > 87.56218905472637
 > 80.1186943620178
 > 86.73978065802592
Average (mean) 85.47395329503448

parseNumbers with merge
Raw:
 > 38.272816486751715
 > 38.767395626242546
 > 38.72889771598808
 > 38.423645320197046
Average (mean) 38.54818878729485

Winner: parseNumbers with cloneDeep
Compared with next highest (parseNumbers with merge), it's:
54.9% faster
2.22 times as fast
0.35 order(s) of magnitude faster
QUITE A BIT FASTER
```

So this refactor is actually a bit faster. Not sure this will fix my instantsearch issue, but this is a good start.

I'm also unsure about keeping the perf benchmark in the repo. On one hand I find it interesting to prove that it is actually faster than before, on the other hand I'm not sure it is useful to keep it in the repo like this. Tell me what you think @bobylito @vvo and I'll remove it from the PR.