### PR TITLE
chore(build): add source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "1.10.3",
     "eslint-config-airbnb": "0.0.8",
     "eslint-config-algolia": "3.0.0",
+    "exorcist": "^1.0.1",
     "gh-pages": "1.0.0",
     "gulp": "3.9.1",
     "gulp-cli": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "1.10.3",
     "eslint-config-airbnb": "0.0.8",
     "eslint-config-algolia": "3.0.0",
-    "exorcist": "^1.0.1",
+    "exorcist": "1.0.1",
     "gh-pages": "1.0.0",
     "gulp": "3.9.1",
     "gulp-cli": "1.3.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,12 +12,20 @@ bundle='algoliasearch.helper'
 
 echo "Build"
 
-browserify index.js -s algoliasearchHelper --debug | exorcist dist/algoliasearch.helper.js.map > dist/algoliasearch.helper.js
+browserify index.js \
+  -s algoliasearchHelper \
+  --debug | \
+  exorcist dist/algoliasearch.helper.js.map > dist/algoliasearch.helper.js
 
 echo "..Minify"
 
-uglifyjs dist/algoliasearch.helper.js --mangle --compress=warnings=false --in-source-map "dist/algoliasearch.helper.js.map" --source-map "dist/algoliasearch.helper.min.js.map" --output dist/algoliasearch.helper.min.js
+uglifyjs dist/algoliasearch.helper.js \
+  --mangle \
+  --compress=warnings=false \
+  --in-source-map "dist/algoliasearch.helper.js.map" \
+  --source-map "dist/algoliasearch.helper.min.js.map" \
+  --output dist/algoliasearch.helper.min.js
 
 echo '..Gzipped file size'
 
-echo "${bundle}.min.js gzipped will weight" $(cat dist/"${bundle}".min.js | gzip -9 | wc -c | pretty-bytes)
+echo "${bundle}.min.js gzipped will weigh" $(cat dist/"${bundle}".min.js | gzip -9 | wc -c | pretty-bytes)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,11 +12,11 @@ bundle='algoliasearch.helper'
 
 echo "Build"
 
-browserify index.js -s algoliasearchHelper -o dist/algoliasearch.helper.js
+browserify index.js -s algoliasearchHelper --debug | exorcist dist/algoliasearch.helper.js.map > dist/algoliasearch.helper.js
 
 echo "..Minify"
 
-uglifyjs dist/algoliasearch.helper.js --mangle --compress=warnings=false > dist/algoliasearch.helper.min.js
+uglifyjs dist/algoliasearch.helper.js --mangle --compress=warnings=false --in-source-map "dist/algoliasearch.helper.js.map" --source-map "dist/algoliasearch.helper.min.js.map" --output dist/algoliasearch.helper.min.js
 
 echo '..Gzipped file size'
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ bundle='algoliasearch.helper'
 echo "Build"
 
 browserify index.js \
-  -s algoliasearchHelper \
+  --standalone algoliasearchHelper \
   --debug | \
   exorcist dist/algoliasearch.helper.js.map > dist/algoliasearch.helper.js
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,6 +4229,16 @@ exit-hook@^1.0.0:
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
   integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
+exorcist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exorcist/-/exorcist-1.0.1.tgz#79316e3c4885845490f7bb405c0e5b5db1167c52"
+  integrity sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=
+  dependencies:
+    is-stream "~1.1.0"
+    minimist "0.0.5"
+    mkdirp "~0.5.1"
+    mold-source-map "~0.4.0"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -6346,7 +6356,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0, is-stream@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -7890,6 +7900,11 @@ minimatch@^2.0.1:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimist@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
+  integrity sha1-16oye87PUY+RBqxrjwA/o7zqhWY=
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -7952,6 +7967,14 @@ module-deps@^4.0.2, module-deps@^4.0.8:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+mold-source-map@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mold-source-map/-/mold-source-map-0.4.0.tgz#cf67e0b31c47ab9badb5c9c25651862127bb8317"
+  integrity sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=
+  dependencies:
+    convert-source-map "^1.1.0"
+    through "~2.2.7"
 
 mout@^0.11.0:
   version "0.11.1"
@@ -11309,6 +11332,11 @@ through@2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.4.tgz#495e40e8d8a8eaebc7c275ea88c2b8fc14c56455"
   integrity sha1-SV5A6Nio6uvHwnXqiMK4/BTFZFU=
+
+through@~2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
+  integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
 
 thunkify-wrap@~1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,7 +4229,7 @@ exit-hook@^1.0.0:
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
   integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
-exorcist@^1.0.1:
+exorcist@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/exorcist/-/exorcist-1.0.1.tgz#79316e3c4885845490f7bb405c0e5b5db1167c52"
   integrity sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=


### PR DESCRIPTION
this creates two new files:

```
//# sourceMappingURL=algoliasearch.helper.js.map
//# sourceMappingURL=dist/algoliasearch.helper.min.js.map
```

- add exorcist for having the source map via browserify (otherwise only inline)
- add appropriate options for uglifyJS

Further nothing is changed. This setup is compatible with `source-map-explorer`

IFW-622