### PR TITLE
chore(package.json): add files entry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-examples/
-test/
-# we do not want to lock down dependencies when used as an npm dependency
-# only when we build
-npm-shrinkwrap.json

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "files": [
     "dist",
     "src",
-    "CHANGELOG"
   ],
   "devDependencies": {
     "algolia-frontend-components": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist",
     "src",
+    "index.js"
   ],
   "devDependencies": {
     "algolia-frontend-components": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
     "type": "git",
     "url": "https://github.com/algolia/algoliasearch-helper-js.git"
   },
+  "files": [
+    "dist",
+    "src",
+    "CHANGELOG"
+  ],
   "devDependencies": {
     "algolia-frontend-components": "^0.0.33",
     "algoliasearch": "^3.20.2",


### PR DESCRIPTION
Right now all files in the directory are published to npm on publish. On the [Yarn site](https://yarn.pm/algoliasearch-helper) you can check which files are included now, which includes the documentation and other files. 

Also removes the .npmignore file, since a whitelist is better than a blacklist