### PR TITLE
feat: implement dedicated reset page method

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1331,6 +1331,20 @@ SearchParameters.prototype = {
   },
 
   /**
+   * Returns a new instance with the page reset. Two scenarios possible:
+   * the page is omitted -> return the given instance
+   * the page is set -> return a new instance with a page of 0
+   * @return {SearchParameters} a new updated instance
+   */
+  resetPage: function() {
+    if (this.page === undefined) {
+      return this;
+    }
+
+    return this.setPage(0);
+  },
+
+  /**
    * Returns an object with only the selected attributes.
    * @param {string[]} filters filters to retrieve only a subset of the state. It
    * accepts strings that can be either attributes of the SearchParameters (e.g. hitsPerPage)

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -329,7 +329,7 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setQuery = function(q) {
-  this._change(this.state.setPage(0).setQuery(q));
+  this._change(this.state.resetPage().setQuery(q));
   return this;
 };
 
@@ -357,7 +357,7 @@ AlgoliaSearchHelper.prototype.setQuery = function(q) {
  * }).search();
  */
 AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
-  this._change(this.state.setPage(0).clearRefinements(name));
+  this._change(this.state.resetPage().clearRefinements(name));
   return this;
 };
 
@@ -370,7 +370,7 @@ AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.clearTags = function() {
-  this._change(this.state.setPage(0).clearTags());
+  this._change(this.state.resetPage().clearTags());
   return this;
 };
 
@@ -386,7 +386,7 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).addDisjunctiveFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addDisjunctiveFacetRefinement(facet, value));
   return this;
 };
 
@@ -411,7 +411,7 @@ AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function() {
  * @fires change
  */
 AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).addHierarchicalFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addHierarchicalFacetRefinement(facet, value));
   return this;
 };
 
@@ -428,7 +428,7 @@ AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, v
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.setPage(0).addNumericRefinement(attribute, operator, value));
+  this._change(this.state.resetPage().addNumericRefinement(attribute, operator, value));
   return this;
 };
 
@@ -444,7 +444,7 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operato
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).addFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addFacetRefinement(facet, value));
   return this;
 };
 
@@ -468,7 +468,7 @@ AlgoliaSearchHelper.prototype.addRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetExclusion = function(facet, value) {
-  this._change(this.state.setPage(0).addExcludeRefinement(facet, value));
+  this._change(this.state.resetPage().addExcludeRefinement(facet, value));
   return this;
 };
 
@@ -490,7 +490,7 @@ AlgoliaSearchHelper.prototype.addExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addTag = function(tag) {
-  this._change(this.state.setPage(0).addTagRefinement(tag));
+  this._change(this.state.resetPage().addTagRefinement(tag));
   return this;
 };
 
@@ -513,7 +513,7 @@ AlgoliaSearchHelper.prototype.addTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.setPage(0).removeNumericRefinement(attribute, operator, value));
+  this._change(this.state.resetPage().removeNumericRefinement(attribute, operator, value));
   return this;
 };
 
@@ -532,7 +532,7 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, oper
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).removeDisjunctiveFacetRefinement(facet, value));
+  this._change(this.state.resetPage().removeDisjunctiveFacetRefinement(facet, value));
   return this;
 };
 
@@ -552,7 +552,7 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet) {
-  this._change(this.state.setPage(0).removeHierarchicalFacetRefinement(facet));
+  this._change(this.state.resetPage().removeHierarchicalFacetRefinement(facet));
 
   return this;
 };
@@ -572,7 +572,7 @@ AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).removeFacetRefinement(facet, value));
+  this._change(this.state.resetPage().removeFacetRefinement(facet, value));
   return this;
 };
 
@@ -598,7 +598,7 @@ AlgoliaSearchHelper.prototype.removeRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetExclusion = function(facet, value) {
-  this._change(this.state.setPage(0).removeExcludeRefinement(facet, value));
+  this._change(this.state.resetPage().removeExcludeRefinement(facet, value));
   return this;
 };
 
@@ -620,7 +620,7 @@ AlgoliaSearchHelper.prototype.removeExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeTag = function(tag) {
-  this._change(this.state.setPage(0).removeTagRefinement(tag));
+  this._change(this.state.resetPage().removeTagRefinement(tag));
   return this;
 };
 
@@ -636,7 +636,7 @@ AlgoliaSearchHelper.prototype.removeTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetExclusion = function(facet, value) {
-  this._change(this.state.setPage(0).toggleExcludeFacetRefinement(facet, value));
+  this._change(this.state.resetPage().toggleExcludeFacetRefinement(facet, value));
   return this;
 };
 
