### PR TITLE
fix(events): only trigger change when there is an actual change

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "readme:toc": "doctoc --notitle README.md --maxlevel 3",
     "test-ci": "scripts/test-ci.sh",
     "test": "scripts/test.sh",
+    "test:unit": "ONLY_UNIT=true scripts/test.sh",
     "test-node": "clear && node test/run",
     "test:watch": "onchange '{src,test}/**/*.js' 'index.js' -- npm run test-node",
     "test:perf": "node ./test/perf/index.js",

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -110,10 +110,10 @@ var lib = {
         });
 
         if (!isEmpty(facetList)) {
-          if (facetList.length !== values.length) hasChanged = hasChanged || true;
+          if (facetList.length !== values.length) hasChanged = true;
           memo[key] = facetList;
         }
-        else hasChanged = hasChanged || true;
+        else hasChanged = true;
 
         return memo;
       }, {});

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -96,19 +96,30 @@ var lib = {
    */
   clearRefinement: function clearRefinement(refinementList, attribute, refinementType) {
     if (isUndefined(attribute)) {
+      if (isEmpty(refinementList)) return refinementList;
       return {};
     } else if (isString(attribute)) {
+      if (isEmpty(refinementList[attribute])) return refinementList;
       return omit(refinementList, attribute);
     } else if (isFunction(attribute)) {
-      return reduce(refinementList, function(memo, values, key) {
+      var hasChanged = false;
+
+      var newRefinementList = reduce(refinementList, function(memo, values, key) {
         var facetList = filter(values, function(value) {
           return !attribute(value, key, refinementType);
         });
 
-        if (!isEmpty(facetList)) memo[key] = facetList;
+        if (!isEmpty(facetList)) {
+          if (facetList.length !== values.length) hasChanged = hasChanged || true;
+          memo[key] = facetList;
+        }
+        else hasChanged = hasChanged || true;
 
         return memo;
       }, {});
+
+      if (hasChanged) return newRefinementList;
+      return refinementList;
     }
   },
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1676,6 +1676,10 @@ SearchParameters.prototype = {
     );
     var path = refinement.split(separator);
     return map(path, trim);
+  },
+
+  toString: function() {
+    return JSON.stringify(this, null, 2);
   }
 };
 

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -620,13 +620,22 @@ SearchParameters.prototype = {
    */
   clearRefinements: function clearRefinements(attribute) {
     var clear = RefinementList.clearRefinement;
-    return this.setQueryParameters({
+    var patch = {
       numericRefinements: this._clearNumericRefinements(attribute),
       facetsRefinements: clear(this.facetsRefinements, attribute, 'conjunctiveFacet'),
       facetsExcludes: clear(this.facetsExcludes, attribute, 'exclude'),
       disjunctiveFacetsRefinements: clear(this.disjunctiveFacetsRefinements, attribute, 'disjunctiveFacet'),
       hierarchicalFacetsRefinements: clear(this.hierarchicalFacetsRefinements, attribute, 'hierarchicalFacet')
-    });
+    };
+    console.log(patch);
+    if (isEmpty(patch.numericRefinements) &&
+        isEmpty(patch.facetsRefinements) &&
+        isEmpty(patch.facetsExcludes) &&
+        isEmpty(patch.disjunctiveFacetsRefinements) &&
+        isEmpty(patch.hierarchicalFacetsRefinements)) {
+      return this;
+    }
+    return this.setQueryParameters(patch);
   },
   /**
    * Remove all the refined tags from the SearchParameters

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -904,10 +904,10 @@ SearchParameters.prototype = {
             if (!predicateResult) outValues.push(value);
           });
           if (!isEmpty(outValues)) {
-            if (outValues.length !== values.length) hasChanged = hasChanged || true;
+            if (outValues.length !== values.length) hasChanged = true;
             operatorList[operator] = outValues;
           }
-          else hasChanged = hasChanged || true;
+          else hasChanged = true;
         });
 
         if (!isEmpty(operatorList)) memo[key] = operatorList;

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -302,8 +302,7 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setQuery = function(q) {
-  this.state = this.state.setPage(0).setQuery(q);
-  this._change();
+  this._change(this.state.setPage(0).setQuery(q));
   return this;
 };
 
@@ -331,8 +330,7 @@ AlgoliaSearchHelper.prototype.setQuery = function(q) {
  * }).search();
  */
 AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
-  this.state = this.state.setPage(0).clearRefinements(name);
-  this._change();
+  this._change(this.state.setPage(0).clearRefinements(name));
   return this;
 };
 
@@ -345,8 +343,7 @@ AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.clearTags = function() {
-  this.state = this.state.setPage(0).clearTags();
-  this._change();
+  this._change(this.state.setPage(0).clearTags());
   return this;
 };
 
@@ -362,8 +359,7 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).addDisjunctiveFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).addDisjunctiveFacetRefinement(facet, value));
   return this;
 };
 
