### PR TITLE
Proposed copy changes on the docs home page

### DIFF
--- a/documentation-src/metalsmith/content/index.md
+++ b/documentation-src/metalsmith/content/index.md
@@ -1,7 +1,7 @@
 ---
 layout: main.jade
 title: Algolia JS Helper
-subtitle: The toolbox for creating advanced search experiences
+subtitle: A set of utilities for further customizing search behavior
 ---
 
 Don't sweat, the content of this file won't be read.

--- a/documentation-src/metalsmith/layouts/main.jade
+++ b/documentation-src/metalsmith/layouts/main.jade
@@ -25,32 +25,35 @@ html
     section
       .container
         div
-          h2.title Made for building your next advanced search experience with Algolia
+          h2.title A companion to Algolia's JS API client, used by instantsearch.js
           p
-            | The helper is built on top of the Algolia JS Client. It provides all the necessary
-            | tools to make your next search experience. With advanced faceting features, your
-            | users will find what they’re looking for even faster and precisely than ever before.
+            | The Algolia JS Helper is a set of functions and patterns that
+            | make it possible to customize search experiences at a deeper
+            | level. Working side-by-side with the Algolia JS Client, the JS
+            | Helper exposes new interfaces to perform advanced faceting,
+            | manage stateful parameters, and subscribe to events.
           a.btn.btn-cta(href='gettingstarted.html') Get Started
     hr
     section.oddbg
       .container
         div
-          h2.title Rock solid foundation
+          h2.title Reusable abstractions
           p
-            | The Helper is opinionated on the structure of the search logic but not about
-            | the context on which it is used. The Helper defines:
+            | The Helper can be used in any context and helps structure
+            | your search logic. The Helper:
           ul
-            li An immutable model that is the source of truth for the search parameters
-            li Events to dispatch the steps of the search flow
-          a.btn.btn-cta(href='concepts.html') Learn more
+            li defines an immutable source of truth for search parameters
+            li dispatches events at key stages of the search cycle
+          a.btn.btn-cta(href='concepts.html') See the concepts
     hr
     section
       .container
         div
-          h2.title Any framework friendly
+          h2.title Framework-agnostic
           p
-            | The Helper is all the frameworks best friend. Its architecture doesn’t have
-            | any ties with a specific framework nor it leaks abstractions that are foreign
-            | to your tools. We even used it for creating our own widget library 
+            | The Helper can be any search application's best friend. The architecture isn't
+            | tied to a specific framework nor does it leak any unsightly abstractions.
+            | And it's battle-tested—we use it inside of our widget-based, full-page search library
             a(href='https://community.algolia.com/instantsearch.js/') instantsearch.js
+            | .
     include ./common/footer.jade


### PR DESCRIPTION
I tried to be more exact about the relationship of the JS Helper to other Algolia front-end tools. Beyond that, it's mostly tweaking grammar and swapping in some more common idioms.