### PR TITLE
chore(lodash): remove isNaN

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -9,7 +9,6 @@ var map = require('lodash/map');
 var reduce = require('lodash/reduce');
 var omit = require('lodash/omit');
 var indexOf = require('lodash/indexOf');
-var isNaN = require('lodash/isNaN');
 var isArray = require('lodash/isArray');
 var isEmpty = require('lodash/isEmpty');
 var isEqual = require('lodash/isEqual');
@@ -509,7 +508,7 @@ SearchParameters._parseNumbers = function(partialState) {
     var value = partialState[k];
     if (isString(value)) {
       var parsedValue = parseFloat(value);
-      numbers[k] = isNaN(parsedValue) ? value : parsedValue;
+      numbers[k] = Number.isNaN(parsedValue) ? value : parsedValue;
     }
   });
 


### PR DESCRIPTION
_.isNaN behaves like Number.isNaN according to the docs: https://lodash.com/docs#isNaN

and Number.isNaN is supported where we want it: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN

Also a really small impact, but quickly saw it while researching the isArray situation