### PR TITLE
feat(sffv): can override search when using searchForFacetValues

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -262,14 +262,16 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * See the description of [FacetSearchResult](reference.html#FacetSearchResult)
  * @param {string} facet the name of the faceted attribute
  * @param {string} query the string query for the search
- * @param {number} maxFacetHits the maximum number values returned. Should be > 0 and <= 100
- * @return {promise<FacetSearchResult>} the results of the search
+ * @param {number} [maxFacetHits] the maximum number values returned. Should be > 0 and <= 100
+ * @param {object} [userState] the set of custom parameters to use on top of the current state. Setting a property to `undefined` removes
+ * it in the generated query.
+ * @return {promise.<FacetSearchResult>} the results of the search
  */
-AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits) {
-  var state = this.state;
-  var index = this.client.initIndex(this.state.index);
+AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits, userState) {
+  var state = this.state.setQueryParameters(userState || {});
+  var index = this.client.initIndex(state.index);
   var isDisjunctive = state.isDisjunctiveFacet(facet);
-  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, this.state);
+  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state);
 
   this._currentNbQueries++;
   var self = this;

--- a/test/integration-spec/helper.searchForFacetValues.js
+++ b/test/integration-spec/helper.searchForFacetValues.js
@@ -152,4 +152,3 @@ test(
       });
     }).then(null, bind(t.error, t));
   });
-

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var test = require('tape');
+// var algoliaSearch = require('algoliasearch');
+// var SearchParameters = require('../../../src/SearchParameters');
+
+var algoliasearchHelper = require('../../../index');
+
+test('searchForFacetValues should search for facetValues with the current state', function(t) {
+  var lastParameters = null;
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          lastParameters = arguments;
+          return Promise.resolve({
+          });
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    highlightPreTag: 'HIGHLIGHT>',
+    highlightPostTag: '<HIGHLIGHT',
+    query: 'iphone'
+  });
+
+  helper.searchForFacetValues('facet', 'query', 75);
+
+  t.equal(lastParameters[0].query, 'iphone');
+  t.equal(lastParameters[0].facetQuery, 'query');
+  t.equal(lastParameters[0].facetName, 'facet');
+  t.equal(lastParameters[0].highlightPreTag, 'HIGHLIGHT>');
+  t.equal(lastParameters[0].highlightPostTag, '<HIGHLIGHT');
+
+  t.end();
+});
+
+test('searchForFacetValues can override the current search state', function(t) {
+  var lastParameters = null;
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          lastParameters = arguments;
+          return Promise.resolve({
+          });
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    highlightPreTag: 'HIGHLIGHT>',
+    highlightPostTag: '<HIGHLIGHT',
+    query: 'iphone'
+  });
+
+  helper.searchForFacetValues('facet', 'query', 75, {
+    query: undefined,
+    highlightPreTag: 'highlightTag'
+  });
+
+  t.equal(lastParameters[0].query, undefined);
+  t.equal(lastParameters[0].facetQuery, 'query');
+  t.equal(lastParameters[0].facetName, 'facet');
+  t.equal(lastParameters[0].highlightPreTag, 'highlightTag');
+  t.equal(lastParameters[0].highlightPostTag, '<HIGHLIGHT');
+
+  t.end();
+});

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -38,7 +38,7 @@ test('searchForFacetValues should search for facetValues with the current state'
   t.end();
 });
 
-test('searchForFacetValues can override the current search state', function(t) {
+test.only('searchForFacetValues can override the current search state', function(t) {
   var lastParameters = null;
   var fakeClient = {
     addAlgoliaAgent: function() {},
@@ -64,7 +64,7 @@ test('searchForFacetValues can override the current search state', function(t) {
     highlightPreTag: 'highlightTag'
   });
 
-  t.equal(lastParameters[0].query, undefined);
+  t.notOk(lastParameters[0].hasOwnProperty('query'));
   t.equal(lastParameters[0].facetQuery, 'query');
   t.equal(lastParameters[0].facetName, 'facet');
   t.equal(lastParameters[0].highlightPreTag, 'highlightTag');

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var test = require('tape');
-// var algoliaSearch = require('algoliasearch');
-// var SearchParameters = require('../../../src/SearchParameters');
 
 var algoliasearchHelper = require('../../../index');
 


### PR DESCRIPTION
Until now it was not possible to update the state before searching for a facet value. But this can be annoying to not be able the search state that is sent to Algolia. This PR adds a new parameter to the method.

It does make for a great looking API but I didn't want to make a breaking change.

This PR is required for https://github.com/algolia/instantsearch.js/issues/2474