### PR TITLE
fix(url): treat insideBoundingBox in float form as number

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -513,6 +513,16 @@ SearchParameters._parseNumbers = function(partialState) {
     }
   });
 
+  // there's two formats of insideBoundingBox, we need to parse
+  // the one which is an array of float geo rectangles
+  if (Array.isArray(partialState.insideBoundingBox)) {
+    numbers.insideBoundingBox = partialState.insideBoundingBox.map(function(geoRect) {
+      return geoRect.map(function(value) {
+        return parseFloat(value);
+      });
+    });
+  }
+
   if (partialState.numericRefinements) {
     var numericRefinements = {};
     forEach(partialState.numericRefinements, function(operators, attribute) {

--- a/test/spec/SearchParameters/_parseNumbers.js
+++ b/test/spec/SearchParameters/_parseNumbers.js
@@ -8,6 +8,7 @@ test('_parseNumbers should convert to number all specified root keys (that are p
     aroundPrecision: '42',
     aroundRadius: '42',
     getRankingInfo: '42',
+    insideBoundingBox: [['51.1241999', '9.662499900000057', '41.3253001', '-5.559099999999944']],
     minWordSizefor2Typos: '42',
     minWordSizefor1Typo: '42',
     page: '42',
@@ -22,6 +23,7 @@ test('_parseNumbers should convert to number all specified root keys (that are p
   t.equal(actual.aroundPrecision, 42, 'aroundPrecision should be converted to number');
   t.equal(actual.aroundRadius, 42, 'aroundRadius should be converted to number');
   t.equal(actual.getRankingInfo, 42, 'getRankingInfo should be converted to number');
+  t.deepEqual(actual.insideBoundingBox, [[51.1241999, 9.662499900000057, 41.3253001, -5.559099999999944]], 'insideBoundingBox should be converted to number');
   t.equal(actual.minWordSizefor2Typos, 42, 'minWordSizeFor2Typos should be converted to number');
   t.equal(actual.minWordSizefor1Typo, 42, 'minWordSizeFor1Typo should be converted to number');
   t.equal(actual.page, 42, 'page should be converted to number');
@@ -41,6 +43,17 @@ test('_parseNumbers should not convert undefined to NaN', function(t) {
   var actual = SearchParameters._parseNumbers(partialState);
 
   t.equal(actual.aroundPrecision, undefined);
+
+  t.end();
+});
+
+test('_parseNumbers should not convert insideBoundingBox if it\'s a string', function(t) {
+  var partialState = {
+    insideBoundingBox: '5,4,5,4'
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  t.equal(actual.insideBoundingBox, '5,4,5,4');
 
   t.end();
 });

--- a/test/spec/algoliasearch.helper/state.js
+++ b/test/spec/algoliasearch.helper/state.js
@@ -387,7 +387,7 @@ test('getStateFromQueryString should parse page as number and be consistent with
   t.deepEquals(
     partialStateFromQueryString.page,
     helper.state.page,
-    'Page should be consistent throught query string serialization/deserialization');
+    'Page should be consistent through query string serialization/deserialization');
   t.end();
 });
 

--- a/test/spec/url.js
+++ b/test/spec/url.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var test = require('tape');
+var algoliasearchHelper = require('../../index');
+
+var fakeClient = {
+  addAlgoliaAgent: function() {}
+};
+
+test('getStateFromQueryString should parse insideBoundingBox as float georects and be consistent with the state', function(t) {
+  var index = 'indexNameInTheHelper';
+  var helper = algoliasearchHelper(fakeClient, index, {
+    insideBoundingBox: [[51.1241999, 9.662499900000057, 41.3253001, -5.559099999999944]]
+  });
+
+  var queryString = algoliasearchHelper.url.getQueryStringFromState(helper.getState());
+
+  var partialStateFromQueryString = algoliasearchHelper.url.getStateFromQueryString(
+    queryString
+  );
+
+  t.deepEquals(
+    partialStateFromQueryString.insideBoundingBox,
+    helper.state.insideBoundingBox,
+    'insideBoundingBox should be consistent through query string serialization/deserialization');
+  t.end();
+});
+
+test('getStateFromQueryString should parse insideBoundingBox as float georects and be consistent with the state', function(t) {
+  var index = 'indexNameInTheHelper';
+  var helper = algoliasearchHelper(fakeClient, index, {
+    insideBoundingBox: '51.1241999,9.662499900000057,41.3253001,-5.559099999999944'
+  });
+
+  var queryString = algoliasearchHelper.url.getQueryStringFromState(helper.getState());
+
+  var partialStateFromQueryString = algoliasearchHelper.url.getStateFromQueryString(
+    queryString
+  );
+
+  t.deepEquals(
+    partialStateFromQueryString.insideBoundingBox,
+    helper.state.insideBoundingBox,
+    'insideBoundingBox should be consistent through query string serialization/deserialization');
+  t.end();
+});


### PR DESCRIPTION
fixes #553

There's two representation of insideBoundingBox, one is `'47.3165,4.9665,47.3424,5.0201'`, the other is `[[47.3165, 4.9665,47.3424, 5.0201], [40.9234, 2.1185, 38.6430, 1.9916]]`. If URLSync was
used with the second form, it would be parsed as `[ ["51.1241999","9.662499900000057", "41.3253001", "-5.559099999999944"] ]` instead of the original array of array of floats.

This commit adds special handling for this kind of shape to the `_parseNumbers` of `SearchParameters`