### PR TITLE
fix(agent): Add a test if addAlgoliaAgent exists

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -83,7 +83,8 @@ var version = require('./version');
  * just an object containing the properties you need from it.
  */
 function AlgoliaSearchHelper(client, index, options) {
-  client.addAlgoliaAgent('JS Helper ' + version);
+  if (!client.addAlgoliaAgent) console.log('Please upgrade to the newest version of the JS Client.'); // eslint-disable-line
+  else client.addAlgoliaAgent('JS Helper ' + version);
 
   this.client = client;
   var opts = options || {};

--- a/test/spec/algoliasearch.helper/instanciate.js
+++ b/test/spec/algoliasearch.helper/instanciate.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var test = require('tape');
+var algoliasearchHelper = require('../../../index.js');
+
+test('It should instanciate even with an old client that does not support addAlgoliaAgent', function(t) {
+  var helper = algoliasearchHelper({}, null, {
+    facets: ['facetConj'],
+    disjunctiveFacets: ['facet']
+  });
+
+  t.ok(helper);
+  t.end();
+});


### PR DESCRIPTION
This was causing problems with users who are not upgrading their JS
Helper, but not their client.