### PR TITLE
fix(setState): use .make() instead of constructor()

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -806,7 +806,7 @@ AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setState = function(newState) {
-  this.state = new SearchParameters(newState);
+  this.state = SearchParameters.make(newState);
   this._change();
   return this;
 };

--- a/test/spec/algoliasearch.helper/state.js
+++ b/test/spec/algoliasearch.helper/state.js
@@ -465,3 +465,39 @@ test('should be able to get configuration that is not from algolia', function(t)
     moar);
   t.end();
 });
+
+test('setState should set a default hierarchicalFacetRefinement when a rootPath is defined', function(t) {
+  var searchParameters = {hierarchicalFacets: [
+    {
+      name: 'hierarchicalCategories.lvl0',
+      attributes: [
+        'hierarchicalCategories.lvl0',
+        'hierarchicalCategories.lvl1',
+        'hierarchicalCategories.lvl2'
+      ],
+      separator: ' > ',
+      rootPath: 'Cameras & Camcorders',
+      showParentLevel: true
+    }
+  ]};
+
+  var helper = algoliasearchHelper(fakeClient, null, searchParameters);
+  var initialHelperState = Object.assign({}, helper.getState());
+
+  t.deepEquals(initialHelperState.hierarchicalFacetsRefinements, {
+    'hierarchicalCategories.lvl0': ['Cameras & Camcorders']
+  });
+
+  // reset state
+  helper.setState(helper.state.removeHierarchicalFacet('hierarchicalCategories.lvl0'));
+  t.deepEquals(helper.getState().hierarchicalFacetsRefinements, {});
+
+  // re-add `hierarchicalFacets`
+  helper.setState(Object.assign({}, helper.state, searchParameters));
+  var finalHelperState = Object.assign({}, helper.getState());
+
+  t.deepEquals(initialHelperState, finalHelperState);
+  t.deepEquals(finalHelperState.hierarchicalFacetsRefinements, {
+    'hierarchicalCategories.lvl0': ['Cameras & Camcorders']
+  });
+});

--- a/test/spec/algoliasearch.helper/state.js
+++ b/test/spec/algoliasearch.helper/state.js
@@ -500,4 +500,6 @@ test('setState should set a default hierarchicalFacetRefinement when a rootPath 
   t.deepEquals(finalHelperState.hierarchicalFacetsRefinements, {
     'hierarchicalCategories.lvl0': ['Cameras & Camcorders']
   });
+
+  t.end();
 });


### PR DESCRIPTION
**Bug:**

When you call `helper.setState()` it won't compute `hierarchicalFacets` to check if there is a `rootPath` defined to set a `hierarchicalFacetRefinement`.