### PR TITLE
feat(searchForFacetValues): implement a new method to be able to search into facet values

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -176,11 +176,11 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
 };
 
 /**
- * Search for a facet value based on an query and the name of the facetted attribute. This
+ * Search for facet values based on an query and the name of a facetted attribute. This
  * triggers a search and will retrun a promise. On top of using the query, it also sends
  * the parameters from the state so that the search is narrowed to only the possible values.
  * @param {string} query the string query for the search
- * @param {string} facet the name of the facetted attribute for which to search for a value
+ * @param {string} facet the name of the facetted attribute
  * @return {promise<FacetSearchResult>} the results of the search
  */
 AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -176,6 +176,19 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
 };
 
 /**
+ * Search for a facet value based on an query and the name of the facetted attribute. This
+ * triggers a search and will retrun a promise. On top of using the query, it also sends
+ * the parameters from the state so that the search is narrowed to only the possible values.
+ * @param {string} query the string query for the search
+ * @param {string} facet the name of the facetted attribute for which to search for a value
+ * @return {promise<FacetSearchResult>} the results of the search
+ */
+AlgoliaSearchHelper.prototype.searchForFacetValues = function(query, facet) {
+  var index = this.client.initIndex(this.state.index);
+  return index.searchFacet(requestBuilder.getSearchForFacetQuery(query, facet));
+};
+
+/**
  * Sets the text query used for the search.
  *
  * This method resets the current page to 0.

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -185,7 +185,9 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  */
 AlgoliaSearchHelper.prototype.searchForFacetValues = function(query, facet) {
   var index = this.client.initIndex(this.state.index);
-  return index.searchFacet(requestBuilder.getSearchForFacetQuery(query, facet));
+  var algoliaQuery = requestBuilder.getSearchForFacetQuery(query, facet, this.state);
+  console.log(algoliaQuery);
+  return index.searchFacet(algoliaQuery);
 };
 
 /**

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -288,6 +288,13 @@ var requestBuilder = {
 
     var parentLevel = hierarchicalRefinement.split(separator).length - 1;
     return hierarchicalFacet.attributes.slice(0, parentLevel + 1);
+  },
+
+  getSearchForFacetQuery: function(query, facetName, state) {
+    return merge(requestBuilder._getHitsSearchParams(state), {
+      facetQuery: query,
+      facetName: facetName
+    });
   }
 };
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -291,10 +291,14 @@ var requestBuilder = {
   },
 
   getSearchForFacetQuery: function(facetName, query, state) {
-    return merge(requestBuilder._getHitsSearchParams(state), {
+    var stateForSearchForFacetValues = state.isDisjunctiveFacet(facetName) ?
+      state.clearRefinements(facetName) :
+      state;
+    var queries = merge(requestBuilder._getHitsSearchParams(stateForSearchForFacetValues), {
       facetQuery: query,
       facetName: facetName
     });
+    return queries;
   }
 };
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -290,7 +290,7 @@ var requestBuilder = {
     return hierarchicalFacet.attributes.slice(0, parentLevel + 1);
   },
 
-  getSearchForFacetQuery: function(query, facetName, state) {
+  getSearchForFacetQuery: function(facetName, query, state) {
     return merge(requestBuilder._getHitsSearchParams(state), {
       facetQuery: query,
       facetName: facetName

--- a/test/integration-spec/helper.searchForFacetValues.js
+++ b/test/integration-spec/helper.searchForFacetValues.js
@@ -17,14 +17,16 @@ var indexName = '_travis-algoliasearch-helper-js-' +
   'helper_searchonce' + random(0, 5000);
 
 var dataset = [
-  {objectID: '1', facet: ['f1', 'f2'], f2: ['a']},
-  {objectID: '2', facet: ['f1', 'f3'], f2: ['b']},
-  {objectID: '3', facet: ['f2', 'f3'], f2: ['c']}
+  {objectID: '1', f: 'ba', f2: ['b']},
+  {objectID: '2', f: 'ba', f2: ['c', 'x']},
+  {objectID: '3', f: 'ba', f2: ['d']},
+  {objectID: '4', f: 'bb', f2: ['b']},
+  {objectID: '5', f: 'bb', f2: ['c', 'y']}
 ];
 
 var config = {
-  attributesToIndex: ['facet'],
-  attributesForFaceting: ['facet', 'f2']
+  searchableAttributes: ['f', 'f2'],
+  attributesForFaceting: ['f', 'f2']
 };
 
 test(
@@ -33,42 +35,41 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {
-        facets: ['facet', 'f2']
+        facets: ['f', 'f2']
       });
 
-      helper.searchForFacetValues('facet', 'a').then(function(content) {
+      helper.searchForFacetValues('f', 'a').then(function(content) {
         t.ok(content, 'should get some content');
         t.equal(content.facetHits.length, 0, 'should get 0 results');
 
-        return helper.searchForFacetValues('facet', 'f');
+        return helper.searchForFacetValues('f', 'b');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
-          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
-          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+          {value: 'ba', highlighted: '<em>b</em>a', count: 3, isRefined: false},
+          {value: 'bb', highlighted: '<em>b</em>b', count: 2, isRefined: false}
         ]);
 
-        helper.addFacetRefinement('facet', 'f2');
-        return helper.searchForFacetValues('facet', 'f');
+        helper.addFacetRefinement('f2', 'c');
+        return helper.searchForFacetValues('f', 'b');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
-          {value: 'f1', highlighted: '<em>f</em>1', count: 1},
-          {value: 'f3', highlighted: '<em>f</em>3', count: 1}
+          {value: 'ba', highlighted: '<em>b</em>a', count: 1, isRefined: false},
+          {value: 'bb', highlighted: '<em>b</em>b', count: 1, isRefined: false}
         ]);
 
-        helper.clearRefinements().addFacetRefinement('f2', 'a');
-        return helper.searchForFacetValues('facet', 'f');
+        helper.clearRefinements().addFacetRefinement('f2', 'c');
+        return helper.searchForFacetValues('f2', '');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f1', highlighted: '<em>f</em>1', count: 1},
-          {value: 'f2', highlighted: '<em>f</em>2', count: 1}
+          {value: 'c', highlighted: 'c', count: 2, isRefined: true},
+          {value: 'x', highlighted: 'x', count: 1, isRefined: false},
+          {value: 'y', highlighted: 'y', count: 1, isRefined: false}
         ]);
 
         t.end();
@@ -84,43 +85,42 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {
-        disjunctiveFacets: ['facet', 'f2']
+        disjunctiveFacets: ['f', 'f2']
       });
 
-      helper.searchForFacetValues('facet', 'a').then(function(content) {
+      helper.searchForFacetValues('f', 'a').then(function(content) {
         t.ok(content, 'should get some content');
         t.equal(content.facetHits.length, 0, 'should get 0 results');
 
-        return helper.searchForFacetValues('facet', 'f');
+        return helper.searchForFacetValues('f', 'b');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
-          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
-          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+          {value: 'ba', highlighted: '<em>b</em>a', count: 3, isRefined: false},
+          {value: 'bb', highlighted: '<em>b</em>b', count: 2, isRefined: false}
         ]);
 
-        helper.addDisjunctiveFacetRefinement('facet', 'f2');
-        return helper.searchForFacetValues('facet', 'f');
+        helper.addDisjunctiveFacetRefinement('f2', 'd');
+        return helper.searchForFacetValues('f', 'b');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
-          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
-          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+          {value: 'ba', highlighted: '<em>b</em>a', count: 1, isRefined: false}
         ]);
 
-        helper.clearRefinements().addDisjunctiveFacetRefinement('f2', 'a');
-        return helper.searchForFacetValues('facet', 'f');
+        helper.addDisjunctiveFacetRefinement('f2', 'c');
+        return helper.searchForFacetValues('f2', '');
       }).then(function(content) {
         t.ok(content, 'should get some content');
 
         t.deepEqual(content.facetHits, [
-          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
-          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
-          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+          {value: 'b', highlighted: 'b', count: 2, isRefined: false},
+          {value: 'c', highlighted: 'c', count: 1, isRefined: false},
+          {value: 'x', highlighted: 'x', count: 1, isRefined: false},
+          {value: 'd', highlighted: 'd', count: 1, isRefined: false},
+          {value: 'y', highlighted: 'y', count: 1, isRefined: false}
         ]);
 
         t.end();

--- a/test/integration-spec/helper.searchForFacetValues.js
+++ b/test/integration-spec/helper.searchForFacetValues.js
@@ -1,0 +1,132 @@
+'use strict';
+
+var utils = require('../integration-utils.js');
+var setup = utils.setupSimple;
+
+var algoliasearchHelper = utils.isCIBrowser ? window.algoliasearchHelper : require('../../');
+
+var test = require('tape');
+var bind = require('lodash/bind');
+var random = require('lodash/random');
+
+if (!utils.shouldRun) {
+  test = test.skip;
+}
+var indexName = '_travis-algoliasearch-helper-js-' +
+  (process.env.TRAVIS_BUILD_NUMBER || 'DEV') +
+  'helper_searchonce' + random(0, 5000);
+
+var dataset = [
+  {objectID: '1', facet: ['f1', 'f2'], f2: ['a']},
+  {objectID: '2', facet: ['f1', 'f3'], f2: ['b']},
+  {objectID: '3', facet: ['f2', 'f3'], f2: ['c']}
+];
+
+var config = {
+  attributesToIndex: ['facet'],
+  attributesForFaceting: ['facet', 'f2']
+};
+
+test(
+  '[INT][SEARCHFORCETVALUES] Should be able to search for facet values - conjunctive',
+  function(t) {
+    setup(indexName, dataset, config).
+    then(function(client) {
+      var helper = algoliasearchHelper(client, indexName, {
+        facets: ['facet', 'f2']
+      });
+
+      helper.searchForFacetValues('facet', 'a').then(function(content) {
+        t.ok(content, 'should get some content');
+        t.equal(content.facetHits.length, 0, 'should get 0 results');
+
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
+          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
+          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+        ]);
+
+        helper.addFacetRefinement('facet', 'f2');
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
+          {value: 'f1', highlighted: '<em>f</em>1', count: 1},
+          {value: 'f3', highlighted: '<em>f</em>3', count: 1}
+        ]);
+
+        helper.clearRefinements().addFacetRefinement('f2', 'a');
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f1', highlighted: '<em>f</em>1', count: 1},
+          {value: 'f2', highlighted: '<em>f</em>2', count: 1}
+        ]);
+
+        t.end();
+      }).catch(function(err) {
+        setTimeout(function() {throw err;}, 1);
+      });
+    }).then(null, bind(t.error, t));
+  });
+
+test(
+  '[INT][SEARCHFORCETVALUES] Should be able to search for facet values - disjunctive',
+  function(t) {
+    setup(indexName, dataset, config).
+    then(function(client) {
+      var helper = algoliasearchHelper(client, indexName, {
+        disjunctiveFacets: ['facet', 'f2']
+      });
+
+      helper.searchForFacetValues('facet', 'a').then(function(content) {
+        t.ok(content, 'should get some content');
+        t.equal(content.facetHits.length, 0, 'should get 0 results');
+
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
+          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
+          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+        ]);
+
+        helper.addDisjunctiveFacetRefinement('facet', 'f2');
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
+          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
+          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+        ]);
+
+        helper.clearRefinements().addDisjunctiveFacetRefinement('f2', 'a');
+        return helper.searchForFacetValues('facet', 'f');
+      }).then(function(content) {
+        t.ok(content, 'should get some content');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'f1', highlighted: '<em>f</em>1', count: 2},
+          {value: 'f2', highlighted: '<em>f</em>2', count: 2},
+          {value: 'f3', highlighted: '<em>f</em>3', count: 2}
+        ]);
+
+        t.end();
+      }).catch(function(err) {
+        setTimeout(function() {throw err;}, 1);
+      });
+    }).then(null, bind(t.error, t));
+  });
+

--- a/test/integration-utils.js
+++ b/test/integration-utils.js
@@ -22,6 +22,18 @@ function setup(indexName, fn) {
     });
 }
 
+function withDatasetAndConfig(indexName, dataset, config) {
+  return setup(indexName, function(client, index) {
+    return index.addObjects(dataset).then(function() {
+      return index.setSettings(config);
+    }).then(function(content) {
+      return index.waitTask(content.taskID);
+    }).then(function() {
+      return client;
+    });
+  });
+}
+
 // some environements are not able to do indexing requests using
 // PUT, like IE8 and IE9
 var shouldRun;
@@ -37,5 +49,6 @@ if (!process.browser) {
 module.exports = {
   isCIBrowser: process.browser && process.env.TRAVIS_BUILD_NUMBER,
   setup: setup,
+  setupSimple: withDatasetAndConfig,
   shouldRun: shouldRun
 };


### PR DESCRIPTION
# Search for facet values

## Description of the feature

This new method on the helper lets a user search into facet values. The function takes the attribute and the query as parameters, and it returns a promise of the content of the search. Because this method is implemented on the helper, it takes also the current context / state: all the facets and parameters will be sent with the query. Also the returned value is altered to add an `isRefined` attribute so that we know if the value is already selected.

_A note on facets_
If the searched facet is conjunctive, the filters that are already set on it will be sent - whereas if the facet is disjunctive, the filters on this facet won't be sent.

## Code example

Given that we the following dataset:

```js
[
  {objectID: '1', f: 'ba', f2: ['b']},
  {objectID: '2', f: 'ba', f2: ['c', 'x']},
  {objectID: '3', f: 'ba', f2: ['d']},
  {objectID: '4', f: 'bb', f2: ['b']},
  {objectID: '5', f: 'bb', f2: ['c', 'y']}
]
```

With the following configuration:
  - searchableAttributes: ['f', 'f2'],
  - attributesForFaceting: ['f', 'f2']

	
```js
var helper = AlgoliasearchHelper(client, 'index', {
  facets: ['f', 'f2']
});

helper.addFacetRefinement('f2', 'c');

helper.searchForFacetValues('f2', '').then(function(content) {
  console.log(content);
  /*
{
  facetHits: [
    {value: 'c', highlighted: 'c', count: 2, isRefined: true},
    {value: 'x', highlighted: 'x', count: 1, isRefined: false},
    {value: 'y', highlighted: 'y', count: 1, isRefined: false}
  ],
  processingTimeMS: 1
}
  */
});
```

⚠️ There is a test failt because of an issue when there is no filter at all. @Nagriar is on it :)