### PR TITLE
refactor(search): emit object

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1229,7 +1229,10 @@ AlgoliaSearchHelper.prototype._search = function() {
     helper: this
   }];
 
-  this.emit('search', state, this.lastResults);
+  this.emit('search', {
+    state: state,
+    results: this.lastResults
+  });
 
   var derivedQueries = this.derivedHelpers.map(function(derivedHelper) {
     var derivedState = derivedHelper.getModifiedState(state);

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1237,12 +1237,18 @@ AlgoliaSearchHelper.prototype._search = function() {
   var derivedQueries = this.derivedHelpers.map(function(derivedHelper) {
     var derivedState = derivedHelper.getModifiedState(state);
     var queries = requestBuilder._getQueries(derivedState.index, derivedState);
+
     states.push({
       state: derivedState,
       queriesCount: queries.length,
       helper: derivedHelper
     });
-    derivedHelper.emit('search', derivedState, derivedHelper.lastResults);
+
+    derivedHelper.emit('search', {
+      state: derivedState,
+      results: derivedHelper.lastResults
+    });
+
     return queries;
   });
 

--- a/test/spec/algoliasearch.helper/derive/events.js
+++ b/test/spec/algoliasearch.helper/derive/events.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var algoliasearchHelper = require('../../../../index.js');
+
+function makeFakeClient() {
+  return {
+    search: jest.fn(function() {
+      return new Promise(function() {});
+    }),
+    searchForFacetValues: jest.fn(function() {
+      return new Promise(function() {});
+    })
+  };
+}
+
+test('[derived helper] emit a search event', function() {
+  var searched = jest.fn();
+  var client = makeFakeClient();
+  var helper = algoliasearchHelper(client, 'index');
+  var derivedHelper = helper.derive(function(s) {
+    return s;
+  });
+
+  derivedHelper.on('search', searched);
+
+  expect(searched).toHaveBeenCalledTimes(0);
+
+  helper.search();
+
+  expect(searched).toHaveBeenCalledTimes(1);
+  expect(searched).toHaveBeenLastCalledWith({
+    state: helper.state,
+    results: null
+  });
+});

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -204,52 +204,53 @@ test('Change events should only be emitted for meaningful changes', function() {
 });
 
 test('search event should be emitted once when the search is triggered and before the request is sent', function() {
+  var searched = jest.fn();
   var fakeClient = makeFakeClient();
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     disjunctiveFacets: ['city'],
     facets: ['tower']
   });
 
-  var count = 0;
-
-  helper.on('search', function() {
-    count++;
-  });
+  helper.on('search', searched);
 
   helper.setQuery('');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.clearRefinements();
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.addDisjunctiveRefine('city', 'Paris');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.removeDisjunctiveRefine('city', 'Paris');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.addExclude('tower', 'Empire State Building');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.removeExclude('tower', 'Empire State Building');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.addRefine('tower', 'Empire State Building');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.removeRefine('tower', 'Empire State Building');
-  expect(count).toBe(0);
+  expect(searched).toHaveBeenCalledTimes(0);
   expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
   helper.search();
-  expect(count).toBe(1);
+  expect(searched).toHaveBeenCalledTimes(1);
+  expect(searched).toHaveBeenLastCalledWith({
+    state: helper.state,
+    results: null
+  });
   expect(fakeClient.search).toHaveBeenCalledTimes(1);
 });
 


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have to migrate all the emitted events to the same structure. This PR takes care of the event: `search`.

Related: https://github.com/algolia/algoliasearch-helper-js/pull/681