### PR TITLE
doc(url): document URL utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,19 +770,10 @@ var state1 = helper.searchOnce({hitsPerPage: 1})
 
 ### URL Helpers
 
-#### Get a query string of a part of the parameters
-
-```js
-// see the jsdoc for the parameters
-// http://algolia.github.io/algoliasearch-helper-js/docs/AlgoliaSearchHelper.html#getStateAsQueryString
-var qs = helper.getStateAsQueryString();
-// by defaults it serialize the current index, the query and all the refinements
-```
-
 #### Set the state from a query string
 
 ```js
-helper.setStateFromQueryString(qs);
+helper.setState(algoliasearchHelper.url.getStateFromQueryString(qs));
 ```
 
 #### Get a plain object with a subset of the state
@@ -807,7 +798,7 @@ var otherConf = algoliasearchHelper.url.getUnrecognizedParametersInQueryString(q
 #### Get the query string of any state
 
 ```js
-var state = helper.state;
+var state = helper.getState();
 var qs = algoliasearchHelper.url.getQueryStringFromState(state);
 ```
 

--- a/documentation-src/build.gulp.js
+++ b/documentation-src/build.gulp.js
@@ -56,6 +56,10 @@ function makeMetalsmithBuilder() {
                   namespace: 'state'
                 }))
                 .use(jsdoc({
+                  src: 'src/url.js',
+                  namespace: 'url'
+                }))
+                .use(jsdoc({
                   src: 'index.js',
                   namespace: 'main'
                 }))

--- a/documentation-src/metalsmith/content/reference.md
+++ b/documentation-src/metalsmith/content/reference.md
@@ -398,7 +398,6 @@ Algolia.
 {{> jsdoc jsdoc/helper/getState}}
 {{> jsdoc jsdoc/helper/setState}}
 {{> jsdoc jsdoc/helper/overrideStateWithoutTriggeringChangeEvent}}
-{{> jsdoc jsdoc/helper/getStateAsQueryString}}
 
 ### Events
 
@@ -525,3 +524,14 @@ instance contain the change implied by the method call.
 {{> jsdoc jsdoc/state/getHierarchicalFacetByName}}
 {{> jsdoc jsdoc/state/make}}
 {{> jsdoc jsdoc/state/validate}}
+
+## URL
+
+The helper exposes some URL utility methods for serializing and deserializing
+state to and from a URL query string.
+
+The following methods are available under the `algoliasearchHelper.url` namespace.
+
+{{> jsdoc jsdoc/url/getStateFromQueryString}}
+{{> jsdoc jsdoc/url/getUnrecognizedParametersInQueryString}}
+{{> jsdoc jsdoc/url/getQueryStringFromState}}

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -649,8 +649,9 @@ AlgoliaSearchHelper.prototype.getState = function(filters) {
 };
 
 /**
- * Get part of the state as a query string. By default, the output keys will not
+ * DEPRECATED Get part of the state as a query string. By default, the output keys will not
  * be prefixed and will only take the applied refinements and the query.
+ * @deprecated
  * @param {object} [options] May contain the following parameters :
  *
  * **filters** : possible values are all the keys of the [SearchParameters](#searchparameters), `index` for
@@ -699,8 +700,9 @@ AlgoliaSearchHelper.getConfigurationFromQueryString = url.getStateFromQueryStrin
 AlgoliaSearchHelper.getForeignConfigurationInQueryString = url.getUnrecognizedParametersInQueryString;
 
 /**
- * Overrides part of the state with the properties stored in the provided query
+ * DEPRECATED Overrides part of the state with the properties stored in the provided query
  * string.
+ * @deprecated
  * @param {string} queryString the query string containing the informations to url the state
  * @param {object} options optionnal parameters :
  *  - prefix : prefix used for the algolia parameters

--- a/src/url.js
+++ b/src/url.js
@@ -67,7 +67,7 @@ function sortQueryStringValues(prefixRegexp, invertedMapping, a, b) {
 /**
  * Read a query string and return an object containing the state
  * @param {string} queryString the query string that will be decoded
- * @param {object} options accepted options :
+ * @param {object} [options] accepted options :
  *   - prefix : the prefix used for the saved attributes, you have to provide the
  *     same that was used for serialization
  *   - mapping : map short attributes to another value e.g. {q: 'query'}
@@ -100,7 +100,7 @@ exports.getStateFromQueryString = function(queryString, options) {
  * Retrieve an object of all the properties that are not understandable as helper
  * parameters.
  * @param {string} queryString the query string to read
- * @param {object} options the options
+ * @param {object} [options] the options
  *   - prefixForParameters : prefix used for the helper configuration keys
  *   - mapping : map short attributes to another value e.g. {q: 'query'}
  * @return {object} the object containing the parsed configuration that doesn't


### PR DESCRIPTION
I've also deprecated all the query string related methods on the helper in favor of using `algoliasearchHelper.url`.