### PR TITLE
chore(Travis): build all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
 script:
 - yarn test:ci
 - yarn doc
-branches:
-  only:
-  - master
-  - develop
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
The current Travis setup build only the `develop` & `master` branch. It's annoying with stacked PRs because the CI does not run on those. This PR removes the restrictions and build all the branches that are pushed on the project.