### PR TITLE
misc(event-order): single event statement

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1227,23 +1227,20 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
 
   if (err) {
     this.emit('error', err);
-    if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
-    return;
+  } else {
+    var results = content.results;
+    forEach(states, function(s) {
+      var state = s.state;
+      var queriesCount = s.queriesCount;
+      var helper = s.helper;
+      var specificResults = results.splice(0, queriesCount);
+
+      var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
+      helper.emit('result', formattedResponse, state);
+    });
   }
-
+  
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
-
-  var results = content.results;
-  forEach(states, function(s) {
-    var state = s.state;
-    var queriesCount = s.queriesCount;
-    var helper = s.helper;
-
-    var specificResults = results.splice(0, queriesCount);
-
-    var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
-    helper.emit('result', formattedResponse, state);
-  });
 };
 
 AlgoliaSearchHelper.prototype.containsRefinement = function(query, facetFilters, numericFilters, tagFilters) {


### PR DESCRIPTION
Move code around to make sure that we both have a proper event order with `searchQueueEmpty` after `result` or `error`.