### PR TITLE
refactor(lodash): remove forEach

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -3,7 +3,6 @@
 var keys = require('lodash/keys');
 var intersection = require('lodash/intersection');
 var forOwn = require('lodash/forOwn');
-var forEach = require('lodash/forEach');
 var filter = require('lodash/filter');
 var map = require('lodash/map');
 var reduce = require('lodash/reduce');
@@ -502,7 +501,7 @@ SearchParameters._parseNumbers = function(partialState) {
     'minProximity'
   ];
 
-  forEach(numberKeys, function(k) {
+  numberKeys.forEach(function(k) {
     var value = partialState[k];
     if (typeof value === 'string') {
       var parsedValue = parseFloat(value);
@@ -522,9 +521,11 @@ SearchParameters._parseNumbers = function(partialState) {
 
   if (partialState.numericRefinements) {
     var numericRefinements = {};
-    forEach(partialState.numericRefinements, function(operators, attribute) {
+    Object.keys(partialState.numericRefinements).forEach(function(attribute) {
+      var operators = partialState.numericRefinements[attribute] || {};
       numericRefinements[attribute] = {};
-      forEach(operators, function(values, operator) {
+      Object.keys(operators).forEach(function(operator) {
+        var values = operators[operator];
         var parsedValues = values.map(function(v) {
           if (Array.isArray(v)) {
             return v.map(function(vPrime) {
@@ -556,7 +557,8 @@ SearchParameters._parseNumbers = function(partialState) {
 SearchParameters.make = function makeSearchParameters(newParameters) {
   var instance = new SearchParameters(newParameters);
 
-  forEach(newParameters.hierarchicalFacets, function(facet) {
+  var hierarchicalFacets = newParameters.hierarchicalFacets || [];
+  hierarchicalFacets.forEach(function(facet) {
     if (facet.rootPath) {
       var currentRefinement = instance.getHierarchicalRefinement(facet.name);
 
@@ -904,9 +906,11 @@ SearchParameters.prototype = {
       var newNumericRefinements = reduce(this.numericRefinements, function(memo, operators, key) {
         var operatorList = {};
 
-        forEach(operators, function(values, operator) {
+        operators = operators || {};
+        Object.keys(operators).forEach(function(operator) {
+          var values = operators[operator] || [];
           var outValues = [];
-          forEach(values, function(value) {
+          values.forEach(function(value) {
             var predicateResult = attribute({val: value, op: operator}, key, 'numeric');
             if (!predicateResult) outValues.push(value);
           });
@@ -1595,7 +1599,7 @@ SearchParameters.prototype = {
     return this.mutateMe(function mergeWith(newInstance) {
       var ks = keys(params);
 
-      forEach(ks, function(k) {
+      ks.forEach(function(k) {
         newInstance[k] = parsedParams[k];
       });
 

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -9,7 +9,6 @@ var events = require('events');
 var inherits = require('./functions/inherits');
 
 var flatten = require('lodash/flatten');
-var forEach = require('lodash/forEach');
 var isEmpty = require('lodash/isEmpty');
 
 var url = require('./url');
@@ -306,10 +305,15 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
 
     content = Array.isArray(content) ? content[0] : content;
 
-    content.facetHits = forEach(content.facetHits, function(f) {
-      f.isRefined = isDisjunctive ?
-        state.isDisjunctiveFacetRefined(facet, f.value) :
-        state.isFacetRefined(facet, f.value);
+    content.facetHits = Array.isArray(content.facetHits)
+      ? content.facetHits
+      : [];
+
+    content.facetHits = content.facetHits.map(function(f) {
+      f.isRefined = isDisjunctive
+        ? state.isDisjunctiveFacetRefined(facet, f.value)
+        : state.isFacetRefined(facet, f.value);
+      return f;
     });
 
     return content;
@@ -1130,7 +1134,7 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
   if (this.state.isConjunctiveFacet(facetName)) {
     var conjRefinements = this.state.getConjunctiveRefinements(facetName);
 
-    forEach(conjRefinements, function(r) {
+    conjRefinements.forEach(function(r) {
       refinements.push({
         value: r,
         type: 'conjunctive'
@@ -1139,7 +1143,7 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
 
     var excludeRefinements = this.state.getExcludeRefinements(facetName);
 
-    forEach(excludeRefinements, function(r) {
+    excludeRefinements.forEach(function(r) {
       refinements.push({
         value: r,
         type: 'exclude'
@@ -1148,7 +1152,7 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
   } else if (this.state.isDisjunctiveFacet(facetName)) {
     var disjRefinements = this.state.getDisjunctiveRefinements(facetName);
 
-    forEach(disjRefinements, function(r) {
+    disjRefinements.forEach(function(r) {
       refinements.push({
         value: r,
         type: 'disjunctive'
@@ -1158,7 +1162,9 @@ AlgoliaSearchHelper.prototype.getRefinements = function(facetName) {
 
   var numericRefinements = this.state.getNumericRefinements(facetName);
 
-  forEach(numericRefinements, function(value, operator) {
+  Object.keys(numericRefinements).forEach(function(operator) {
+    var value = numericRefinements[operator];
+
     refinements.push({
       value: value,
       operator: operator,
@@ -1262,7 +1268,8 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results.slice();
-  forEach(states, function(s) {
+
+  states.forEach(function(s) {
     var state = s.state;
     var queriesCount = s.queriesCount;
     var helper = s.helper;


### PR DESCRIPTION

I've been on the safe side and added defaults on places that probably already have defaults.

I didn't remove the `forEach` in URLs, because that file is removed in `next`