### PR TITLE
feat(sffv): throw an error if it's called and the client doesn't have the functions

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -280,6 +280,14 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * @return {promise.<FacetSearchResult>} the results of the search
  */
 AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits, userState) {
+  if (
+    typeof this.client.searchForFacetValues !== 'function' &&
+    typeof this.client.initIndex !== 'function'
+  ) {
+    throw new Error(
+      'search for facet values (searchable) was called, but this client does not have a function client.searchForFacetValues or client.initIndex(index).searchForFacetValues'
+    );
+  }
   var state = this.state.setQueryParameters(userState || {});
   var isDisjunctive = state.isDisjunctiveFacet(facet);
   var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state);

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -236,3 +236,22 @@ test('client.searchForFacetValues can override the current search state', functi
 
   t.end();
 });
+
+test('an error will be thrown if the client does not contain .searchForFacetValues', function(t) {
+  var fakeClient = {
+    search() { return Promise.resolve({}); }
+  };
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    highlightPreTag: 'HIGHLIGHT>',
+    highlightPostTag: '<HIGHLIGHT',
+    query: 'iphone'
+  });
+
+  t.throws(function() {
+    helper.searchForFacetValues('facet', 'query', 75, {
+      query: undefined,
+      highlightPreTag: 'highlightTag'
+    });
+  }, /searchable/);
+  t.end();
+});


### PR DESCRIPTION
We will throw an error if `client.searchForFacetValues` is not a function and `client.initIndex` neither. We won't explicitly test if `client.initIndex(...).searchForFacetValues` is there, but that's the old signature anyway, so it doesn't explicitly need this clearer error. We also don't assert that they are returning Promises, but i haven't seen that problem yet, so i don't think it's necessary to throw a specific error there.