### PR TITLE
Update the color of the text in the hero section to improve readability

### DIFF
--- a/documentation-src/metalsmith/stylesheets/components/_containers.scss
+++ b/documentation-src/metalsmith/stylesheets/components/_containers.scss
@@ -34,7 +34,7 @@ section {
 
   &.hero-section {
     background: $hero-color;
-    color: #fff;
+    color: $hero-color-accent;
     padding-top: $navigation-height*1.5;
 
     .container {
@@ -64,7 +64,7 @@ section {
         content: '';
         width: 16px;
         height: 2px;
-        background: #D8D8D8;
+        background: $hero-color-accent;
         top: 30px;
         left: 0;
         right: 0;
@@ -81,7 +81,7 @@ section {
 
     h3 {
       font-size: 20px;
-      color: $bg-pale-accent;
+      color: $hero-color-accent;
       font-weight: 400;
       padding: 8px 0;
     }

--- a/documentation-src/metalsmith/stylesheets/vendors/_variables.scss
+++ b/documentation-src/metalsmith/stylesheets/vendors/_variables.scss
@@ -42,6 +42,7 @@ $steel: #788795;
 $brand-primary: #1D96C7;
 $black: #0a1724;
 $white-75: rgba(white, 0.75);
+$chocolate: #7d4704;
 
 
 // Fonts
@@ -102,6 +103,7 @@ $font-code: 'inconsolata', monospace;
 // Business variables
 
 $hero-color: $saffron-mango;
+$hero-color-accent: $chocolate;
 $accent-color: $red-pink;
 $accent-color-darkish: $darkish-pink;
 $bg-pale-accent: $saffron-mango-light;


### PR DESCRIPTION
So far, we were using a white for the color of the font in the hero section of the new doc. This had a poor contrast and was very bright, which led to blurry and hard to read section. This PR proposes to use a chocolate like color.

![screenshot 2016-08-04 15 17 57](https://cloud.githubusercontent.com/assets/393765/17403179/e6e5002c-5a56-11e6-90e0-df3735a39266.png)
