### PR TITLE
refactor(lodash): don't use lodash/isarray

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -10,7 +10,6 @@ var reduce = require('lodash/reduce');
 var omit = require('lodash/omit');
 var indexOf = require('lodash/indexOf');
 var isNaN = require('lodash/isNaN');
-var isArray = require('lodash/isArray');
 var isEmpty = require('lodash/isEmpty');
 var isEqual = require('lodash/isEqual');
 var isUndefined = require('lodash/isUndefined');
@@ -529,7 +528,7 @@ SearchParameters._parseNumbers = function(partialState) {
       numericRefinements[attribute] = {};
       forEach(operators, function(values, operator) {
         var parsedValues = map(values, function(v) {
-          if (isArray(v)) {
+          if (Array.isArray(v)) {
             return map(v, function(vPrime) {
               if (isString(vPrime)) {
                 return parseFloat(vPrime);

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -15,7 +15,6 @@ var orderBy = require('lodash/orderBy');
 var defaults = require('lodash/defaults');
 var merge = require('lodash/merge');
 
-var isArray = require('lodash/isArray');
 var isFunction = require('lodash/isFunction');
 
 var partial = require('lodash/partial');
@@ -648,15 +647,15 @@ SearchResults.prototype.getFacetValues = function(attribute, opts) {
 
   var options = defaults({}, opts, {sortBy: SearchResults.DEFAULT_SORT});
 
-  if (isArray(options.sortBy)) {
+  if (Array.isArray(options.sortBy)) {
     var order = formatSort(options.sortBy, SearchResults.DEFAULT_SORT);
-    if (isArray(facetValues)) {
+    if (Array.isArray(facetValues)) {
       return orderBy(facetValues, order[0], order[1]);
     }
     // If facetValues is not an array, it's an object thus a hierarchical facet object
     return recSort(partialRight(orderBy, order[0], order[1]), facetValues);
   } else if (isFunction(options.sortBy)) {
-    if (isArray(facetValues)) {
+    if (Array.isArray(facetValues)) {
       return facetValues.sort(options.sortBy);
     }
     // If facetValues is not an array, it's an object thus a hierarchical facet object

--- a/src/functions/valToNumber.js
+++ b/src/functions/valToNumber.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var map = require('lodash/map');
-var isArray = require('lodash/isArray');
 var isNumber = require('lodash/isNumber');
 var isString = require('lodash/isString');
 function valToNumber(v) {
@@ -9,7 +8,7 @@ function valToNumber(v) {
     return v;
   } else if (isString(v)) {
     return parseFloat(v);
-  } else if (isArray(v)) {
+  } else if (Array.isArray(v)) {
     return map(v, valToNumber);
   }
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -4,7 +4,6 @@ var forEach = require('lodash/forEach');
 var map = require('lodash/map');
 var reduce = require('lodash/reduce');
 var merge = require('lodash/merge');
-var isArray = require('lodash/isArray');
 
 var requestBuilder = {
   /**
@@ -141,7 +140,7 @@ var requestBuilder = {
       forEach(operators, function(values, operator) {
         if (facetName !== attribute) {
           forEach(values, function(value) {
-            if (isArray(value)) {
+            if (Array.isArray(value)) {
               var vs = map(value, function(v) {
                 return attribute + operator + v;
               });

--- a/src/url.js
+++ b/src/url.js
@@ -19,7 +19,6 @@ var mapKeys = require('lodash/mapKeys');
 var mapValues = require('lodash/mapValues');
 var isString = require('lodash/isString');
 var isPlainObject = require('lodash/isPlainObject');
-var isArray = require('lodash/isArray');
 var isEmpty = require('lodash/isEmpty');
 var invert = require('lodash/invert');
 
@@ -29,7 +28,7 @@ function recursiveEncode(input) {
   if (isPlainObject(input)) {
     return mapValues(input, recursiveEncode);
   }
-  if (isArray(input)) {
+  if (Array.isArray(input)) {
     return map(input, recursiveEncode);
   }
   if (isString(input)) {


### PR DESCRIPTION
This function is deprecated, and all it exports is Array.isArray anyway.

Won't have a significant impact on bundle size, but it's at least less to think about :)

Array.isArray is supported in IE9+ as we do with the rest of the helper (and we already used it in some places)