### PR TITLE
fix(FacetValue doc): wrong attribute name in docs

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -47,7 +47,7 @@ var generateHierarchicalTree = require('./generate-hierarchical-tree');
 /**
  * @typedef SearchResults.FacetValue
  * @type {object}
- * @property {string} value the facet value itself
+ * @property {string} name the facet value itself
  * @property {number} count times this facet appears in the results
  * @property {boolean} isRefined is the facet currently selected
  * @property {boolean} isExcluded is the facet currently excluded (only for conjunctive facets)


### PR DESCRIPTION
The `FacetValue` type is wrongly documented as having a `value` attribute, when it actually is called `name`
(see [relevant code](https://github.com/algolia/algoliasearch-helper-js/blob/master/src/SearchResults/index.js#L541-L548))