@@ -388,8 +384,7 @@ AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function() {
  * @fires change
  */
 AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).addHierarchicalFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).addHierarchicalFacetRefinement(facet, value));
   return this;
 };
 
@@ -406,8 +401,7 @@ AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, v
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operator, value) {
-  this.state = this.state.setPage(0).addNumericRefinement(attribute, operator, value);
-  this._change();
+  this._change(this.state.setPage(0).addNumericRefinement(attribute, operator, value));
   return this;
 };
 
@@ -423,8 +417,7 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operato
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).addFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).addFacetRefinement(facet, value));
   return this;
 };
 
@@ -448,8 +441,7 @@ AlgoliaSearchHelper.prototype.addRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetExclusion = function(facet, value) {
-  this.state = this.state.setPage(0).addExcludeRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).addExcludeRefinement(facet, value));
   return this;
 };
 
@@ -471,8 +463,7 @@ AlgoliaSearchHelper.prototype.addExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addTag = function(tag) {
-  this.state = this.state.setPage(0).addTagRefinement(tag);
-  this._change();
+  this._change(this.state.setPage(0).addTagRefinement(tag));
   return this;
 };
 
@@ -495,8 +486,7 @@ AlgoliaSearchHelper.prototype.addTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, operator, value) {
-  this.state = this.state.setPage(0).removeNumericRefinement(attribute, operator, value);
-  this._change();
+  this._change(this.state.setPage(0).removeNumericRefinement(attribute, operator, value));
   return this;
 };
 
@@ -515,8 +505,7 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, oper
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeDisjunctiveFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).removeDisjunctiveFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).removeDisjunctiveFacetRefinement(facet, value));
   return this;
 };
 
@@ -536,8 +525,7 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet) {
-  this.state = this.state.setPage(0).removeHierarchicalFacetRefinement(facet);
-  this._change();
+  this._change(this.state.setPage(0).removeHierarchicalFacetRefinement(facet));
 
   return this;
 };
@@ -557,8 +545,7 @@ AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).removeFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).removeFacetRefinement(facet, value));
   return this;
 };
 
@@ -584,8 +571,7 @@ AlgoliaSearchHelper.prototype.removeRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetExclusion = function(facet, value) {
-  this.state = this.state.setPage(0).removeExcludeRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).removeExcludeRefinement(facet, value));
   return this;
 };
 
@@ -607,8 +593,7 @@ AlgoliaSearchHelper.prototype.removeExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeTag = function(tag) {
-  this.state = this.state.setPage(0).removeTagRefinement(tag);
-  this._change();
+  this._change(this.state.setPage(0).removeTagRefinement(tag));
   return this;
 };
 
@@ -624,8 +609,7 @@ AlgoliaSearchHelper.prototype.removeTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetExclusion = function(facet, value) {
-  this.state = this.state.setPage(0).toggleExcludeFacetRefinement(facet, value);
-  this._change();
+  this._change(this.state.setPage(0).toggleExcludeFacetRefinement(facet, value));
   return this;
 };
 
