### PR TITLE
feat(SearchParameters): add option `startPage`

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -259,6 +259,11 @@ function SearchParameters(newParameters) {
    */
   this.page = params.page || 0;
   /**
+   * The start page number
+   * @member {number}
+   */
+  this.startPage = params.startPage || 0;
+  /**
    * How the query should be treated by the search engine.
    * Possible values: prefixAll, prefixLast, prefixNone
    * @see https://www.algolia.com/doc/rest#param-queryType
@@ -1487,7 +1492,7 @@ SearchParameters.prototype = {
   },
 
   managedParameters: [
-    'index',
+    'index', 'startPage',
     'facets', 'disjunctiveFacets', 'facetsRefinements',
     'facetsExcludes', 'disjunctiveFacetsRefinements',
     'numericRefinements', 'tagRefinements', 'hierarchicalFacets', 'hierarchicalFacetsRefinements'
@@ -1502,6 +1507,10 @@ SearchParameters.prototype = {
         queryParams[paramName] = paramValue;
       }
     });
+
+    if (/\d/.test(this.startPage) && this.startPage !== 0) {
+      queryParams.page = queryParams.page + parseInt(this.startPage, 10);
+    }
 
     return queryParams;
   },

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -267,7 +267,11 @@ function SearchResults(state, algoliaResponse) {
    * current page
    * @member {number}
    */
-  this.page = mainSubResponse.page;
+  if (state.startPage && /\d/.test(state.startPage) && state.startPage !== 0) {
+    this.page = mainSubResponse.page - parseInt(state.startPage, 10);
+  } else {
+    this.page = mainSubResponse.page;
+  }
   /**
    * sum of the processing time of all the queries
    * @member {number}


### PR DESCRIPTION
Hello ✌️ 

I could not find a way only using `url-sync.js` like @vvo specified in the original issue to enable this option, so I've added a new `SearchParameters` option to use like this:

``` jsx
const search = instantsearch({
  appId: 'xxxx',
  apiKey: 'xxxx',
  indexName: 'xxxx',
  searchParameters: {startPage: 1},
});
```

I'm opening the PR to know if I'm going to the right direction before writing the tests and update the doc.

linked to: https://github.com/algolia/instantsearch.js/issues/1444
