### PR TITLE
Add trailing space to avoid text running into link

### DIFF
--- a/documentation-src/metalsmith/layouts/main.jade
+++ b/documentation-src/metalsmith/layouts/main.jade
@@ -53,7 +53,7 @@ html
           p
             | The Helper can be any search application's best friend. The architecture isn't
             | tied to a specific framework nor does it leak any unsightly abstractions.
-            | And it's battle-tested—we use it inside of our widget-based, full-page search library
+            | And it's battle-tested—we use it inside of our widget-based, full-page search library 
             a(href='https://community.algolia.com/instantsearch.js/') instantsearch.js
             | .
     include ./common/footer.jade


### PR DESCRIPTION
Fixes small visual bug at the bottom of the home page