@@ -681,7 +681,7 @@ AlgoliaSearchHelper.prototype.toggleRefinement = function(facet, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetRefinement = function(facet, value) {
-  this._change(this.state.setPage(0).toggleFacetRefinement(facet, value));
+  this._change(this.state.resetPage().toggleFacetRefinement(facet, value));
   return this;
 };
 
@@ -703,7 +703,7 @@ AlgoliaSearchHelper.prototype.toggleRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleTag = function(tag) {
-  this._change(this.state.setPage(0).toggleTagRefinement(tag));
+  this._change(this.state.resetPage().toggleTagRefinement(tag));
   return this;
 };
 
@@ -776,7 +776,7 @@ AlgoliaSearchHelper.prototype.setPage = setCurrentPage;
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setIndex = function(name) {
-  this._change(this.state.setPage(0).setIndex(name));
+  this._change(this.state.resetPage().setIndex(name));
   return this;
 };
 
@@ -798,7 +798,7 @@ AlgoliaSearchHelper.prototype.setIndex = function(name) {
  * helper.setQueryParameter('hitsPerPage', 20).search();
  */
 AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
-  this._change(this.state.setPage(0).setQueryParameter(parameter, value));
+  this._change(this.state.resetPage().setQueryParameter(parameter, value));
   return this;
 };
 

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -329,7 +329,11 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setQuery = function(q) {
-  this._change(this.state.resetPage().setQuery(q), true);
+  this._change({
+    state: this.state.resetPage().setQuery(q),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -357,7 +361,11 @@ AlgoliaSearchHelper.prototype.setQuery = function(q) {
  * }).search();
  */
 AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
-  this._change(this.state.resetPage().clearRefinements(name), true);
+  this._change({
+    state: this.state.resetPage().clearRefinements(name),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -370,7 +378,11 @@ AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.clearTags = function() {
-  this._change(this.state.resetPage().clearTags(), true);
+  this._change({
+    state: this.state.resetPage().clearTags(),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -386,7 +398,11 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addDisjunctiveFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().addDisjunctiveFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -411,7 +427,11 @@ AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function() {
  * @fires change
  */
 AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addHierarchicalFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().addHierarchicalFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -428,7 +448,11 @@ AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, v
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.resetPage().addNumericRefinement(attribute, operator, value), true);
+  this._change({
+    state: this.state.resetPage().addNumericRefinement(attribute, operator, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -444,7 +468,11 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operato
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().addFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -468,7 +496,11 @@ AlgoliaSearchHelper.prototype.addRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().addExcludeRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().addExcludeRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -490,7 +522,11 @@ AlgoliaSearchHelper.prototype.addExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addTag = function(tag) {
-  this._change(this.state.resetPage().addTagRefinement(tag), true);
+  this._change({
+    state: this.state.resetPage().addTagRefinement(tag),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -513,7 +549,11 @@ AlgoliaSearchHelper.prototype.addTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.resetPage().removeNumericRefinement(attribute, operator, value), true);
+  this._change({
+    state: this.state.resetPage().removeNumericRefinement(attribute, operator, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -532,7 +572,11 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, oper
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().removeDisjunctiveFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().removeDisjunctiveFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -552,7 +596,10 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet) {
-  this._change(this.state.resetPage().removeHierarchicalFacetRefinement(facet), true);
+  this._change({
+    state: this.state.resetPage().removeHierarchicalFacetRefinement(facet),
+    isPageReset: true
+  });
 
   return this;
 };
@@ -572,7 +619,11 @@ AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().removeFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().removeFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -598,7 +649,11 @@ AlgoliaSearchHelper.prototype.removeRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().removeExcludeRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().removeExcludeRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -620,7 +675,11 @@ AlgoliaSearchHelper.prototype.removeExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeTag = function(tag) {
-  this._change(this.state.resetPage().removeTagRefinement(tag), true);
+  this._change({
+    state: this.state.resetPage().removeTagRefinement(tag),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -636,7 +695,11 @@ AlgoliaSearchHelper.prototype.removeTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().toggleExcludeFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().toggleExcludeFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -681,7 +744,11 @@ AlgoliaSearchHelper.prototype.toggleRefinement = function(facet, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().toggleFacetRefinement(facet, value), true);
+  this._change({
+    state: this.state.resetPage().toggleFacetRefinement(facet, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -703,7 +770,11 @@ AlgoliaSearchHelper.prototype.toggleRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleTag = function(tag) {
-  this._change(this.state.resetPage().toggleTagRefinement(tag), true);
+  this._change({
+    state: this.state.resetPage().toggleTagRefinement(tag),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -741,7 +812,10 @@ AlgoliaSearchHelper.prototype.previousPage = function() {
 function setCurrentPage(page) {
   if (page < 0) throw new Error('Page requested below 0.');
 
-  this._change(this.state.setPage(page));
+  this._change({
+    state: this.state.setPage(page),
+    isPageReset: false
+  });
 
   return this;
 }
@@ -776,7 +850,11 @@ AlgoliaSearchHelper.prototype.setPage = setCurrentPage;
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setIndex = function(name) {
-  this._change(this.state.resetPage().setIndex(name), true);
+  this._change({
+    state: this.state.resetPage().setIndex(name),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -798,7 +876,11 @@ AlgoliaSearchHelper.prototype.setIndex = function(name) {
  * helper.setQueryParameter('hitsPerPage', 20).search();
  */
 AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
-  this._change(this.state.resetPage().setQueryParameter(parameter, value), true);
+  this._change({
+    state: this.state.resetPage().setQueryParameter(parameter, value),
+    isPageReset: true
+  });
+
   return this;
 };
 
@@ -810,7 +892,11 @@ AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setState = function(newState) {
-  this._change(SearchParameters.make(newState));
+  this._change({
+    state: SearchParameters.make(newState),
+    isPageReset: false
+  });
+
   return this;
 };
 
@@ -1238,12 +1324,18 @@ AlgoliaSearchHelper.prototype._hasDisjunctiveRefinements = function(facet) {
     this.state.disjunctiveRefinements[facet].length > 0;
 };
 
-AlgoliaSearchHelper.prototype._change = function(newState, resetPage) {
-  var isPageReset = resetPage || false;
+AlgoliaSearchHelper.prototype._change = function(event) {
+  var state = event.state;
+  var isPageReset = event.isPageReset;
 
-  if (newState !== this.state) {
-    this.state = newState;
-    this.emit('change', this.state, this.lastResults, isPageReset);
+  if (state !== this.state) {
+    this.state = state;
+
+    this.emit('change', {
+      state: this.state,
+      results: this.lastResults,
+      isPageReset: isPageReset
+    });
   }
 };
 

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -329,7 +329,7 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setQuery = function(q) {
-  this._change(this.state.resetPage().setQuery(q));
+  this._change(this.state.resetPage().setQuery(q), true);
   return this;
 };
 
@@ -357,7 +357,7 @@ AlgoliaSearchHelper.prototype.setQuery = function(q) {
  * }).search();
  */
 AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
-  this._change(this.state.resetPage().clearRefinements(name));
+  this._change(this.state.resetPage().clearRefinements(name), true);
   return this;
 };
 
@@ -370,7 +370,7 @@ AlgoliaSearchHelper.prototype.clearRefinements = function(name) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.clearTags = function() {
-  this._change(this.state.resetPage().clearTags());
+  this._change(this.state.resetPage().clearTags(), true);
   return this;
 };
 
@@ -386,7 +386,7 @@ AlgoliaSearchHelper.prototype.clearTags = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addDisjunctiveFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addDisjunctiveFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -411,7 +411,7 @@ AlgoliaSearchHelper.prototype.addDisjunctiveRefine = function() {
  * @fires change
  */
 AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addHierarchicalFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addHierarchicalFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -428,7 +428,7 @@ AlgoliaSearchHelper.prototype.addHierarchicalFacetRefinement = function(facet, v
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.resetPage().addNumericRefinement(attribute, operator, value));
+  this._change(this.state.resetPage().addNumericRefinement(attribute, operator, value), true);
   return this;
 };
 
@@ -444,7 +444,7 @@ AlgoliaSearchHelper.prototype.addNumericRefinement = function(attribute, operato
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().addFacetRefinement(facet, value));
+  this._change(this.state.resetPage().addFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -468,7 +468,7 @@ AlgoliaSearchHelper.prototype.addRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().addExcludeRefinement(facet, value));
+  this._change(this.state.resetPage().addExcludeRefinement(facet, value), true);
   return this;
 };
 
@@ -490,7 +490,7 @@ AlgoliaSearchHelper.prototype.addExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.addTag = function(tag) {
-  this._change(this.state.resetPage().addTagRefinement(tag));
+  this._change(this.state.resetPage().addTagRefinement(tag), true);
   return this;
 };
 
@@ -513,7 +513,7 @@ AlgoliaSearchHelper.prototype.addTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, operator, value) {
-  this._change(this.state.resetPage().removeNumericRefinement(attribute, operator, value));
+  this._change(this.state.resetPage().removeNumericRefinement(attribute, operator, value), true);
   return this;
 };
 
@@ -532,7 +532,7 @@ AlgoliaSearchHelper.prototype.removeNumericRefinement = function(attribute, oper
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeDisjunctiveFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().removeDisjunctiveFacetRefinement(facet, value));
+  this._change(this.state.resetPage().removeDisjunctiveFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -552,7 +552,7 @@ AlgoliaSearchHelper.prototype.removeDisjunctiveRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet) {
-  this._change(this.state.resetPage().removeHierarchicalFacetRefinement(facet));
+  this._change(this.state.resetPage().removeHierarchicalFacetRefinement(facet), true);
 
   return this;
 };
@@ -572,7 +572,7 @@ AlgoliaSearchHelper.prototype.removeHierarchicalFacetRefinement = function(facet
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().removeFacetRefinement(facet, value));
+  this._change(this.state.resetPage().removeFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -598,7 +598,7 @@ AlgoliaSearchHelper.prototype.removeRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().removeExcludeRefinement(facet, value));
+  this._change(this.state.resetPage().removeExcludeRefinement(facet, value), true);
   return this;
 };
 
@@ -620,7 +620,7 @@ AlgoliaSearchHelper.prototype.removeExclude = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.removeTag = function(tag) {
-  this._change(this.state.resetPage().removeTagRefinement(tag));
+  this._change(this.state.resetPage().removeTagRefinement(tag), true);
   return this;
 };
 
@@ -636,7 +636,7 @@ AlgoliaSearchHelper.prototype.removeTag = function(tag) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetExclusion = function(facet, value) {
-  this._change(this.state.resetPage().toggleExcludeFacetRefinement(facet, value));
+  this._change(this.state.resetPage().toggleExcludeFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -681,7 +681,7 @@ AlgoliaSearchHelper.prototype.toggleRefinement = function(facet, value) {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleFacetRefinement = function(facet, value) {
-  this._change(this.state.resetPage().toggleFacetRefinement(facet, value));
+  this._change(this.state.resetPage().toggleFacetRefinement(facet, value), true);
   return this;
 };
 
@@ -703,7 +703,7 @@ AlgoliaSearchHelper.prototype.toggleRefine = function() {
  * @chainable
  */
 AlgoliaSearchHelper.prototype.toggleTag = function(tag) {
-  this._change(this.state.resetPage().toggleTagRefinement(tag));
+  this._change(this.state.resetPage().toggleTagRefinement(tag), true);
   return this;
 };
 
@@ -776,7 +776,7 @@ AlgoliaSearchHelper.prototype.setPage = setCurrentPage;
  * @chainable
  */
 AlgoliaSearchHelper.prototype.setIndex = function(name) {
-  this._change(this.state.resetPage().setIndex(name));
+  this._change(this.state.resetPage().setIndex(name), true);
   return this;
 };
 
@@ -798,7 +798,7 @@ AlgoliaSearchHelper.prototype.setIndex = function(name) {
  * helper.setQueryParameter('hitsPerPage', 20).search();
  */
 AlgoliaSearchHelper.prototype.setQueryParameter = function(parameter, value) {
-  this._change(this.state.resetPage().setQueryParameter(parameter, value));
+  this._change(this.state.resetPage().setQueryParameter(parameter, value), true);
   return this;
 };
 
@@ -1238,10 +1238,12 @@ AlgoliaSearchHelper.prototype._hasDisjunctiveRefinements = function(facet) {
     this.state.disjunctiveRefinements[facet].length > 0;
 };
 
-AlgoliaSearchHelper.prototype._change = function(newState) {
+AlgoliaSearchHelper.prototype._change = function(newState, resetPage) {
+  var isPageReset = resetPage || false;
+
   if (newState !== this.state) {
     this.state = newState;
-    this.emit('change', this.state, this.lastResults);
+    this.emit('change', this.state, this.lastResults, isPageReset);
   }
 };
 

--- a/test/datasets/SearchParameters/search.dataset.js
+++ b/test/datasets/SearchParameters/search.dataset.js
@@ -193,11 +193,6 @@ function getData() {
   };
 
   var searchParams = new SearchParameters({
-    // @TODO: at the moment we have to provide a default value for the page, otherwise
-    // some methods reset the page to 0 (because of the reset behavior). This is what
-    // happens: page omit -> page defined with 0. We'll fix those issues with a next PR
-    // that implements a proper reset with the updated structure of the `SearchParameters`.
-    page: 0,
     index: 'test_hotels-node',
     disjunctiveFacets: ['city'],
     disjunctiveFacetsRefinements: {

--- a/test/spec/SearchParameters/resetPage.js
+++ b/test/spec/SearchParameters/resetPage.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const SearchParameters = require('../../../src/SearchParameters');
+
+test('without a previous page it should return the given SearchParameters', () => {
+  const parameters = new SearchParameters();
+  const parametersWithPageReseted = parameters.resetPage();
+
+  expect(parameters).toBe(parametersWithPageReseted);
+  expect(parametersWithPageReseted.page).toBeUndefined();
+});
+
+test('with a previous page of 0 it should return the given SearchParameters', () => {
+  const parameters = new SearchParameters({
+    page: 0
+  });
+
+  const parametersWithPageReseted = parameters.resetPage();
+
+  expect(parameters).toBe(parametersWithPageReseted);
+  expect(parametersWithPageReseted.page).toBe(0);
+});
+
+
+test('with a previous page it should set the page to 0', () => {
+  const parameters = new SearchParameters({
+    page: 5
+  });
+
+  const parametersWithPageReseted = parameters.resetPage();
+
+  expect(parameters).not.toBe(parametersWithPageReseted);
+  expect(parametersWithPageReseted.page).toBe(0);
+});

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -13,6 +13,53 @@ function makeFakeClient() {
   };
 }
 
+test('Change events should be emitted with reset page to true on implicit reset methods', function() {
+  var changed = jest.fn();
+  var fakeClient = makeFakeClient();
+  var helper = algoliaSearchHelper(fakeClient, 'Index');
+
+  helper.on('change', changed);
+
+  expect(changed).toHaveBeenCalledTimes(0);
+
+  // Trigger a page reset
+  helper.setQuery('Apple');
+
+  expect(changed).toHaveBeenCalledTimes(1);
+  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, true);
+
+  // Trigger a page reset
+  helper.setQueryParameter('hitsPerPage', 10);
+
+  expect(changed).toHaveBeenCalledTimes(2);
+  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, true);
+});
+
+test('Change events should be emitted with reset page to false on regular methods', function() {
+  var changed = jest.fn();
+  var fakeClient = makeFakeClient();
+  var helper = algoliaSearchHelper(fakeClient, 'Index');
+
+  helper.on('change', changed);
+
+  expect(changed).toHaveBeenCalledTimes(0);
+
+  // Don't trigger a page reset
+  helper.setPage(22);
+
+  expect(changed).toHaveBeenCalledTimes(1);
+  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, false);
+
+  // Don't trigger a page reset
+  helper.setState({
+    query: 'Apple',
+    page: 22
+  });
+
+  expect(changed).toHaveBeenCalledTimes(2);
+  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, false);
+});
+
 test('Change events should be emitted as soon as the state change, but search should be triggered (refactored)', function() {
   var fakeClient = makeFakeClient();
   var helper = algoliaSearchHelper(fakeClient, 'Index', {

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -26,13 +26,21 @@ test('Change events should be emitted with reset page to true on implicit reset 
   helper.setQuery('Apple');
 
   expect(changed).toHaveBeenCalledTimes(1);
-  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, true);
+  expect(changed).toHaveBeenLastCalledWith({
+    state: expect.any(algoliaSearchHelper.SearchParameters),
+    results: null,
+    isPageReset: true
+  });
 
   // Trigger a page reset
   helper.setQueryParameter('hitsPerPage', 10);
 
   expect(changed).toHaveBeenCalledTimes(2);
-  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, true);
+  expect(changed).toHaveBeenLastCalledWith({
+    state: expect.any(algoliaSearchHelper.SearchParameters),
+    results: null,
+    isPageReset: true
+  });
 });
 
 test('Change events should be emitted with reset page to false on regular methods', function() {
@@ -48,7 +56,11 @@ test('Change events should be emitted with reset page to false on regular method
   helper.setPage(22);
 
   expect(changed).toHaveBeenCalledTimes(1);
-  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, false);
+  expect(changed).toHaveBeenLastCalledWith({
+    state: expect.any(algoliaSearchHelper.SearchParameters),
+    results: null,
+    isPageReset: false
+  });
 
   // Don't trigger a page reset
   helper.setState({
@@ -57,7 +69,11 @@ test('Change events should be emitted with reset page to false on regular method
   });
 
   expect(changed).toHaveBeenCalledTimes(2);
-  expect(changed).toHaveBeenLastCalledWith(expect.any(algoliaSearchHelper.SearchParameters), null, false);
+  expect(changed).toHaveBeenLastCalledWith({
+    state: expect.any(algoliaSearchHelper.SearchParameters),
+    results: null,
+    isPageReset: false
+  });
 });
 
 test('Change events should be emitted as soon as the state change, but search should be triggered (refactored)', function() {

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -74,11 +74,6 @@ test('Change events should only be emitted for meaningful changes', function() {
   var fakeClient = makeFakeClient();
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     query: 'a',
-    // @TODO: at the moment we have to provide a default value for the page, otherwise
-    // some methods reset the page to 0 (because of the reset behavior). This is what
-    // happens: page omit -> page defined with 0. We'll fix those issues with a next PR
-    // that implements a proper reset with the updated structure of the `SearchParameters`.
-    page: 0,
     disjunctiveFacets: ['city'],
     disjunctiveFacetsRefinements: {city: ['Paris']},
     facets: ['tower'],

--- a/test/spec/algoliasearch.helper/searchOnce.js
+++ b/test/spec/algoliasearch.helper/searchOnce.js
@@ -18,11 +18,6 @@ test('searchOnce should call the algolia client according to the number of refin
   var parameters = new SearchParameters({
     disjunctiveFacets: ['city']
   })
-    // @TODO: at the moment we have to provide a default value for the page, otherwise
-    // some methods reset the page to 0 (because of the reset behavior). This is what
-    // happens: page omit -> page defined with 0. We'll fix those issues with a next PR
-    // that implements a proper reset with the updated structure of the `SearchParameters`.
-    .setPage(0)
     .setIndex('test_hotels-node')
     .addDisjunctiveFacetRefinement('city', 'Paris')
     .addDisjunctiveFacetRefinement('city', 'New York');

--- a/test/spec/algoliasearch.helper/setQueryParameter.js
+++ b/test/spec/algoliasearch.helper/setQueryParameter.js
@@ -20,13 +20,7 @@ test('setChange should change the current state', function() {
 });
 
 test('setChange should not change the current state: no real modification', function() {
-  var helper = algoliasearchHelper(fakeClient, null, {
-    // @TODO: at the moment we have to provide a default value for the page, otherwise
-    // some methods reset the page to 0 (because of the reset behavior). This is what
-    // happens: page omit -> page defined with 0. We'll fix those issues with a next PR
-    // that implements a proper reset with the updated structure of the `SearchParameters`.
-    page: 0
-  });
+  var helper = algoliasearchHelper(fakeClient, null, {page: 0});
   var changed = false;
   var initialState = helper.state;
 

--- a/test/spec/algoliasearch.helper/state.js
+++ b/test/spec/algoliasearch.helper/state.js
@@ -14,9 +14,9 @@ test('setState should set the state of the helper and trigger a change event', f
 
   expect(helper.state).toEqual(new SearchParameters(state0));
 
-  helper.on('change', function(newState) {
+  helper.on('change', function(event) {
     expect(helper.state).toEqual(new SearchParameters(state1));
-    expect(newState).toEqual(new SearchParameters(state1));
+    expect(event.state).toEqual(new SearchParameters(state1));
     done();
   });
 


### PR DESCRIPTION
This PR introduces a new internal method on the `SearchParameters` called `resetPage`. This function allows differentiating a "page reset" against a "regular refinement". It wasn't an issue until now because the default value for the page was `0`. We don't have default values anymore, the value is either omit or set to a value. With the previous implementation, a call to a method that resets (implicitly) the page on a `SearchParameters` that doesn't already contain a page it creates the attribute with the value 0. This is not the expected behavior. We want to let parameter without the page.

- page omit: we don't touch the instance
- page present: we reset its value to `0`

We are now able to detect a "page reset" against a "regular refinement". The `change` event now contains an additional argument that provide the information. It allows the subscribers to trigger some specific actions based on that.

```js
const helper = algoliaSearchHelper();

helper.on("change", ({ state, results, isPageReset }) => {
  if (isPageReset) {
    // specific action
  }
});
```