### PR TITLE
refactor(searchForFacetValues): emit object

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -295,7 +295,12 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
   this._currentNbQueries++;
   var self = this;
 
-  this.emit('searchForFacetValues', state, facet, query);
+  this.emit('searchForFacetValues', {
+    state: state,
+    facet: facet,
+    query: query
+  });
+
   var searchForFacetValuesPromise = clientHasSFFV
     ? this.client.searchForFacetValues([{indexName: state.index, params: algoliaQuery}])
     : this.client.initIndex(state.index).searchForFacetValues(algoliaQuery);

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -279,22 +279,24 @@ test('searchOnce event should be emitted once when the search is triggered using
 
 test('searchForFacetValues event should be emitted once when the search is triggered using' +
      ' searchForFacetValues and before the request is sent', function() {
+  var searchedForFacetValues = jest.fn();
   var fakeClient = makeFakeClient();
   var helper = algoliaSearchHelper(fakeClient, 'Index', {
     disjunctiveFacets: ['city'],
     facets: ['tower']
   });
 
-  var count = 0;
+  helper.on('searchForFacetValues', searchedForFacetValues);
 
-  helper.on('searchForFacetValues', function() {
-    count++;
-  });
-
-  expect(count).toBe(0);
+  expect(searchedForFacetValues).toHaveBeenCalledTimes(0);
   expect(fakeClient.searchForFacetValues).toHaveBeenCalledTimes(0);
 
-  helper.searchForFacetValues();
-  expect(count).toBe(1);
+  helper.searchForFacetValues('city', 'NYC');
+  expect(searchedForFacetValues).toHaveBeenCalledTimes(1);
+  expect(searchedForFacetValues).toHaveBeenLastCalledWith({
+    state: helper.state,
+    facet: 'city',
+    query: 'NYC'
+  });
   expect(fakeClient.searchForFacetValues).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have to migrate all the emitted events to the same structure. This PR takes care of the event: `searchForFacetValues`.

Related: https://github.com/algolia/algoliasearch-helper-js/pull/681, https://github.com/algolia/algoliasearch-helper-js/pull/683