### PR TITLE
fix(pending-search): dispatch error event before searchQueueEmpty

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1227,23 +1227,20 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
 
   if (err) {
     this.emit('error', err);
-    if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
-    return;
+  } else {
+    var results = content.results;
+    forEach(states, function(s) {
+      var state = s.state;
+      var queriesCount = s.queriesCount;
+      var helper = s.helper;
+      var specificResults = results.splice(0, queriesCount);
+
+      var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
+      helper.emit('result', formattedResponse, state);
+    });
   }
-
+  
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
-
-  var results = content.results;
-  forEach(states, function(s) {
-    var state = s.state;
-    var queriesCount = s.queriesCount;
-    var helper = s.helper;
-
-    var specificResults = results.splice(0, queriesCount);
-
-    var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
-    helper.emit('result', formattedResponse, state);
-  });
 };
 
 AlgoliaSearchHelper.prototype.containsRefinement = function(query, facetFilters, numericFilters, tagFilters) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1223,14 +1223,15 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
   }
 
   this._currentNbQueries -= (queryId - this._lastQueryIdReceived);
-  if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
-
   this._lastQueryIdReceived = queryId;
 
   if (err) {
     this.emit('error', err);
+    if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
     return;
   }
+
+  if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results;
   forEach(states, function(s) {


### PR DESCRIPTION
This is a fix for #502 .
Let me know if you need more context.

Not sure how to test it. Any help would be more than welcome.

Here is what I want to achieve:

```js
new Promise(resolve => {
  if (this._helper.hasPendingRequests() === false) {
    return resolve();
  }

  // Todo: we need to de-register the one that is not being triggered.
  this._helper.once("searchQueueEmpty", () => {
    resolve();
  });
  this._helper.once("error", error => {
    throw new Error(error.message);
    // Todo: implement rejection once this has a solution
    // https://github.com/algolia/algoliasearch-helper-js/issues/502
    // reject(error);
  });
});
```