@@ -670,9 +654,7 @@ AlgoliaSearchHelper.prototype.toggleRefinement = function(facet, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetRefinement = function(facet, value) {
-  this.state = this.state.setPage(0).toggleFacetRefinement(facet, value);
-
-  this._change();
+  this._change(this.state.setPage(0).toggleFacetRefinement(facet, value));
   return this;
 };
 
@@ -694,8 +676,7 @@ AlgoliaSearchHelper.prototype.toggleRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleTag = function(tag) {
-  this.state = this.state.setPage(0).toggleTagRefinement(tag);
-  this._change();
+  this._change(this.state.setPage(0).toggleTagRefinement(tag));
   return this;
 };
 
@@ -731,8 +712,7 @@ AlgoliaSearchHelper.prototype.previousPage = function() {
 function setCurrentPage(page) {
   if (page < 0) throw new Error('Page requested below 0.');
 
-  this.state = this.state.setPage(page);
-  this._change();
+  this._change(this.state.setPage(page));
   return this;
 }
 
@@ -766,8 +746,7 @@ AlgoliaSearchHelper.prototype.setPage = setCurrentPage;
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setIndex = function(name) {
-  this.state = this.state.setPage(0).setIndex(name);
-  this._change();
+  this._change(this.state.setPage(0).setIndex(name));
   return this;
 };
 
@@ -789,12 +768,7 @@ AlgoliaSearchHelper.prototype.setIndex = function(name) {
  * helper.setQueryParameter('hitsPerPage', 20).search();
  */
 AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
-  var newState = this.state.setPage(0).setQueryParameter(parameter, value);
-
-  if (this.state === newState) return this;
-
-  this.state = newState;
-  this._change();
+  this._change(this.state.setPage(0).setQueryParameter(parameter, value));
   return this;
 };
 
@@ -806,8 +780,7 @@ AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setState = function(newState) {
-  this.state = SearchParameters.make(newState);
-  this._change();
+  this._change(SearchParameters.make(newState));
   return this;
 };
 
@@ -1290,8 +1263,11 @@ AlgoliaSearchHelper.prototype._hasDisjunctiveRefinements = function(facet) {
     this.state.disjunctiveRefinements[facet].length > 0;
 };
 
-AlgoliaSearchHelper.prototype._change = function() {
-  this.emit('change', this.state, this.lastResults);
+AlgoliaSearchHelper.prototype._change = function(newState) {
+  if (newState !== this.state) {
+    this.state = newState;
+    this.emit('change', this.state, this.lastResults);
+  }
 };
 
 /**

--- a/test/run.js
+++ b/test/run.js
@@ -4,7 +4,7 @@ var bulk = require('bulk-require');
 
 bulk(__dirname, ['spec/**/*.js']);
 
-if (process.env.INTEGRATION_TEST_API_KEY && process.env.INTEGRATION_TEST_APPID) {
+if (process.env.ONLY_UNIT !== 'true' && process.env.INTEGRATION_TEST_API_KEY && process.env.INTEGRATION_TEST_APPID) {
   // usage: INTEGRATION_TEST_APPID=$APPID INTEGRATION_TEST_API_KEY=$APIKEY npm run dev
   bulk(__dirname, ['integration-spec/**/*.js']);
 }

--- a/test/spec/SearchParameters/RefinementList/clear.js
+++ b/test/spec/SearchParameters/RefinementList/clear.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var test = require('tape');
+
+var RefinementList = require('../../../../src/SearchParameters/RefinementList.js');
+var clear = RefinementList.clearRefinement;
+
+test('When removing all refinements of a state without any', function(t) {
+  var initialRefinementList = {};
+  t.equal(clear(initialRefinementList), initialRefinementList, 'it should return the same ref');
+  t.end();
+});
+
+test('When removing refinements of a specific attribute, and there are no refinements for this attribute', function(t) {
+  var initialRefinementList = {
+    'attribute': ['test']
+  };
+
+  t.equal(clear(initialRefinementList, 'notThisAttribute'), initialRefinementList, 'it should return the same ref');
+  t.end();
+});
+
+test('When removing numericRefinements using a function, and there are no changes', function(t) {
+  var initialRefinementList = {
+    'attribute': ['test']
+  };
+
+  function clearNothing() {return false;}
+  function clearUndefinedAttribute(value, attribute) {return attribute === 'category';}
+  function clearUndefinedValue(value) {return value === 'toast';}
+
+  t.equal(clear(initialRefinementList, clearNothing, 'facet'), initialRefinementList, 'it should return the same ref - nothing');
+  t.equal(
+    clear(initialRefinementList, clearUndefinedAttribute, 'facet'),
+    initialRefinementList,
+    'it should return the same ref - undefined attribute');
+  t.equal(clear(initialRefinementList, clearUndefinedValue, 'facet'), initialRefinementList, 'it should return the same ref - undefined value');
+
+  t.end();
+});
+

--- a/test/spec/SearchParameters/_clearNumericRefinements.js
+++ b/test/spec/SearchParameters/_clearNumericRefinements.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var test = require('tape');
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('When removing all numeric refinements of a state without any', function(t) {
+  var state = SearchParameters.make({});
+  t.equal(state._clearNumericRefinements(), state.numericRefinements, 'it should return the same ref');
+  t.end();
+});
+
+test('When removing numericRefinements of a specific attribute, and there are no refinements for this attribute', function(t) {
+  var state = SearchParameters.make({
+    numericRefinements: {
+      price: {'>': [300]}
+    }
+  });
+
+  t.equal(state._clearNumericRefinements('size'), state.numericRefinements, 'it should return the same ref');
+  t.end();
+});
+
+test('When removing numericRefinements using a function, and there are no changes', function(t) {
+  var state = SearchParameters.make({
+    numericRefinements: {
+      price: {'>': [300, 30]},
+      size: {'=': [32, 30]}
+    }
+  });
+
+  function clearNothing() {return false;}
+  function clearUndefinedAttribute(v, attribute) {return attribute === 'distance';}
+  function clearUndefinedOperator(v) {return v.op === '<';}
+  function clearUndefinedValue(v) {return v.val === 3;}
+
+  t.equal(state._clearNumericRefinements(clearNothing), state.numericRefinements, 'it should return the same ref - nothing');
+  t.equal(state._clearNumericRefinements(clearUndefinedAttribute), state.numericRefinements, 'it should return the same ref - undefined attribute');
+  t.equal(state._clearNumericRefinements(clearUndefinedOperator), state.numericRefinements, 'it should return the same ref - undefined operator');
+  t.equal(state._clearNumericRefinements(clearUndefinedValue), state.numericRefinements, 'it should return the same ref - undefined value');
+
+  t.end();
+});

--- a/test/spec/algoliasearch.helper/clears.js
+++ b/test/spec/algoliasearch.helper/clears.js
@@ -10,7 +10,11 @@ var isUndefined = require('lodash/isUndefined');
 function fixture() {
   var helper = algoliasearchHelper({addAlgoliaAgent: function() {}}, 'Index', {
     facets: ['facet1', 'facet2', 'both_facet', 'excluded1', 'excluded2'],
-    disjunctiveFacets: ['disjunctiveFacet1', 'disjunctiveFacet2', 'both_facet']
+    disjunctiveFacets: ['disjunctiveFacet1', 'disjunctiveFacet2', 'both_facet'],
+    hierarchicalFacets: [{
+      facetName: 'hierarchy',
+      attributes: ['a', 'b', 'c']
+    }]
   });
 
   return helper.toggleRefine('facet1', '0')
@@ -163,6 +167,53 @@ test('Clearing twice the same attribute should be not problem', function(t) {
   t.doesNotThrow(function() {
     helper.clearRefinements('numeric1');
   });
+
+  t.end();
+});
+
+test('Clearing without parameters should clear everything', function(t) {
+  var helper = fixture();
+
+  helper.clearRefinements();
+
+  t.deepEqual(helper.state.numericRefinements, {}, 'Numeric refinements should be empty');
+  t.deepEqual(helper.state.facetsRefinements, {}, 'Facets refinements should be empty');
+  t.deepEqual(helper.state.disjunctiveFacetsRefinements, {}, 'Disjunctive facets refinements should be empty');
+  t.deepEqual(helper.state.hierarchicalFacetsRefinements, {}, 'Hierarchical facets refinements should be empty');
+
+  t.end();
+});
+
+test('Clearing with no effect should not update the state', function(t) {
+  var helper = fixture();
+  // Reset the state
+  helper.clearRefinements();
+  var emptyState = helper.state;
+  // This operation should not update the reference to the state
+  helper.clearRefinements();
+
+  t.equal(helper.state.numericRefinements, emptyState.numericRefinements, 'Numeric refinements should be empty');
+  t.equal(helper.state.facetsRefinements, emptyState.facetsRefinements, 'Facets refinements should be empty');
+  t.equal(helper.state.disjunctiveFacetsRefinements, emptyState.disjunctiveFacetsRefinements, 'Disjunctive facets refinements should be empty');
+  t.equal(helper.state.hierarchicalFacetsRefinements, emptyState.hierarchicalFacetsRefinements, 'Hierarchical facets refinements should be empty');
+
+  t.equal(helper.state, emptyState, 'State should remain the same');
+
+  t.end();
+});
+
+test('Clearing with no effect should not update the state, if used with an unknown attribute', function(t) {
+  var helper = fixture();
+  var initialState = helper.state;
+  // This operation should not update the reference to the state
+  helper.clearRefinements('unknown');
+
+  t.equal(helper.state.numericRefinements, initialState.numericRefinements, 'Numeric refinements should be empty');
+  t.equal(helper.state.facetsRefinements, initialState.facetsRefinements, 'Facets refinements should be empty');
+  t.equal(helper.state.disjunctiveFacetsRefinements, initialState.disjunctiveFacetsRefinements, 'Disjunctive facets refinements should be empty');
+  t.equal(helper.state.hierarchicalFacetsRefinements, initialState.hierarchicalFacetsRefinements, 'Hierarchical facets refinements should be empty');
+
+  t.equal(helper.state, initialState, 'State should remain the same');
 
   t.end();
 });

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -76,7 +76,10 @@ test('Change events should only be emitted for meaningful changes', function(t) 
     facets: ['tower'],
     facetsRefinements: {tower: ['Empire State Building']},
     facetsExcludes: {tower: ['Empire State Building']},
-    hierarchicalFacets: [],
+    hierarchicalFacets: [{
+      name: 'hierarchicalFacet',
+      attributes: ['lvl1', 'lvl2']
+    }],
     numericRefinements: {
       price: {'>': [300]}
     }
@@ -109,8 +112,6 @@ test('Change events should only be emitted for meaningful changes', function(t) 
   helper.addNumericRefinement('price', '>', 300);
   t.equal(changeEventCount, 0, 'addNumericRefinement');
   t.equal(stubbedSearch.callCount, 0, 'addNumericRefinement');
-
-  console.log(helper.state.toString());
 
   // This is an actual change
   helper.clearRefinements();

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -11,7 +11,14 @@ var fakeClient = {
 test('Change events should be emitted as soon as the state change, but search should be triggered (refactored)', function(t) {
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     disjunctiveFacets: ['city'],
-    facets: ['tower']
+    disjunctiveFacetsRefinements: {city: ['Paris']},
+    facets: ['tower'],
+    facetsRefinements: {tower: ['Empire State Building']},
+    facetsExcludes: {tower: ['Empire State Building']},
+    hierarchicalFacets: [],
+    numericRefinements: {
+      price: {'>': [300]}
+    }
   });
 
   var changeEventCount = 0;
@@ -23,36 +30,36 @@ test('Change events should be emitted as soon as the state change, but search sh
   var stubbedSearch = sinon.stub(helper, '_search');
 
   helper.setQuery('a');
-  t.equal(changeEventCount, 1, 'search');
-  t.equal(stubbedSearch.callCount, 0, 'search');
+  t.equal(changeEventCount, 1, 'query - change');
+  t.equal(stubbedSearch.callCount, 0, 'query - search');
 
   helper.clearRefinements();
-  t.equal(changeEventCount, 2, 'clearRefinements');
-  t.equal(stubbedSearch.callCount, 0, 'clearRefinements');
+  t.equal(changeEventCount, 2, 'clearRefinements - change');
+  t.equal(stubbedSearch.callCount, 0, 'clearRefinements - search');
 
   helper.addDisjunctiveRefine('city', 'Paris');
-  t.equal(changeEventCount, 3, 'addDisjunctiveRefine');
-  t.equal(stubbedSearch.callCount, 0, 'addDisjunctiveRefine');
+  t.equal(changeEventCount, 3, 'addDisjunctiveRefine - change');
+  t.equal(stubbedSearch.callCount, 0, 'addDisjunctiveRefine - search');
 
   helper.removeDisjunctiveRefine('city', 'Paris');
-  t.equal(changeEventCount, 4, 'removeDisjunctiveRefine');
-  t.equal(stubbedSearch.callCount, 0, 'removeDisjunctiveRefine');
+  t.equal(changeEventCount, 4, 'removeDisjunctiveRefine - change');
+  t.equal(stubbedSearch.callCount, 0, 'removeDisjunctiveRefine - search');
 
   helper.addExclude('tower', 'Empire State Building');
-  t.equal(changeEventCount, 5, 'addExclude');
-  t.equal(stubbedSearch.callCount, 0, 'addExclude');
+  t.equal(changeEventCount, 5, 'addExclude - change');
+  t.equal(stubbedSearch.callCount, 0, 'addExclude - search');
 
   helper.removeExclude('tower', 'Empire State Building');
-  t.equal(changeEventCount, 6, 'removeExclude');
-  t.equal(stubbedSearch.callCount, 0, 'removeExclude');
+  t.equal(changeEventCount, 6, 'removeExclude - change');
+  t.equal(stubbedSearch.callCount, 0, 'removeExclude - search');
 
   helper.addRefine('tower', 'Empire State Building');
-  t.equal(changeEventCount, 7, 'addRefine');
-  t.equal(stubbedSearch.callCount, 0, 'addRefine');
+  t.equal(changeEventCount, 7, 'addRefine - change');
+  t.equal(stubbedSearch.callCount, 0, 'addRefine - search');
 
   helper.removeRefine('tower', 'Empire State Building');
-  t.equal(changeEventCount, 8, 'removeRefine');
-  t.equal(stubbedSearch.callCount, 0, 'removeRefine');
+  t.equal(changeEventCount, 8, 'removeRefine - change');
+  t.equal(stubbedSearch.callCount, 0, 'removeRefine - search');
 
   helper.search();
   t.equal(changeEventCount, 8, "final search doesn't call the change");
@@ -61,7 +68,7 @@ test('Change events should be emitted as soon as the state change, but search sh
   t.end();
 });
 
-test.only('Change events should only be emitted for meaningful changes', function(t) {
+test('Change events should only be emitted for meaningful changes', function(t) {
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     query: 'a',
     disjunctiveFacets: ['city'],

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -14,48 +14,120 @@ test('Change events should be emitted as soon as the state change, but search sh
     facets: ['tower']
   });
 
-  var count = 0;
+  var changeEventCount = 0;
 
   helper.on('change', function() {
-    count++;
+    changeEventCount++;
   });
 
   var stubbedSearch = sinon.stub(helper, '_search');
 
-  helper.setQuery('');
-  t.equal(count, 1, 'search');
+  helper.setQuery('a');
+  t.equal(changeEventCount, 1, 'search');
   t.equal(stubbedSearch.callCount, 0, 'search');
 
   helper.clearRefinements();
-  t.equal(count, 2, 'clearRefinements');
+  t.equal(changeEventCount, 2, 'clearRefinements');
   t.equal(stubbedSearch.callCount, 0, 'clearRefinements');
 
   helper.addDisjunctiveRefine('city', 'Paris');
-  t.equal(count, 3, 'addDisjunctiveRefine');
+  t.equal(changeEventCount, 3, 'addDisjunctiveRefine');
   t.equal(stubbedSearch.callCount, 0, 'addDisjunctiveRefine');
 
   helper.removeDisjunctiveRefine('city', 'Paris');
-  t.equal(count, 4, 'removeDisjunctiveRefine');
+  t.equal(changeEventCount, 4, 'removeDisjunctiveRefine');
   t.equal(stubbedSearch.callCount, 0, 'removeDisjunctiveRefine');
 
   helper.addExclude('tower', 'Empire State Building');
-  t.equal(count, 5, 'addExclude');
+  t.equal(changeEventCount, 5, 'addExclude');
   t.equal(stubbedSearch.callCount, 0, 'addExclude');
 
   helper.removeExclude('tower', 'Empire State Building');
-  t.equal(count, 6, 'removeExclude');
+  t.equal(changeEventCount, 6, 'removeExclude');
   t.equal(stubbedSearch.callCount, 0, 'removeExclude');
 
   helper.addRefine('tower', 'Empire State Building');
-  t.equal(count, 7, 'addRefine');
+  t.equal(changeEventCount, 7, 'addRefine');
   t.equal(stubbedSearch.callCount, 0, 'addRefine');
 
   helper.removeRefine('tower', 'Empire State Building');
-  t.equal(count, 8, 'removeRefine');
+  t.equal(changeEventCount, 8, 'removeRefine');
   t.equal(stubbedSearch.callCount, 0, 'removeRefine');
 
   helper.search();
-  t.equal(count, 8, "final search doesn't call the change");
+  t.equal(changeEventCount, 8, "final search doesn't call the change");
+  t.equal(stubbedSearch.callCount, 1, 'final search triggers the search');
+
+  t.end();
+});
+
+test.only('Change events should only be emitted for meaningful changes', function(t) {
+  var helper = algoliaSearchHelper(fakeClient, 'Index', {
+    query: 'a',
+    disjunctiveFacets: ['city'],
+    disjunctiveFacetsRefinements: {city: ['Paris']},
+    facets: ['tower'],
+    facetsRefinements: {tower: ['Empire State Building']},
+    facetsExcludes: {tower: ['Empire State Building']},
+    hierarchicalFacets: [],
+    numericRefinements: {
+      price: {'>': [300]}
+    }
+  });
+
+  var changeEventCount = 0;
+
+  helper.on('change', function() {
+    changeEventCount++;
+  });
+
+  var stubbedSearch = sinon.stub(helper, '_search');
+
+  helper.setQuery('a');
+  t.equal(changeEventCount, 0, 'search');
+  t.equal(stubbedSearch.callCount, 0, 'search');
+
+  helper.addDisjunctiveRefine('city', 'Paris');
+  t.equal(changeEventCount, 0, 'addDisjunctiveRefine');
+  t.equal(stubbedSearch.callCount, 0, 'addDisjunctiveRefine');
+
+  helper.addExclude('tower', 'Empire State Building');
+  t.equal(changeEventCount, 0, 'addExclude');
+  t.equal(stubbedSearch.callCount, 0, 'addExclude');
+
+  helper.addRefine('tower', 'Empire State Building');
+  t.equal(changeEventCount, 0, 'addRefine');
+  t.equal(stubbedSearch.callCount, 0, 'addRefine');
+
+  helper.addNumericRefinement('price', '>', 300);
+  t.equal(changeEventCount, 0, 'addNumericRefinement');
+  t.equal(stubbedSearch.callCount, 0, 'addNumericRefinement');
+
+  console.log(helper.state.toString());
+
+  // This is an actual change
+  helper.clearRefinements();
+  t.equal(changeEventCount, 1, 'clearRefinements');
+  t.equal(stubbedSearch.callCount, 0, 'clearRefinements');
+
+  helper.clearRefinements();
+  t.equal(changeEventCount, 1, 'clearRefinements');
+  t.equal(stubbedSearch.callCount, 0, 'clearRefinements');
+
+  helper.removeDisjunctiveRefine('city', 'Paris');
+  t.equal(changeEventCount, 1, 'removeDisjunctiveRefine');
+  t.equal(stubbedSearch.callCount, 0, 'removeDisjunctiveRefine');
+
+  helper.removeExclude('tower', 'Empire State Building');
+  t.equal(changeEventCount, 1, 'removeExclude');
+  t.equal(stubbedSearch.callCount, 0, 'removeExclude');
+
+  helper.removeRefine('tower', 'Empire State Building');
+  t.equal(changeEventCount, 1, 'removeRefine');
+  t.equal(stubbedSearch.callCount, 0, 'removeRefine');
+
+  helper.search();
+  t.equal(changeEventCount, 1, "final search doesn't call the change");
   t.equal(stubbedSearch.callCount, 1, 'final search triggers the search');
 
   t.end();

--- a/test/spec/algoliasearch.helper/numericFilters.js
+++ b/test/spec/algoliasearch.helper/numericFilters.js
@@ -78,7 +78,7 @@ test('Should be able to remove values one by one even 0s', function(t) {
   helper.addNumericRefinement('attribute', '>', 4);
   t.deepEqual(helper.state.numericRefinements.attribute['>'], [0, 4], 'should be set to [0, 4] initially');
   helper.removeNumericRefinement('attribute', '>', 0);
-  t.deepEqual(helper.state.numericRefinements.attribute['>'], [4], 'should be set to [ 0 ]');
+  t.deepEqual(helper.state.numericRefinements.attribute['>'], [4], 'should be set to [ 4 ]');
   helper.removeNumericRefinement('attribute', '>', 4);
   t.equal(helper.state.numericRefinements.attribute, undefined, 'should set to undefined');
   t.end();


### PR DESCRIPTION
In order to fix this issue, we needed to actually fix two things:
 - make sure that the mechanics in the Helper, check if there is a `change` and not trigger all the time. This implies a refactoring on the Helper side of all the mutating methods and make sure that before triggering the change event, we check the changes.
 - make sure that we are able to determine that there has been a change. This implies to verify that all updating methods on the searchParameters are not returning new instance of the state if this is not necessary.

The first point was pretty easy to implement. For the second, it was trickier. The clears were not scarce at all.

Also please the implementation of the _clearRefinements and clear (in refinementList), the usage with function will create a new structure but will not return if it yields the same value. This is a bit of trick but couldn't find a better solution for that. If you have another approach, I'd be happy to learn about it :)