### PR TITLE
feat(urls): provide a `safe` option to fully encode the url

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -134,17 +134,22 @@ exports.getUnrecognizedParametersInQueryString = function(queryString, options) 
  *  - mapping : map short attributes to another value e.g. {q: 'query'}
  *  - moreAttributes : more values to be added in the query string. Those values
  *    won't be prefixed.
+ *  - safe : get safe urls for use in emails, chat apps or any application auto linking urls.
+ *  All parameters and values will be encoded in a way that it's safe to share them.
+ *  Default to false for legacy reasons ()
  * @return {string} the query string
  */
 exports.getQueryStringFromState = function(state, options) {
   var moreAttributes = options && options.moreAttributes;
   var prefixForParameters = options && options.prefix || '';
   var mapping = options && options.mapping || {};
+  var safe = options && options.safe || false;
   var invertedMapping = invert(mapping);
-  var partialStateWithEncodedValues = recursiveEncode(state);
+
+  var stateForUrl = safe ? state : recursiveEncode(state);
 
   var encodedState = mapKeys(
-    partialStateWithEncodedValues,
+    stateForUrl,
     function(v, k) {
       var shortK = shortener.encode(k);
       return prefixForParameters + (mapping[shortK] || shortK);
@@ -154,11 +159,11 @@ exports.getQueryStringFromState = function(state, options) {
   var prefixRegexp = prefixForParameters === '' ? null : new RegExp('^' + prefixForParameters);
   var sort = bind(sortQueryStringValues, null, prefixRegexp, invertedMapping);
   if (moreAttributes) {
-    var stateQs = qs.stringify(encodedState, {encode: false, sort: sort});
-    var moreQs = qs.stringify(moreAttributes, {encode: false});
+    var stateQs = qs.stringify(encodedState, {encode: safe, sort: sort});
+    var moreQs = qs.stringify(moreAttributes, {encode: safe});
     if (!stateQs) return moreQs;
     return stateQs + '&' + moreQs;
   }
 
-  return qs.stringify(encodedState, {encode: false, sort: sort});
+  return qs.stringify(encodedState, {encode: safe, sort: sort});
 };

--- a/test/spec/algoliasearch.helper/getStateAsQueryString.js
+++ b/test/spec/algoliasearch.helper/getStateAsQueryString.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var test = require('tape');
+var algoliaSearchHelper = require('../../../index.js');
+
+test('getStateAsQueryString', function(t) {
+  var helper = algoliaSearchHelper(null, 'fake index', {
+    facets: ['color'],
+    hierarchicalFacets: [{
+      name: 'products',
+      attributes: ['categories.lvl0', 'categories.lvl1']
+    }]
+  });
+  helper.setQuery('hello mama');
+  helper.toggleRefine('color', 'white');
+  helper.toggleRefine('products', 'fruits > bananas');
+  t.equal(
+    helper.getStateAsQueryString(),
+    'q=hello%20mama&fR[color][0]=white&hFR[products][0]=fruits%20%3E%20bananas'
+  );
+
+  t.end();
+});
+
+test('getStateAsQueryString({safe: true})', function(t) {
+  var helper = algoliaSearchHelper(null, 'fake index', {
+    facets: ['color'],
+    hierarchicalFacets: [{
+      name: 'products',
+      attributes: ['categories.lvl0', 'categories.lvl1']
+    }]
+  });
+  helper.setQuery('hello mama');
+  helper.toggleRefine('color', 'white');
+  helper.toggleRefine('products', 'fruits > bananas');
+  t.equal(
+    helper.getStateAsQueryString({safe: true}),
+    'q=hello%20mama&fR%5Bcolor%5D%5B0%5D=white&hFR%5Bproducts%5D%5B0%5D=fruits%20%3E%20bananas'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
following algolia/instantsearch.js#982,
I propose to add a `safe` parameter to getQueryStringFromState that
allows you to retrieve the fully encoded url instead of a custom
encoded non-safe one.