### PR TITLE
refactor(searchOnce): emit object

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -203,7 +203,9 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
 
   this._currentNbQueries++;
 
-  this.emit('searchOnce', tempState);
+  this.emit('searchOnce', {
+    state: tempState
+  });
 
   if (cb) {
     this.client

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -254,23 +254,25 @@ test('search event should be emitted once when the search is triggered and befor
 });
 
 test('searchOnce event should be emitted once when the search is triggered using searchOnce and before the request is sent', function() {
+  var searchedOnce = jest.fn();
   var fakeClient = makeFakeClient();
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     disjunctiveFacets: ['city'],
     facets: ['tower']
   });
 
-  var count = 0;
+  helper.on('searchOnce', searchedOnce);
 
-  helper.on('searchOnce', function() {
-    count++;
-  });
-
-  expect(count).toBe(0);
+  expect(searchedOnce).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.searchOnce({}, function() {});
-  expect(count).toBe(1);
+
+  expect(searchedOnce).toHaveBeenCalledTimes(1);
+  expect(searchedOnce).toHaveBeenLastCalledWith({
+    state: helper.state
+  });
+
   expect(fakeClient.search).toHaveBeenCalledTimes(1);
 });
 


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have to migrate all the emitted events to the same structure. This PR takes care of the event: `searchOnce`.