### PR TITLE
feat(sffv): Use client SFFV over index SFFV

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -280,7 +280,6 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  */
 AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits, userState) {
   var state = this.state.setQueryParameters(userState || {});
-  var index = this.client.initIndex(state.index);
   var isDisjunctive = state.isDisjunctiveFacet(facet);
   var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state);
 
@@ -288,9 +287,9 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
   var self = this;
 
   this.emit('searchForFacetValues', state, facet, query);
-  var searchForFacetValuesPromise = this.client.searchForFacetValues
-    ? this.client.searchForFacetValues([algoliaQuery])
-    : index.searchForFacetValues(algoliaQuery);
+  var searchForFacetValuesPromise = typeof this.client.searchForFacetValues === 'function'
+    ? this.client.searchForFacetValues([{indexName: state.index, params: algoliaQuery}])
+    : this.client.initIndex(state.index).searchForFacetValues(algoliaQuery);
 
   return searchForFacetValuesPromise.then(function addIsRefined(content) {
     self._currentNbQueries--;

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -288,7 +288,11 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
   var self = this;
 
   this.emit('searchForFacetValues', state, facet, query);
-  return index.searchForFacetValues(algoliaQuery).then(function addIsRefined(content) {
+  var searchForFacetValuesPromise = this.client.searchForFacetValues
+    ? this.client.searchForFacetValues([algoliaQuery])
+    : index.searchForFacetValues(algoliaQuery);
+
+  return searchForFacetValuesPromise.then(function addIsRefined(content) {
     self._currentNbQueries--;
     if (self._currentNbQueries === 0) self.emit('searchQueueEmpty');
     content.facetHits = forEach(content.facetHits, function(f) {

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -177,8 +177,8 @@ test('client.searchForFacetValues can override the current search state', functi
     highlightPreTag: 'highlightTag'
   });
 
-  t.notOk(lastParameters[0].hasOwnProperty('query'));
   t.equal(lastParameters[0].indexName, 'index');
+  t.notOk(lastParameters[0].params.hasOwnProperty('query'));
   t.equal(lastParameters[0].params.facetQuery, 'query');
   t.equal(lastParameters[0].params.facetName, 'facet');
   t.equal(lastParameters[0].params.highlightPreTag, 'highlightTag');

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -4,7 +4,64 @@ var test = require('tape');
 
 var algoliasearchHelper = require('../../../index');
 
-test('searchForFacetValues should search for facetValues with the current state', function(t) {
+test('searchForFacetValues calls the client method over the index method', function(t) {
+  t.plan(2);
+
+  var indexSearchForFacetValuesCalled = 0;
+  var clientSearchForFacetValuesCalled = 0;
+
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    searchForFacetValues: function() {
+      clientSearchForFacetValuesCalled++;
+      return Promise.resolve({});
+    },
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          indexSearchForFacetValuesCalled++;
+          return Promise.resolve({});
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index');
+
+  helper.searchForFacetValues('facet', 'query', 1).then(function() {
+    t.equal(clientSearchForFacetValuesCalled, 1);
+    t.equal(indexSearchForFacetValuesCalled, 0);
+
+    t.end();
+  });
+});
+
+test('searchForFacetValues calls the index method if no client method', function(t) {
+  t.plan(1);
+
+  var indexSearchForFacetValuesCalled = 0;
+
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          indexSearchForFacetValuesCalled++;
+          return Promise.resolve({});
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index');
+
+  helper.searchForFacetValues('facet', 'query', 1).then(function() {
+    t.equal(indexSearchForFacetValuesCalled, 1);
+    t.end();
+  });
+});
+
+test('index.searchForFacetValues should search for facetValues with the current state', function(t) {
   var lastParameters = null;
   var fakeClient = {
     addAlgoliaAgent: function() {},
@@ -36,7 +93,7 @@ test('searchForFacetValues should search for facetValues with the current state'
   t.end();
 });
 
-test('searchForFacetValues can override the current search state', function(t) {
+test('index.searchForFacetValues can override the current search state', function(t) {
   var lastParameters = null;
   var fakeClient = {
     addAlgoliaAgent: function() {},
@@ -71,59 +128,61 @@ test('searchForFacetValues can override the current search state', function(t) {
   t.end();
 });
 
-test('searchForFacetValues calls the client method over the initIndex method', function(t) {
-  t.plan(2);
-
-  var indexSearchForFacetValuesCalled = 0;
-  var clientSearchForFacetValuesCalled = 0;
-
+test('client.searchForFacetValues should search for facetValues with the current state', function(t) {
+  var lastParameters = null;
   var fakeClient = {
     addAlgoliaAgent: function() {},
     searchForFacetValues: function() {
-      clientSearchForFacetValuesCalled++;
+      lastParameters = arguments[0];
       return Promise.resolve({});
-    },
-    initIndex: function() {
-      return {
-        searchForFacetValues: function() {
-          indexSearchForFacetValuesCalled++;
-          return Promise.resolve({});
-        }
-      };
     }
   };
 
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  helper.searchForFacetValues('facet', 'query', 1).then(function() {
-    t.equal(clientSearchForFacetValuesCalled, 1, 'client called');
-    t.equal(indexSearchForFacetValuesCalled, 0, 'index not called');
-
-    t.end();
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    highlightPreTag: 'HIGHLIGHT>',
+    highlightPostTag: '<HIGHLIGHT',
+    query: 'iphone'
   });
+
+  helper.searchForFacetValues('facet', 'query', 75);
+
+  t.equal(lastParameters[0].indexName, 'index');
+  t.equal(lastParameters[0].params.query, 'iphone');
+  t.equal(lastParameters[0].params.facetQuery, 'query');
+  t.equal(lastParameters[0].params.facetName, 'facet');
+  t.equal(lastParameters[0].params.highlightPreTag, 'HIGHLIGHT>');
+  t.equal(lastParameters[0].params.highlightPostTag, '<HIGHLIGHT');
+
+  t.end();
 });
 
-test('searchForFacetValues calls the initIndex method if no client method', function(t) {
-  t.plan(1);
-
-  var indexSearchForFacetValuesCalled = 0;
-
+test('client.searchForFacetValues can override the current search state', function(t) {
+  var lastParameters = null;
   var fakeClient = {
     addAlgoliaAgent: function() {},
-    initIndex: function() {
-      return {
-        searchForFacetValues: function() {
-          indexSearchForFacetValuesCalled++;
-          return Promise.resolve({});
-        }
-      };
+    searchForFacetValues: function() {
+      lastParameters = arguments[0];
+      return Promise.resolve({});
     }
   };
 
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  helper.searchForFacetValues('facet', 'query', 1).then(function() {
-    t.equal(indexSearchForFacetValuesCalled, 1);
-    t.end();
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    highlightPreTag: 'HIGHLIGHT>',
+    highlightPostTag: '<HIGHLIGHT',
+    query: 'iphone'
   });
+
+  helper.searchForFacetValues('facet', 'query', 75, {
+    query: undefined,
+    highlightPreTag: 'highlightTag'
+  });
+
+  t.notOk(lastParameters[0].hasOwnProperty('query'));
+  t.equal(lastParameters[0].indexName, 'index');
+  t.equal(lastParameters[0].params.facetQuery, 'query');
+  t.equal(lastParameters[0].params.facetName, 'facet');
+  t.equal(lastParameters[0].params.highlightPreTag, 'highlightTag');
+  t.equal(lastParameters[0].params.highlightPostTag, '<HIGHLIGHT');
+
+  t.end();
 });

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -70,3 +70,60 @@ test('searchForFacetValues can override the current search state', function(t) {
 
   t.end();
 });
+
+test('searchForFacetValues calls the client method over the initIndex method', function(t) {
+  t.plan(2);
+
+  var indexSearchForFacetValuesCalled = 0;
+  var clientSearchForFacetValuesCalled = 0;
+
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    searchForFacetValues: function() {
+      clientSearchForFacetValuesCalled++;
+      return Promise.resolve({});
+    },
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          indexSearchForFacetValuesCalled++;
+          return Promise.resolve({});
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index');
+
+  helper.searchForFacetValues('facet', 'query', 1).then(function() {
+    t.equal(clientSearchForFacetValuesCalled, 1, 'client called');
+    t.equal(indexSearchForFacetValuesCalled, 0, 'index not called');
+
+    t.end();
+  });
+});
+
+test('searchForFacetValues calls the initIndex method if no client method', function(t) {
+  t.plan(1);
+
+  var indexSearchForFacetValuesCalled = 0;
+
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    initIndex: function() {
+      return {
+        searchForFacetValues: function() {
+          indexSearchForFacetValuesCalled++;
+          return Promise.resolve({});
+        }
+      };
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index');
+
+  helper.searchForFacetValues('facet', 'query', 1).then(function() {
+    t.equal(indexSearchForFacetValuesCalled, 1);
+    t.end();
+  });
+});


### PR DESCRIPTION
This PR adds usage of `client.searchForFacetValues(query[])` over `client.initIndex('indexName').searchForFacetValues(query)` when available.

Related feature in the client: algolia/algoliasearch-client-javascript#677