### PR TITLE
feat(maxFacetHits): implement maxFacetHits for SFFV

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -211,13 +211,14 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * See the description of [FacetSearchResult](reference.html#FacetSearchResult)
  * @param {string} query the string query for the search
  * @param {string} facet the name of the facetted attribute
+ * @param {number} maxFacetHits the maximum number values returned. Should be > 0 and <= 100
  * @return {promise<FacetSearchResult>} the results of the search
  */
-AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query) {
+AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits) {
   var state = this.state;
   var index = this.client.initIndex(this.state.index);
   var isDisjunctive = state.isDisjunctiveFacet(facet);
-  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, this.state);
+  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, this.state);
   return index.searchForFacetValues(algoliaQuery).then(function addIsRefined(content) {
     content.facetHits = forEach(content.facetHits, function(f) {
       f.isRefined = isDisjunctive ?

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -290,14 +290,18 @@ var requestBuilder = {
     return hierarchicalFacet.attributes.slice(0, parentLevel + 1);
   },
 
-  getSearchForFacetQuery: function(facetName, query, state) {
+  getSearchForFacetQuery: function(facetName, query, maxFacetHits, state) {
     var stateForSearchForFacetValues = state.isDisjunctiveFacet(facetName) ?
       state.clearRefinements(facetName) :
       state;
-    var queries = merge(requestBuilder._getHitsSearchParams(stateForSearchForFacetValues), {
+    var searchForFacetSearchParameters = {
       facetQuery: query,
       facetName: facetName
-    });
+    };
+    if (typeof maxFacetHits === 'number') {
+      searchForFacetSearchParameters.maxFacetHits = maxFacetHits;
+    }
+    var queries = merge(requestBuilder._getHitsSearchParams(stateForSearchForFacetValues), searchForFacetSearchParameters);
     return queries;
   }
 };

--- a/test/integration-spec/helper.searchForFacetValues.js
+++ b/test/integration-spec/helper.searchForFacetValues.js
@@ -129,3 +129,27 @@ test(
     }).then(null, bind(t.error, t));
   });
 
+
+test.only(
+  '[INT][SEARCHFORCETVALUES] Should be able to limit the number of returned items',
+  function(t) {
+    setup(indexName, dataset, config).
+    then(function(client) {
+      var helper = algoliasearchHelper(client, indexName, {
+        facets: ['f', 'f2']
+      });
+
+      helper.searchForFacetValues('f', 'b', 1).then(function(content) {
+        t.ok(content.facetHits.length, 'should get one value');
+
+        t.deepEqual(content.facetHits, [
+          {value: 'ba', highlighted: '<em>b</em>a', count: 3, isRefined: false}
+        ]);
+
+        t.end();
+      }).catch(function(err) {
+        setTimeout(function() {throw err;}, 1);
+      });
+    }).then(null, bind(t.error, t));
+  });
+


### PR DESCRIPTION
Adds the support for the `maxFacetHits` parameter that limits the number
of items returned by the search for facet value API.

Fixes #480 

cc @seafoox 