### PR TITLE
feat(search-response): Exposed raw response

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -224,6 +224,8 @@ function findMatchingHierarchicalFacetFromAttributeName(hierarchicalFacets, hier
 function SearchResults(state, results) {
   var mainSubResponse = results[0];
 
+  this._rawResults = results;
+
   /**
    * query used to generate the results
    * @member {string}

--- a/test/spec/search.testdata.js
+++ b/test/spec/search.testdata.js
@@ -199,6 +199,7 @@ function getData() {
   });
 
   var responseHelper = {
+    '_rawResults': response.results.slice(0),
     '_state': searchParams,
     'query': '',
     'hits': [


### PR DESCRIPTION
This PR aims to expose the content `mainSubResponse` inside `SearchResults` in order to have the raw Algolia JSON response available in our JS application.

Here's some more context about it: in our dashboard we would like to display a raw Algolia JSON response like the following:

![image](https://cloud.githubusercontent.com/assets/357937/23372906/dcb98f0e-fd1d-11e6-851c-2f4d496df4f0.png)

Currently this is not easily achievable by solely using the Helper, as the original, pre-parsed request is not available.

I'm not sure this is the best way to go or if it would be better to optionally expose the field. Any thoughts on this @bobylito?

