### PR TITLE
Fix(_parseNumber): Store unparseable strings for root query parameter

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -9,6 +9,7 @@ var map = require('lodash/collection/map');
 var reduce = require('lodash/collection/reduce');
 var omit = require('lodash/object/omit');
 var indexOf = require('lodash/array/indexOf');
+var isNaN = require('lodash/lang/isNaN');
 var isArray = require('lodash/lang/isArray');
 var isEmpty = require('lodash/lang/isEmpty');
 var isEqual = require('lodash/lang/isEqual');
@@ -460,7 +461,10 @@ SearchParameters._parseNumbers = function(partialState) {
 
   forEach(numberKeys, function(k) {
     var value = partialState[k];
-    if (isString(value)) numbers[k] = parseFloat(partialState[k]);
+    if (isString(value)) {
+      var parsedValue = parseFloat(value);
+      numbers[k] = isNaN(parsedValue) ? value : parsedValue;
+    }
   });
 
   if (partialState.numericRefinements) {

--- a/test/spec/SearchParameters/_parseNumbers.js
+++ b/test/spec/SearchParameters/_parseNumbers.js
@@ -3,7 +3,7 @@
 var test = require('tape');
 var SearchParameters = require('../../../src/SearchParameters');
 
-test('_parseNumbers should convert to number all specified root keys', function(t) {
+test('_parseNumbers should convert to number all specified root keys (that are parseable)', function(t) {
   var partialState = {
     aroundPrecision: '42',
     aroundRadius: '42',
@@ -41,6 +41,17 @@ test('_parseNumbers should not convert undefined to NaN', function(t) {
   var actual = SearchParameters._parseNumbers(partialState);
 
   t.equal(actual.aroundPrecision, undefined);
+
+  t.end();
+});
+
+test('_parseNumbers should not convert unparseable strings', function(t) {
+  var partialState = {
+    aroundRadius: 'all'
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.equal(actual.aroundRadius, 'all');
 
   t.end();
 });


### PR DESCRIPTION
Some number parameters can also have string values. Storing number as numbers ensures that the same doesn't have 2 representations. If it's not parseable it should still be stored.

Fixes #313 