### PR TITLE
docs: fix typo on hierarchical facets

### DIFF
--- a/documentation-src/metalsmith/content/concepts.md
+++ b/documentation-src/metalsmith/content/concepts.md
@@ -151,7 +151,7 @@ hierarchy of facet values.
 ```
 
 Since this is a feature built on top of the Algolia API, we expect the dataset to
-follow a hierachical notation ([see the configuration](reference.html#hierarchical-facets)).
+follow a hierarchical notation ([see the configuration](reference.html#hierarchical-facets)).
 
 ## Special capabilities
 


### PR DESCRIPTION
Added a missing "r" to hierarchical facets, as pointed out from a customer: https://secure.helpscout.net/conversation/804189820/129600?folderId=1106367