### PR TITLE
docs(jsdoc): fix spelling

### DIFF
--- a/documentation-src/metalsmith/content/gettingstarted.md
+++ b/documentation-src/metalsmith/content/gettingstarted.md
@@ -278,8 +278,8 @@ values that are meaningful for the current other parameters. Try typing
 This kind of facets are called *conjunctive facets* but they are not the only
 kind of filtering that you can apply with the helper. You can also do:
 
- - disjunctive facetting (for making multiple choices filters)
- - hierarchical facetting (for making hierarchical navigations)
+ - disjunctive faceting (for making multiple choices filters)
+ - hierarchical faceting (for making hierarchical navigations)
  - numerical filtering
  - tag filtering
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
       <h1><a href="http://www.algolia.com/">AlgoliaSearch</a>Helper</h1>
       <h2>Getting started with the examples</h2>
       <ul>
-        <li><a href="examples/instantsearch+helper.html">Facetting with the helper</a></li>
-        <li><a href="examples/instantsearch+helper+excludes.html">Negative facetting with the helper</a></li>
+        <li><a href="examples/instantsearch+helper.html">Faceting with the helper</a></li>
+        <li><a href="examples/instantsearch+helper+excludes.html">Negative faceting with the helper</a></li>
       </ul>
       <h2>Play with the examples locally</h2>
       <p>To get you started with the helper examples on your machine, follow these steps: </p>

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -28,7 +28,7 @@ var lib = {
    * @param {RefinementList} refinementList the initial list
    * @param {string} attribute the attribute to refine
    * @param {string} value the value of the refinement, if the value is not a string it will be converted
-   * @return {RefinementList} a new and updated prefinement list
+   * @return {RefinementList} a new and updated refinement list
    */
   addRefinement: function addRefinement(refinementList, attribute, value) {
     if (lib.isRefined(refinementList, attribute, value)) {
@@ -85,13 +85,13 @@ var lib = {
   },
   /**
    * Clear all or parts of a RefinementList. Depending on the arguments, three
-   * behaviors can happen:
+   * kinds of behavior can happen:
    *  - if no attribute is provided: clears the whole list
    *  - if an attribute is provided as a string: clears the list for the specific attribute
    *  - if an attribute is provided as a function: discards the elements for which the function returns true
    * @param {RefinementList} refinementList the initial list
    * @param {string} [attribute] the attribute or function to discard
-   * @param {string} [refinementType] optionnal parameter to give more context to the attribute function
+   * @param {string} [refinementType] optional parameter to give more context to the attribute function
    * @return {RefinementList} a new and updated refinement list
    */
   clearRefinement: function clearRefinement(refinementList, attribute, refinementType) {

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -141,7 +141,7 @@ function SearchParameters(newParameters) {
    * filters selected for the associated facet name.
    *
    * When querying algolia, the values stored in this attribute will
-   * be translated into the `facetFiters` attribute.
+   * be translated into the `facetFilters` attribute.
    * @member {Object.<string, SearchParameters.FacetList>}
    */
   this.facetsRefinements = params.facetsRefinements || {};
@@ -154,7 +154,7 @@ function SearchParameters(newParameters) {
    * filters excluded for the associated facet name.
    *
    * When querying algolia, the values stored in this attribute will
-   * be translated into the `facetFiters` attribute.
+   * be translated into the `facetFilters` attribute.
    * @member {Object.<string, SearchParameters.FacetList>}
    */
   this.facetsExcludes = params.facetsExcludes || {};
@@ -167,7 +167,7 @@ function SearchParameters(newParameters) {
    * filters selected for the associated facet name.
    *
    * When querying algolia, the values stored in this attribute will
-   * be translated into the `facetFiters` attribute.
+   * be translated into the `facetFilters` attribute.
    * @member {Object.<string, SearchParameters.FacetList>}
    */
   this.disjunctiveFacetsRefinements = params.disjunctiveFacetsRefinements || {};
@@ -199,10 +199,10 @@ function SearchParameters(newParameters) {
    * The key is the name of the facet, and the `FacetList` contains all
    * filters selected for the associated facet name. The FacetList values
    * are structured as a string that contain the values for each level
-   * seperated by the configured separator.
+   * separated by the configured separator.
    *
    * When querying algolia, the values stored in this attribute will
-   * be translated into the `facetFiters` attribute.
+   * be translated into the `facetFilters` attribute.
    * @member {Object.<string, SearchParameters.FacetList>}
    */
   this.hierarchicalFacetsRefinements = params.hierarchicalFacetsRefinements || {};
@@ -247,7 +247,7 @@ function SearchParameters(newParameters) {
    */
   this.hitsPerPage = params.hitsPerPage;
   /**
-   * Number of values for each facetted attribute
+   * Number of values for each faceted attribute
    * @member {number}
    * @see https://www.algolia.com/doc/rest#param-maxValuesPerFacet
    */
@@ -612,7 +612,7 @@ SearchParameters.prototype = {
   /**
    * Remove all refinements (disjunctive + conjunctive + excludes + numeric filters)
    * @method
-   * @param {undefined|string|SearchParameters.clearCallback} [attribute] optionnal string or function
+   * @param {undefined|string|SearchParameters.clearCallback} [attribute] optional string or function
    * - If not given, means to clear all the filters.
    * - If `string`, means to clear all refinements for the `attribute` named filter.
    * - If `function`, means to clear all the refinements that return truthy values.
@@ -682,9 +682,9 @@ SearchParameters.prototype = {
   },
   /**
    * Facets setter
-   * The facets are the simple facets, used for conjunctive (and) facetting.
+   * The facets are the simple facets, used for conjunctive (and) faceting.
    * @method
-   * @param {string[]} facets all the attributes of the algolia records used for conjunctive facetting
+   * @param {string[]} facets all the attributes of the algolia records used for conjunctive faceting
    * @return {SearchParameters}
    */
   setFacets: function setFacets(facets) {
@@ -696,7 +696,7 @@ SearchParameters.prototype = {
    * Disjunctive facets setter
    * Change the list of disjunctive (or) facets the helper chan handle.
    * @method
-   * @param {string[]} facets all the attributes of the algolia records used for disjunctive facetting
+   * @param {string[]} facets all the attributes of the algolia records used for disjunctive faceting
    * @return {SearchParameters}
    */
   setDisjunctiveFacets: function setDisjunctiveFacets(facets) {
@@ -773,7 +773,7 @@ SearchParameters.prototype = {
   },
   /**
    * Get the list of conjunctive refinements for a single facet
-   * @param {string} facetName name of the attribute used for facetting
+   * @param {string} facetName name of the attribute used for faceting
    * @return {string[]} list of refinements
    */
   getConjunctiveRefinements: function(facetName) {
@@ -784,7 +784,7 @@ SearchParameters.prototype = {
   },
   /**
    * Get the list of disjunctive refinements for a single facet
-   * @param {string} facetName name of the attribute used for facetting
+   * @param {string} facetName name of the attribute used for faceting
    * @return {string[]} list of refinements
    */
   getDisjunctiveRefinements: function(facetName) {
@@ -797,7 +797,7 @@ SearchParameters.prototype = {
   },
   /**
    * Get the list of hierarchical refinements for a single facet
-   * @param {string} facetName name of the attribute used for facetting
+   * @param {string} facetName name of the attribute used for faceting
    * @return {string[]} list of refinements
    */
   getHierarchicalRefinement: function(facetName) {
@@ -807,7 +807,7 @@ SearchParameters.prototype = {
   },
   /**
    * Get the list of exclude refinements for a single facet
-   * @param {string} facetName name of the attribute used for facetting
+   * @param {string} facetName name of the attribute used for faceting
    * @return {string[]} list of refinements
    */
   getExcludeRefinements: function(facetName) {
@@ -852,7 +852,7 @@ SearchParameters.prototype = {
   },
   /**
    * Get the list of numeric refinements for a single facet
-   * @param {string} facetName name of the attribute used for facetting
+   * @param {string} facetName name of the attribute used for faceting
    * @return {SearchParameters.OperatorList[]} list of refinements
    */
   getNumericRefinements: function(facetName) {
@@ -871,7 +871,7 @@ SearchParameters.prototype = {
    * Clear numeric filters.
    * @method
    * @private
-   * @param {string|SearchParameters.clearCallback} [attribute] optionnal string or function
+   * @param {string|SearchParameters.clearCallback} [attribute] optional string or function
    * - If not given, means to clear all the filters.
    * - If `string`, means to clear all refinements for the `attribute` named filter.
    * - If `function`, means to clear all the refinements that return truthy values.
@@ -954,7 +954,7 @@ SearchParameters.prototype = {
   /**
    * Add a refinement on a "normal" facet
    * @method
-   * @param {string} facet attribute to apply the facetting on
+   * @param {string} facet attribute to apply the faceting on
    * @param {string} value value of the attribute (will be converted to string)
    * @return {SearchParameters}
    */
@@ -988,7 +988,7 @@ SearchParameters.prototype = {
   /**
    * Adds a refinement on a disjunctive facet.
    * @method
-   * @param {string} facet attribute to apply the facetting on
+   * @param {string} facet attribute to apply the faceting on
    * @param {string} value value of the attribute (will be converted to string)
    * @return {SearchParameters}
    */
@@ -1076,9 +1076,9 @@ SearchParameters.prototype = {
   /**
    * Remove a refinement set on facet. If a value is provided, it will clear the
    * refinement for the given value, otherwise it will clear all the refinement
-   * values for the facetted attribute.
+   * values for the faceted attribute.
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {string} [value] value used to filter
    * @return {SearchParameters}
    */
@@ -1095,7 +1095,7 @@ SearchParameters.prototype = {
   /**
    * Remove a negative refinement on a facet
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {string} value value used to filter
    * @return {SearchParameters}
    */
@@ -1112,7 +1112,7 @@ SearchParameters.prototype = {
   /**
    * Remove a refinement on a disjunctive facet
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {string} value value used to filter
    * @return {SearchParameters}
    */
@@ -1178,7 +1178,7 @@ SearchParameters.prototype = {
   /**
    * Switch the refinement applied over a facet/value
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {SearchParameters}
    */
@@ -1194,7 +1194,7 @@ SearchParameters.prototype = {
   /**
    * Switch the refinement applied over a facet/value
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {SearchParameters}
    */
@@ -1210,7 +1210,7 @@ SearchParameters.prototype = {
   /**
    * Switch the refinement applied over a facet/value
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {SearchParameters}
    */
@@ -1228,7 +1228,7 @@ SearchParameters.prototype = {
   /**
    * Switch the refinement applied over a facet/value
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {SearchParameters}
    */
@@ -1348,8 +1348,8 @@ SearchParameters.prototype = {
    * Returns true if the facet is refined, either for a specific value or in
    * general.
    * @method
-   * @param {string} facet name of the attribute for used for facetting
-   * @param {string} value, optionnal value. If passed will test that this value
+   * @param {string} facet name of the attribute for used for faceting
+   * @param {string} value, optional value. If passed will test that this value
    * is filtering the given facet.
    * @return {boolean} returns true if refined
    */
@@ -1364,8 +1364,8 @@ SearchParameters.prototype = {
    * excluded.
    *
    * @method
-   * @param {string} facet name of the attribute for used for facetting
-   * @param {string} [value] optionnal value. If passed will test that this value
+   * @param {string} facet name of the attribute for used for faceting
+   * @param {string} [value] optional value. If passed will test that this value
    * is filtering the given facet.
    * @return {boolean} returns true if refined
    */
@@ -1379,8 +1379,8 @@ SearchParameters.prototype = {
    * Returns true if the facet contains a refinement, or if a value passed is a
    * refinement for the facet.
    * @method
-   * @param {string} facet name of the attribute for used for facetting
-   * @param {string} value optionnal, will test if the value is used for refinement
+   * @param {string} facet name of the attribute for used for faceting
+   * @param {string} value optional, will test if the value is used for refinement
    * if there is one, otherwise will test if the facet contains any refinement
    * @return {boolean}
    */
@@ -1395,8 +1395,8 @@ SearchParameters.prototype = {
    * Returns true if the facet contains a refinement, or if a value passed is a
    * refinement for the facet.
    * @method
-   * @param {string} facet name of the attribute for used for facetting
-   * @param {string} value optionnal, will test if the value is used for refinement
+   * @param {string} facet name of the attribute for used for faceting
+   * @param {string} value optional, will test if the value is used for refinement
    * if there is one, otherwise will test if the facet contains any refinement
    * @return {boolean}
    */
@@ -1455,7 +1455,7 @@ SearchParameters.prototype = {
   /**
    * Returns the list of all disjunctive facets refined
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {string[]}
    */
@@ -1473,7 +1473,7 @@ SearchParameters.prototype = {
   /**
    * Returns the list of all disjunctive facets refined
    * @method
-   * @param {string} facet name of the attribute used for facetting
+   * @param {string} facet name of the attribute used for faceting
    * @param {value} value value used for filtering
    * @return {string[]}
    */

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -29,7 +29,7 @@ var generateHierarchicalTree = require('./generate-hierarchical-tree');
  * @typedef SearchResults.Facet
  * @type {object}
  * @property {string} name name of the attribute in the record
- * @property {object} data the facetting data: value, number of entries
+ * @property {object} data the faceting data: value, number of entries
  * @property {object} stats undefined unless facet_stats is retrieved from algolia
  */
 
@@ -38,7 +38,7 @@ var generateHierarchicalTree = require('./generate-hierarchical-tree');
  * @type {object}
  * @property {string} name name of the current value given the hierarchical level, trimmed.
  * If root node, you get the facet name
- * @property {number} count number of objets matching this hierarchical value
+ * @property {number} count number of objects matching this hierarchical value
  * @property {string} path the current hierarchical value full path
  * @property {boolean} isRefined `true` if the current value was refined, `false` otherwise
  * @property {HierarchicalFacet[]} data sub values for the current level
@@ -60,7 +60,7 @@ var generateHierarchicalTree = require('./generate-hierarchical-tree');
  * `numeric`, `facet`, `exclude`, `disjunctive`, `hierarchical`
  * @property {string} attributeName name of the attribute used for filtering
  * @property {string} name the value of the filter
- * @property {number} numericValue the value as a number. Only for numeric fitlers.
+ * @property {number} numericValue the value as a number. Only for numeric filters.
  * @property {string} operator the operator used. Only for numeric filters.
  * @property {number} count the number of computed hits for this filter. Only on facets.
  * @property {boolean} exhaustive if the count is exhaustive
@@ -500,7 +500,7 @@ function SearchResults(state, results) {
 /**
  * Get a facet object with its name
  * @deprecated
- * @param {string} name name of the attribute facetted
+ * @param {string} name name of the faceted attribute
  * @return {SearchResults.Facet} the facet object
  */
 SearchResults.prototype.getFacetByName = function(name) {
@@ -515,7 +515,7 @@ SearchResults.prototype.getFacetByName = function(name) {
  * Get the facet values of a specified attribute from a SearchResults object.
  * @private
  * @param {SearchResults} results the search results to search in
- * @param {string} attribute name of the facetted attribute to search for
+ * @param {string} attribute name of the faceted attribute to search for
  * @return {array|object} facet values. For the hierarchical facets it is an object.
  */
 function extractNormalizedFacetValues(results, attribute) {
@@ -643,7 +643,7 @@ SearchResults.prototype.getFacetValues = function(attribute, opts) {
 /**
  * Returns the facet stats if attribute is defined and the facet contains some.
  * Otherwise returns undefined.
- * @param {string} attribute name of the facetted attribute
+ * @param {string} attribute name of the faceted attribute
  * @return {object} The stats of the facet
  */
 SearchResults.prototype.getFacetStats = function(attribute) {

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -114,7 +114,7 @@ util.inherits(AlgoliaSearchHelper, events.EventEmitter);
 /**
  * Start the search with the parameters set in the state. When the
  * method is called, it triggers a `search` event. The results will
- * be available through the `result` event. If an error occcurs, an
+ * be available through the `result` event. If an error occurs, an
  * `error` will be fired instead.
  * @return {AlgoliaSearchHelper}
  * @fires search
@@ -155,7 +155,7 @@ AlgoliaSearchHelper.prototype.getQuery = function() {
  * // This example uses the callback API
  * var state = helper.searchOnce({hitsPerPage: 1},
  *   function(error, content, state) {
- *     // if an error occured it will be passed in error, otherwise its value is null
+ *     // if an error occurred it will be passed in error, otherwise its value is null
  *     // content contains the results formatted as a SearchResults
  *     // state is the instance of SearchParameters used for this search
  *   });
@@ -214,7 +214,7 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * @type {object}
  * @property {string} value the facet value
  * @property {string} highlighted the facet value highlighted with the query string
- * @property {number} count number of occurence of this facet value
+ * @property {number} count number of occurrence of this facet value
  * @property {boolean} isRefined true if the value is already refined
  */
 
@@ -223,18 +223,18 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * [`searchForFacetValues()`](reference.html#AlgoliaSearchHelper#searchForFacetValues)
  * promise.
  * @typedef FacetSearchResult
- * @type {objet}
+ * @type {object}
  * @property {FacetSearchHit} facetHits the results for this search for facet values
- * @property {number} processingTimeMS time taken by the query insde the engine
+ * @property {number} processingTimeMS time taken by the query inside the engine
  */
 
 /**
- * Search for facet values based on an query and the name of a facetted attribute. This
+ * Search for facet values based on an query and the name of a faceted attribute. This
  * triggers a search and will return a promise. On top of using the query, it also sends
  * the parameters from the state so that the search is narrowed down to only the possible values.
  *
  * See the description of [FacetSearchResult](reference.html#FacetSearchResult)
- * @param {string} facet the name of the facetted attribute
+ * @param {string} facet the name of the faceted attribute
  * @param {string} query the string query for the search
  * @param {number} maxFacetHits the maximum number values returned. Should be > 0 and <= 100
  * @return {promise<FacetSearchResult>} the results of the search
@@ -324,7 +324,7 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
 };
 
 /**
- * Adds a disjunctive filter to a facetted attribute with the `value` provided. If the
+ * Adds a disjunctive filter to a faceted attribute with the `value` provided. If the
  * filter is already set, it doesn't change the filters.
  *
  * This method resets the current page to 0.
@@ -385,7 +385,7 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operato
 };
 
 /**
- * Adds a filter to a facetted attribute with the `value` provided. If the
+ * Adds a filter to a faceted attribute with the `value` provided. If the
  * filter is already set, it doesn't change the filters.
  *
  * This method resets the current page to 0.
@@ -410,7 +410,7 @@ AlgoliaSearchHelper.prototype.addRefine = function() {
 
 
 /**
- * Adds a an exclusion filter to a facetted attribute with the `value` provided. If the
+ * Adds a an exclusion filter to a faceted attribute with the `value` provided. If the
  * filter is already set, it doesn't change the filters.
  *
  * This method resets the current page to 0.
@@ -453,7 +453,7 @@ AlgoliaSearchHelper.prototype.addTag = function(tag) {
  * Removes an numeric filter to an attribute with the `operator` and `value` provided. If the
  * filter is not set, it doesn't change the filters.
  *
- * Some parameters are optionnals, triggering different behaviors:
+ * Some parameters are optional, triggering different behavior:
  *  - if the value is not provided, then all the numeric value will be removed for the
  *  specified attribute/operator couple.
  *  - if the operator is not provided either, then all the numeric filter on this attribute
@@ -474,7 +474,7 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, oper
 };
 
 /**
- * Removes a disjunctive filter to a facetted attribute with the `value` provided. If the
+ * Removes a disjunctive filter to a faceted attribute with the `value` provided. If the
  * filter is not set, it doesn't change the filters.
  *
  * If the value is omitted, then this method will remove all the filters for the
@@ -516,7 +516,7 @@ AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet
 };
 
 /**
- * Removes a filter to a facetted attribute with the `value` provided. If the
+ * Removes a filter to a faceted attribute with the `value` provided. If the
  * filter is not set, it doesn't change the filters.
  *
  * If the value is omitted, then this method will remove all the filters for the
@@ -543,7 +543,7 @@ AlgoliaSearchHelper.prototype.removeRefine = function() {
 };
 
 /**
- * Removes an exclusion filter to a facetted attribute with the `value` provided. If the
+ * Removes an exclusion filter to a faceted attribute with the `value` provided. If the
  * filter is not set, it doesn't change the filters.
  *
  * If the value is omitted, then this method will remove all the filters for the
@@ -586,7 +586,7 @@ AlgoliaSearchHelper.prototype.removeTag = function(tag) {
 };
 
 /**
- * Adds or removes an exclusion filter to a facetted attribute with the `value` provided. If
+ * Adds or removes an exclusion filter to a faceted attribute with the `value` provided. If
  * the value is set then it removes it, otherwise it adds the filter.
  *
  * This method resets the current page to 0.
@@ -610,7 +610,7 @@ AlgoliaSearchHelper.prototype.toggleExclude = function() {
 };
 
 /**
- * Adds or removes a filter to a facetted attribute with the `value` provided. If
+ * Adds or removes a filter to a faceted attribute with the `value` provided. If
  * the value is set then it removes it, otherwise it adds the filter.
  *
  * This method can be used for conjunctive, disjunctive and hierarchical filters.
@@ -629,7 +629,7 @@ AlgoliaSearchHelper.prototype.toggleRefinement = function(facet, value) {
 };
 
 /**
- * Adds or removes a filter to a facetted attribute with the `value` provided. If
+ * Adds or removes a filter to a faceted attribute with the `value` provided. If
  * the value is set then it removes it, otherwise it adds the filter.
  *
  * This method can be used for conjunctive, disjunctive and hierarchical filters.
@@ -786,7 +786,7 @@ AlgoliaSearchHelper.prototype.setState = function(newState) {
 
 /**
  * Get the current search state stored in the helper. This object is immutable.
- * @param {string[]} [filters] optionnal filters to retrieve only a subset of the state
+ * @param {string[]} [filters] optional filters to retrieve only a subset of the state
  * @return {SearchParameters|object} if filters is specified a plain object is
  * returned containing only the requested fields, otherwise return the unfiltered
  * state
@@ -858,7 +858,7 @@ AlgoliaSearchHelper.getForeignConfigurationInQueryString = url.getUnrecognizedPa
  * string.
  * @deprecated
  * @param {string} queryString the query string containing the informations to url the state
- * @param {object} options optionnal parameters :
+ * @param {object} options optional parameters :
  *  - prefix : prefix used for the algolia parameters
  *  - triggerChange : if set to true the state update will trigger a change event
  */
@@ -951,11 +951,11 @@ AlgoliaSearchHelper.prototype.hasRefinements = function(attribute) {
 };
 
 /**
- * Check if a value is excluded for a specific facetted attribute. If the value
+ * Check if a value is excluded for a specific faceted attribute. If the value
  * is omitted then the function checks if there is any excluding refinements.
  *
- * @param  {string}  facet name of the attribute for used for facetting
- * @param  {string}  [value] optionnal value. If passed will test that this value
+ * @param  {string}  facet name of the attribute for used for faceting
+ * @param  {string}  [value] optional value. If passed will test that this value
    * is filtering the given facet.
  * @return {boolean} true if refined
  * @example
@@ -1058,7 +1058,7 @@ AlgoliaSearchHelper.prototype.getQueryParameter = function(parameterName) {
  *
  * See also SearchResults#getRefinements
  *
- * @param {string} facetName attribute name used for facetting
+ * @param {string} facetName attribute name used for faceting
  * @return {Array.<FacetRefinement|NumericRefinement>} All Refinement are objects that contain a value, and
  * a type. Numeric also contains an operator.
  * @example
@@ -1204,7 +1204,7 @@ AlgoliaSearchHelper.prototype._search = function() {
 
 /**
  * Transform the responses as sent by the server and transform them into a user
- * usable objet that merge the results of all the batch requests. It will dispatch
+ * usable object that merge the results of all the batch requests. It will dispatch
  * over the different helper + derived helpers (when there are some).
  * @private
  * @param {array.<{SearchParameters, AlgoliaQueries, AlgoliaSearchHelper}>}
@@ -1350,7 +1350,7 @@ AlgoliaSearchHelper.prototype.hasPendingRequests = function() {
  * @type {object}
  * @property {number[]} value the numbers that are used for filtering this attribute with
  * the operator specified.
- * @property {string} operator the facetting data: value, number of entries
+ * @property {string} operator the faceting data: value, number of entries
  * @property {string} type will be 'numeric'
  */
 


### PR DESCRIPTION
I have spelling detection enabled in my editor, and it complained that there were a few typos, so I fixed them.

There's one typo I can't really fix or I'm not sure if it's worth it since it changes a parameter.

There's `...Sizefor...` in a few attributes that should be `...SizeFor...`.