### PR TITLE
fix(algoliasearch): avoid mutate the client response

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1253,7 +1253,7 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
 
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
-  var results = content.results;
+  var results = content.results.slice();
   forEach(states, function(s) {
     var state = s.state;
     var queriesCount = s.queriesCount;

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -80,6 +80,29 @@ test('Search should call the algolia client according to the number of refinemen
   helper.search('');
 });
 
+test('Search should not mutate the original client response', function(t) {
+  var testData = require('./search.testdata.js')();
+
+  var client = algoliaSearch('dsf', 'dsfdf');
+  var mock = sinon.mock(client);
+
+  mock.expects('search').once().resolves(testData.response);
+
+  var helper = algoliasearchHelper(client, 'test_hotels-node');
+
+  var originalResponseLength = testData.response.results.length;
+
+  helper.on('result', function() {
+    var currentResponseLength = testData.response.results.length;
+
+    t.equal(currentResponseLength, originalResponseLength);
+
+    t.end();
+  });
+
+  helper.search('');
+});
+
 test('no mutating methods should trigger a search', function(t) {
   var client = algoliaSearch('dsf', 'dsfdf');
   sinon.mock(client);


### PR DESCRIPTION
**Summary**

With the latest client (`3.28.x`) we can now cache the request rather than the response (see [#694](https://github.com/algolia/algoliasearch-client-javascript/pull/694)) This new option is disabled by default. When it's enabled the shape of the cache is a bit different than before:

```ts
type Response = {
  body: object;
  responseText: string;
};

type Cache = {
  [cacheID: string]: Promise<Response>;
};
```

With the body inside the cache when we update its reference (mutate it) we also modify the value in the cache. It doesn't have an impact on the next response serve by the client because we don't use the `body` for the cached requests. We use the `responseText` in that way we always return the original response. But in case the `body` is modified the we have an inconsistencies between the two. This is what happen with the helper, in [`_dispatchAlgloliaResponse`](https://github.com/algolia/algoliasearch-helper-js/blob/develop/src/algoliasearch.helper.js#L1261) we mutate the original response of the client. IMO we should never modify the original response.

This PR solve this issue by doing a shallow copy of the response before calling `splice` on it. It does not prevent the update of the content but at least the results remain the same.

In the following example the helper trigger a search on each `input` event. On each search we log the value of the `body`. This is value is either read from the response or the cache. The first and the third log should be exactly the same since it's the same query.

**Before**

![before](https://user-images.githubusercontent.com/6513513/41536368-b37db336-7305-11e8-93de-38302153b5ff.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/41536378-ba0018f2-7305-11e8-8c59-2aaa134d6ead.gif)