### PR TITLE
feat(query rules): expose userData

### DIFF
--- a/documentation-src/metalsmith/content/reference.md
+++ b/documentation-src/metalsmith/content/reference.md
@@ -471,6 +471,10 @@ are implemented on top of Algolia API such as faceting.
 {{> jsdoc jsdoc/results/page}}
 {{> jsdoc jsdoc/results/parsedQuery}}
 
+### Query rules
+
+{{> jsdoc jsdoc/results/userData}}
+
 ### Technical metadata
 
 {{> jsdoc jsdoc/results/processingTimeMS}}

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -515,8 +515,6 @@ function SearchResults(state, results) {
   this.facets = compact(this.facets);
   this.disjunctiveFacets = compact(this.disjunctiveFacets);
 
-
-
   this._state = state;
 }
 

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -318,6 +318,13 @@ function SearchResults(state, results) {
    */
   this.exhaustiveNbHits = mainSubResponse.exhaustiveNbHits;
 
+
+  /**
+   * Contains the userData if they are set by a [query rule](https://www.algolia.com/doc/guides/query-rules/query-rules-overview/).
+   * @member {object[]}
+   */
+  this.userData = mainSubResponse.userData;
+
   /**
    * disjunctive facets results
    * @member {SearchResults.Facet[]}
@@ -507,6 +514,8 @@ function SearchResults(state, results) {
 
   this.facets = compact(this.facets);
   this.disjunctiveFacets = compact(this.disjunctiveFacets);
+
+
 
   this._state = state;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9176,7 +9176,7 @@ typical@^2.1, typical@^2.2, typical@^2.3.0, typical@^2.4.2, typical@^2.5.0, typi
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
 
-uglify-js@^2.6, uglify-js@^2.6.2, uglify-js@^2.8.27:
+uglify-js@^2.4.19, uglify-js@^2.6, uglify-js@^2.6.2, uglify-js@^2.8.27:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
userData is a field that can be populated through the use of query rules. Until now it was only available by accessing the _rawResults object. Now it is accessible directly on the SearchResults.

fix #529 
