### PR TITLE
refactor(addAgent): remove duplicate code

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -118,7 +118,7 @@ var version = require('./version');
  * just an object containing the properties you need from it.
  */
 function AlgoliaSearchHelper(client, index, options) {
-  if (client.addAlgoliaAgent) {
+  if (typeof client.addAlgoliaAgent === 'function') {
     client.addAlgoliaAgent('JS Helper (' + version + ')');
   }
 
@@ -1330,7 +1330,7 @@ AlgoliaSearchHelper.prototype.clearCache = function() {
 AlgoliaSearchHelper.prototype.setClient = function(newClient) {
   if (this.client === newClient) return this;
 
-  if (newClient.addAlgoliaAgent) {
+  if (typeof newClient.addAlgoliaAgent === 'function') {
     newClient.addAlgoliaAgent('JS Helper (' + version + ')');
   }
   this.client = newClient;

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -118,7 +118,7 @@ var version = require('./version');
  * just an object containing the properties you need from it.
  */
 function AlgoliaSearchHelper(client, index, options) {
-  if (client.addAlgoliaAgent && !doesClientAgentContainsHelper(client)) {
+  if (client.addAlgoliaAgent) {
     client.addAlgoliaAgent('JS Helper (' + version + ')');
   }
 
@@ -1330,7 +1330,7 @@ AlgoliaSearchHelper.prototype.clearCache = function() {
 AlgoliaSearchHelper.prototype.setClient = function(newClient) {
   if (this.client === newClient) return this;
 
-  if (newClient.addAlgoliaAgent && !doesClientAgentContainsHelper(newClient)) {
+  if (newClient.addAlgoliaAgent) {
     newClient.addAlgoliaAgent('JS Helper (' + version + ')');
   }
   this.client = newClient;
@@ -1407,17 +1407,5 @@ AlgoliaSearchHelper.prototype.hasPendingRequests = function() {
  * @property {string} value the string use to filter the attribute
  * @property {string} type the type of filter: 'conjunctive', 'disjunctive', 'exclude'
  */
-
-
-/*
- * This function tests if the _ua parameter of the client
- * already contains the JS Helper UA
- */
-function doesClientAgentContainsHelper(client) {
-  // this relies on JS Client internal variable, this might break if implementation changes
-  var currentAgent = client._ua;
-  return !currentAgent ? false :
-    currentAgent.indexOf('JS Helper') !== -1;
-}
 
 module.exports = AlgoliaSearchHelper;


### PR DESCRIPTION
could be considered as a breaking change if you're using a client version < 3.20.4 https://github.com/algolia/algoliasearch-client-javascript/commit/77b97629dbc692401c07b0d03854d6a93c57022c (and > 3.8.0, when addAlgoliaAgent was added https://github.com/algolia/algoliasearch-client-javascript/commit/3370fa48bc5dc66a84769dd19160be47597eb21e)

In the case of the older client being used, the agent will simply be injected multiple times, as was before that fix was added
