### PR TITLE
feat(add-remove-facet): add methods to add and remove facets from SearchParameters configuration

### DIFF
--- a/documentation-src/metalsmith/content/reference.md
+++ b/documentation-src/metalsmith/content/reference.md
@@ -492,10 +492,16 @@ instance contain the change implied by the method call.
 {{> jsdoc jsdoc/state/removeNumericRefinement}}
 {{> jsdoc jsdoc/state/getNumericRefinements}}
 {{> jsdoc jsdoc/state/getNumericRefinement}}
+{{> jsdoc jsdoc/state/addFacet}}
+{{> jsdoc jsdoc/state/addDisjunctiveFacet}}
+{{> jsdoc jsdoc/state/addHierarchicalFacet}}
 {{> jsdoc jsdoc/state/addFacetRefinement}}
 {{> jsdoc jsdoc/state/addExcludeRefinement}}
 {{> jsdoc jsdoc/state/addDisjunctiveFacetRefinement}}
 {{> jsdoc jsdoc/state/addTagRefinement}}
+{{> jsdoc jsdoc/state/removeFacet}}
+{{> jsdoc jsdoc/state/removeDisjunctiveFacet}}
+{{> jsdoc jsdoc/state/removeHierarchicalFacet}}
 {{> jsdoc jsdoc/state/removeFacetRefinement}}
 {{> jsdoc jsdoc/state/removeExcludeRefinement}}
 {{> jsdoc jsdoc/state/removeDisjunctiveFacetRefinement}}

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -921,14 +921,15 @@ SearchParameters.prototype = {
   },
   /**
    * Add a hierarchical facet to the hierarchicalFacets attribute of the helper
-   * configuration, if it isn't already present.
+   * configuration.
    * @method
    * @param {object} hierarchicalFacet hierarchical facet to add
    * @return {SearchParameters}
+   * @throws will throw an error if a hierarchical facet with the same name was already declared
    */
   addHierarchicalFacet: function addHierarchicalFacet(hierarchicalFacet) {
     if (this.isHierarchicalFacet(hierarchicalFacet.name)) {
-      return this;
+      throw new Error('Cannot declare two hierarchical facets with the same name: `' + hierarchicalFacet.name + '`');
     }
 
     return this.setQueryParameters({

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -17,7 +17,6 @@ var isUndefined = require('lodash/isUndefined');
 var isString = require('lodash/isString');
 var isFunction = require('lodash/isFunction');
 var find = require('lodash/find');
-var findIndex = require('lodash/findIndex');
 
 var defaults = require('lodash/defaults');
 var merge = require('lodash/merge');

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1020,7 +1020,7 @@ SearchParameters.prototype = {
       return this;
     }
 
-    return this.setQueryParameters({
+    return this.clearRefinements(facet).setQueryParameters({
       facets: filter(this.facets, function(f) {
         return f !== facet;
       })
@@ -1038,7 +1038,7 @@ SearchParameters.prototype = {
       return this;
     }
 
-    return this.setQueryParameters({
+    return this.clearRefinements(facet).setQueryParameters({
       disjunctiveFacets: filter(this.disjunctiveFacets, function(f) {
         return f !== facet;
       })
@@ -1056,7 +1056,7 @@ SearchParameters.prototype = {
       return this;
     }
 
-    return this.setQueryParameters({
+    return this.clearRefinements(facet).setQueryParameters({
       hierarchicalFacets: filter(this.hierarchicalFacets, function(f) {
         return f.name !== facet;
       })

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -17,6 +17,7 @@ var isUndefined = require('lodash/isUndefined');
 var isString = require('lodash/isString');
 var isFunction = require('lodash/isFunction');
 var find = require('lodash/find');
+var findIndex = require('lodash/findIndex');
 
 var defaults = require('lodash/defaults');
 var merge = require('lodash/merge');
@@ -888,6 +889,54 @@ SearchParameters.prototype = {
     }
   },
   /**
+   * Add a facet to the facets attribute of the helper configuration, if it
+   * isn't already present.
+   * @method
+   * @param {string} facet facet name to add
+   * @return {SearchParameters}
+   */
+  addFacet: function addFacet(facet) {
+    if (this.isConjunctiveFacet(facet)) {
+      return this;
+    }
+
+    return this.setQueryParameters({
+      facets: this.facets.concat([facet])
+    });
+  },
+  /**
+   * Add a disjunctive facet to the disjunctiveFacets attribute of the helper
+   * configuration, if it isn't already present.
+   * @method
+   * @param {string} facet disjunctive facet name to add
+   * @return {SearchParameters}
+   */
+  addDisjunctiveFacet: function addDisjunctiveFacet(facet) {
+    if (this.isDisjunctiveFacet(facet)) {
+      return this;
+    }
+
+    return this.setQueryParameters({
+      disjunctiveFacets: this.disjunctiveFacets.concat([facet])
+    });
+  },
+  /**
+   * Add a hierarchical facet to the hierarchicalFacets attribute of the helper
+   * configuration, if it isn't already present.
+   * @method
+   * @param {object} hierarchicalFacet hierarchical facet to add
+   * @return {SearchParameters}
+   */
+  addHierarchicalFacet: function addHierarchicalFacet(hierarchicalFacet) {
+    if (this.isHierarchicalFacet(hierarchicalFacet.name)) {
+      return this;
+    }
+
+    return this.setQueryParameters({
+      hierarchicalFacets: this.hierarchicalFacets.concat([hierarchicalFacet])
+    });
+  },
+  /**
    * Add a refinement on a "normal" facet
    * @method
    * @param {string} facet attribute to apply the facetting on
@@ -958,6 +1007,60 @@ SearchParameters.prototype = {
     };
 
     return this.setQueryParameters(modification);
+  },
+  /**
+   * Remove a facet from the facets attribute of the helper configuration, if it
+   * is present.
+   * @method
+   * @param {string} facet facet name to remove
+   * @return {SearchParameters}
+   */
+  removeFacet: function removeFacet(facet) {
+    if (!this.isConjunctiveFacet(facet)) {
+      return this;
+    }
+
+    const newFacets = this.facets.slice();
+    newFacets.splice(newFacets.indexOf(facet), 1);
+    return this.setQueryParameters({
+      facets: newFacets
+    });
+  },
+  /**
+   * Remove a disjunctive facet from the disjunctiveFacets attribute of the
+   * helper configuration, if it is present.
+   * @method
+   * @param {string} facet disjunctive facet name to remove
+   * @return {SearchParameters}
+   */
+  removeDisjunctiveFacet: function removeDisjunctiveFacet(facet) {
+    if (!this.isDisjunctiveFacet(facet)) {
+      return this;
+    }
+
+    const newFacets = this.disjunctiveFacets.slice();
+    newFacets.splice(newFacets.indexOf(facet), 1);
+    return this.setQueryParameters({
+      disjunctiveFacets: newFacets
+    });
+  },
+  /**
+   * Add a hierarchical facet to the hierarchicalFacets attribute of the helper
+   * configuration, if it isn't already present.
+   * @method
+   * @param {string} facet hierarchical facet name to remove
+   * @return {SearchParameters}
+   */
+  removeHierarchicalFacet: function removeHierarchicalFacet(facet) {
+    if (!this.isHierarchicalFacet(facet)) {
+      return this;
+    }
+
+    const newFacets = this.hierarchicalFacets.slice();
+    newFacets.splice(findIndex(newFacets, {name: facet}));
+    return this.setQueryParameters({
+      hierarchicalFacets: newFacets
+    });
   },
   /**
    * Remove a refinement set on facet. If a value is provided, it will clear the

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1045,8 +1045,8 @@ SearchParameters.prototype = {
     });
   },
   /**
-   * Add a hierarchical facet to the hierarchicalFacets attribute of the helper
-   * configuration, if it isn't already present.
+   * Remove a hierarchical facet from the hierarchicalFacets attribute of the
+   * helper configuration, if it is present.
    * @method
    * @param {string} facet hierarchical facet name to remove
    * @return {SearchParameters}

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1020,10 +1020,10 @@ SearchParameters.prototype = {
       return this;
     }
 
-    const newFacets = this.facets.slice();
-    newFacets.splice(newFacets.indexOf(facet), 1);
     return this.setQueryParameters({
-      facets: newFacets
+      facets: filter(this.facets, function(f) {
+        return f !== facet;
+      })
     });
   },
   /**
@@ -1038,10 +1038,10 @@ SearchParameters.prototype = {
       return this;
     }
 
-    const newFacets = this.disjunctiveFacets.slice();
-    newFacets.splice(newFacets.indexOf(facet), 1);
     return this.setQueryParameters({
-      disjunctiveFacets: newFacets
+      disjunctiveFacets: filter(this.disjunctiveFacets, function(f) {
+        return f !== facet;
+      })
     });
   },
   /**
@@ -1056,10 +1056,10 @@ SearchParameters.prototype = {
       return this;
     }
 
-    const newFacets = this.hierarchicalFacets.slice();
-    newFacets.splice(findIndex(newFacets, {name: facet}));
     return this.setQueryParameters({
-      hierarchicalFacets: newFacets
+      hierarchicalFacets: filter(this.hierarchicalFacets, function(f) {
+        return f.name !== facet;
+      })
     });
   },
   /**

--- a/test/spec/SearchParameters/listAttributes.js
+++ b/test/spec/SearchParameters/listAttributes.js
@@ -17,6 +17,13 @@ test('removeFacet should remove a facet from the facets list', function(t) {
 
   t.deepEquals(state.facets, []);
 
+  state = SearchParameters.make({})
+    .addFacet('facet')
+    .addFacetRefinement('facet', 'value')
+    .removeFacet('facet');
+
+  t.deepEquals(state.facetsRefinements, {});
+
   t.end();
 });
 
@@ -35,6 +42,13 @@ test('removeDisjunctiveFacet should remove a facet from the disjunctiveFacets li
 
   t.deepEquals(state.disjunctiveFacets, []);
 
+  state = SearchParameters.make({})
+    .addDisjunctiveFacet('facet')
+    .addDisjunctiveFacetRefinement('facet', 'value')
+    .removeDisjunctiveFacet('facet');
+
+  t.deepEquals(state.disjunctiveFacetsRefinements, {});
+
   t.end();
 });
 
@@ -52,6 +66,13 @@ test('removeHierarchicalFacet should remove a facet from the hierarchicalFacets 
     .removeHierarchicalFacet('facet');
 
   t.deepEquals(state.hierarchicalFacets, []);
+
+  state = SearchParameters.make({})
+    .addHierarchicalFacet({name: 'facet'})
+    .toggleHierarchicalFacetRefinement('facet', 'value')
+    .removeHierarchicalFacet('facet');
+
+  t.deepEquals(state.hierarchicalFacetsRefinements, {});
 
   t.end();
 });

--- a/test/spec/SearchParameters/listAttributes.js
+++ b/test/spec/SearchParameters/listAttributes.js
@@ -60,6 +60,16 @@ test('addHierarchicalFacet should add a facet to the hierarchicalFacets list', f
   t.end();
 });
 
+test('addHierarchicalFacet should throw when a facet with the same name is already declared', function(t) {
+  t.throws(function() {
+    SearchParameters
+      .make({hierarchicalFacets: [{name: 'facet'}]})
+      .addHierarchicalFacet({name: 'facet'});
+  });
+
+  t.end();
+});
+
 test('removeHierarchicalFacet should remove a facet from the hierarchicalFacets list', function(t) {
   var state = SearchParameters.make({})
     .addHierarchicalFacet({name: 'facet'})

--- a/test/spec/SearchParameters/listAttributes.js
+++ b/test/spec/SearchParameters/listAttributes.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var test = require('tape');
+
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('addFacet should add a facet to the facets list', function(t) {
+  var state = SearchParameters.make({}).addFacet('facet');
+
+  t.deepEquals(state.facets, ['facet']);
+
+  t.end();
+});
+
+test('removeFacet should remove a facet from the facets list', function(t) {
+  var state = SearchParameters.make({}).addFacet('facet').removeFacet('facet');
+
+  t.deepEquals(state.facets, []);
+
+  t.end();
+});
+
+test('addDisjunctiveFacet should add a facet to the disjunctiveFacets list', function(t) {
+  var state = SearchParameters.make({}).addDisjunctiveFacet('facet');
+
+  t.deepEquals(state.disjunctiveFacets, ['facet']);
+
+  t.end();
+});
+
+test('removeDisjunctiveFacet should remove a facet from the disjunctiveFacets list', function(t) {
+  var state = SearchParameters.make({})
+    .addDisjunctiveFacet('facet')
+    .removeDisjunctiveFacet('facet');
+
+  t.deepEquals(state.disjunctiveFacets, []);
+
+  t.end();
+});
+
+test('addHierarchicalFacet should add a facet to the hierarchicalFacets list', function(t) {
+  var state = SearchParameters.make({}).addHierarchicalFacet({name: 'facet'});
+
+  t.deepEquals(state.hierarchicalFacets, [{name: 'facet'}]);
+
+  t.end();
+});
+
+test('removeHierarchicalFacet should remove a facet from the hierarchicalFacets list', function(t) {
+  var state = SearchParameters.make({})
+    .addHierarchicalFacet({name: 'facet'})
+    .removeHierarchicalFacet('facet');
+
+  t.deepEquals(state.hierarchicalFacets, []);
+
+  t.end();
+});

--- a/test/spec/SearchParameters/noChanges.js
+++ b/test/spec/SearchParameters/noChanges.js
@@ -44,6 +44,54 @@ test('[No changes] setQuery', function(t) {
   t.end();
 });
 
+test('[No changes] addFacet', function(t) {
+  var state = SearchParameters.make({}).addFacet('facet');
+
+  t.equal(state.addFacet('facet'), state, 'addFacet should return the same instance');
+
+  t.end();
+});
+
+test('[No changes] removeFacet', function(t) {
+  var state = SearchParameters.make({});
+
+  t.equal(state.removeFacet('facet'), state, 'removeFacet should return the same instance');
+
+  t.end();
+});
+
+test('[No changes] addDisjunctiveFacet', function(t) {
+  var state = SearchParameters.make({}).addDisjunctiveFacet('facet');
+
+  t.equal(state.addDisjunctiveFacet('facet'), state, 'addDisjunctiveFacet should return the same instance');
+
+  t.end();
+});
+
+test('[No changes] removeDisjunctiveFacet', function(t) {
+  var state = SearchParameters.make({});
+
+  t.equal(state.removeDisjunctiveFacet('facet'), state, 'removeDisjunctiveFacet should return the same instance');
+
+  t.end();
+});
+
+test('[No changes] addHierarchicalFacet', function(t) {
+  var state = SearchParameters.make({}).addHierarchicalFacet({name: 'facet'});
+
+  t.equal(state.addHierarchicalFacet({name: 'facet'}), state, 'addHierarchicalFacet should return the same instance');
+
+  t.end();
+});
+
+test('[No changes] removeHierarchicalFacet', function(t) {
+  var state = SearchParameters.make({});
+
+  t.equal(state.removeHierarchicalFacet('facet'), state, 'removeHierarchicalFacet should return the same instance');
+
+  t.end();
+});
+
 test('[No changes] addTagRefinement', function(t) {
   var state = SearchParameters.make({}).addTagRefinement('tag');
 

--- a/test/spec/SearchParameters/noChanges.js
+++ b/test/spec/SearchParameters/noChanges.js
@@ -76,14 +76,6 @@ test('[No changes] removeDisjunctiveFacet', function(t) {
   t.end();
 });
 
-test('[No changes] addHierarchicalFacet', function(t) {
-  var state = SearchParameters.make({}).addHierarchicalFacet({name: 'facet'});
-
-  t.equal(state.addHierarchicalFacet({name: 'facet'}), state, 'addHierarchicalFacet should return the same instance');
-
-  t.end();
-});
-
 test('[No changes] removeHierarchicalFacet', function(t) {
   var state = SearchParameters.make({});
 

--- a/test/spec/algoliasearch.helper/excludes.js
+++ b/test/spec/algoliasearch.helper/excludes.js
@@ -45,7 +45,7 @@ test('removeExclude should remove an exclusion', function(t) {
   t.end();
 });
 
-test.only('isExcluded should allow to omit the value', function(t) {
+test('isExcluded should allow to omit the value', function(t) {
   var facetName = 'foo';
   var facetValueToExclude = 'brand';
   var facetValueNotExcluded = 'bar';


### PR DESCRIPTION
Let's try this again. See #327, #328, #330, #332.

@bobylito @vvo we sometimes use `conjunctive` to describe the facets defined in the `facets` attribute. Should `{add,remove}Facet` be renamed to `{add,remove}ConjunctiveFacet`?