### PR TITLE
test(sffv): no longer test impossible responses

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -305,15 +305,10 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
 
     content = Array.isArray(content) ? content[0] : content;
 
-    content.facetHits = Array.isArray(content.facetHits)
-      ? content.facetHits
-      : [];
-
-    content.facetHits = content.facetHits.map(function(f) {
+    content.facetHits.forEach(function(f) {
       f.isRefined = isDisjunctive
         ? state.isDisjunctiveFacetRefined(facet, f.value)
         : state.isFacetRefined(facet, f.value);
-      return f;
     });
 
     return content;

--- a/test/spec/algoliasearch.helper/pendingSearch.js
+++ b/test/spec/algoliasearch.helper/pendingSearch.js
@@ -67,13 +67,18 @@ test('When searchOnce with promises, hasPendingRequests is true', function(done)
 });
 
 test('When searchForFacetValues, hasPendingRequests is true', function(done) {
-  var testData = require('../../datasets/SearchParameters/search.dataset')();
   var client = algoliaSearch('dsf', 'dsfdf');
 
   var triggerCb;
   client.searchForFacetValues = function() {
     return new Promise(function(resolve) {
-      triggerCb = function() { resolve([testData.response]); };
+      triggerCb = function() {
+        resolve([{
+          exhaustiveFacetsCount: true,
+          facetHits: [],
+          processingTimeMS: 3
+        }]);
+      };
     });
   };
 

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -2,13 +2,19 @@
 
 var algoliasearchHelper = require('../../../index');
 
+var fakeSearchForFacetValuesResponse = {
+  exhaustiveFacetsCount: true,
+  facetHits: [],
+  processingTimeMS: 3
+};
+
 test('searchForFacetValues calls the client method over the index method', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([{}]);
+    return Promise.resolve([fakeSearchForFacetValuesResponse]);
   });
 
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve({});
+    return Promise.resolve(fakeSearchForFacetValuesResponse);
   });
 
   var fakeClient = {
@@ -30,7 +36,7 @@ test('searchForFacetValues calls the client method over the index method', funct
 
 test('searchForFacetValues calls the index method if no client method', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve({});
+    return Promise.resolve(fakeSearchForFacetValuesResponse);
   });
 
   var fakeClient = {
@@ -53,11 +59,7 @@ test('searchForFacetValues resolve with the correct response from client', funct
     addAlgoliaAgent: function() {},
     searchForFacetValues: function() {
       return Promise.resolve([
-        {
-          exhaustiveFacetsCount: true,
-          facetHits: [],
-          processingTimeMS: 3
-        }
+        fakeSearchForFacetValuesResponse
       ]);
     }
   };
@@ -77,11 +79,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
     initIndex: function() {
       return {
         searchForFacetValues: function() {
-          return Promise.resolve({
-            exhaustiveFacetsCount: true,
-            facetHits: [],
-            processingTimeMS: 3
-          });
+          return Promise.resolve(fakeSearchForFacetValuesResponse);
         }
       };
     }
@@ -98,7 +96,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
 
 test('index.searchForFacetValues should search for facetValues with the current state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve({});
+    return Promise.resolve(fakeSearchForFacetValuesResponse);
   });
 
   var fakeClient = {
@@ -128,7 +126,7 @@ test('index.searchForFacetValues should search for facetValues with the current 
 
 test('index.searchForFacetValues can override the current search state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve({});
+    return Promise.resolve(fakeSearchForFacetValuesResponse);
   });
 
   var fakeClient = {
@@ -161,7 +159,7 @@ test('index.searchForFacetValues can override the current search state', functio
 
 test('client.searchForFacetValues should search for facetValues with the current state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([{}]);
+    return Promise.resolve([fakeSearchForFacetValuesResponse]);
   });
 
   var fakeClient = {
@@ -188,7 +186,7 @@ test('client.searchForFacetValues should search for facetValues with the current
 
 test('client.searchForFacetValues can override the current search state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([{}]);
+    return Promise.resolve([fakeSearchForFacetValuesResponse]);
   });
 
   var fakeClient = {

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -2,7 +2,7 @@
 
 var algoliasearchHelper = require('../../../index');
 
-function createFakeSearchForFacetValuesResponse() {
+function makeFakeSearchForFacetValuesResponse() {
   return {
     exhaustiveFacetsCount: true,
     facetHits: [],
@@ -10,14 +10,13 @@ function createFakeSearchForFacetValuesResponse() {
   };
 }
 
-
 test('searchForFacetValues calls the client method over the index method', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
+    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
   });
 
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(createFakeSearchForFacetValuesResponse());
+    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -39,7 +38,7 @@ test('searchForFacetValues calls the client method over the index method', funct
 
 test('searchForFacetValues calls the index method if no client method', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(createFakeSearchForFacetValuesResponse());
+    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -62,7 +61,7 @@ test('searchForFacetValues resolve with the correct response from client', funct
     addAlgoliaAgent: function() {},
     searchForFacetValues: function() {
       return Promise.resolve([
-        createFakeSearchForFacetValuesResponse()
+        makeFakeSearchForFacetValuesResponse()
       ]);
     }
   };
@@ -82,7 +81,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
     initIndex: function() {
       return {
         searchForFacetValues: function() {
-          return Promise.resolve(createFakeSearchForFacetValuesResponse());
+          return Promise.resolve(makeFakeSearchForFacetValuesResponse());
         }
       };
     }
@@ -99,7 +98,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
 
 test('index.searchForFacetValues should search for facetValues with the current state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(createFakeSearchForFacetValuesResponse());
+    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -129,7 +128,7 @@ test('index.searchForFacetValues should search for facetValues with the current 
 
 test('index.searchForFacetValues can override the current search state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(createFakeSearchForFacetValuesResponse());
+    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -162,7 +161,7 @@ test('index.searchForFacetValues can override the current search state', functio
 
 test('client.searchForFacetValues should search for facetValues with the current state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
+    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
   });
 
   var fakeClient = {
@@ -189,7 +188,7 @@ test('client.searchForFacetValues should search for facetValues with the current
 
 test('client.searchForFacetValues can override the current search state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
+    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
   });
 
   var fakeClient = {

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -2,19 +2,22 @@
 
 var algoliasearchHelper = require('../../../index');
 
-var fakeSearchForFacetValuesResponse = {
-  exhaustiveFacetsCount: true,
-  facetHits: [],
-  processingTimeMS: 3
-};
+function createFakeSearchForFacetValuesResponse() {
+  return {
+    exhaustiveFacetsCount: true,
+    facetHits: [],
+    processingTimeMS: 3
+  };
+}
+
 
 test('searchForFacetValues calls the client method over the index method', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([fakeSearchForFacetValuesResponse]);
+    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
   });
 
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(fakeSearchForFacetValuesResponse);
+    return Promise.resolve(createFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -36,7 +39,7 @@ test('searchForFacetValues calls the client method over the index method', funct
 
 test('searchForFacetValues calls the index method if no client method', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(fakeSearchForFacetValuesResponse);
+    return Promise.resolve(createFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -59,7 +62,7 @@ test('searchForFacetValues resolve with the correct response from client', funct
     addAlgoliaAgent: function() {},
     searchForFacetValues: function() {
       return Promise.resolve([
-        fakeSearchForFacetValuesResponse
+        createFakeSearchForFacetValuesResponse()
       ]);
     }
   };
@@ -79,7 +82,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
     initIndex: function() {
       return {
         searchForFacetValues: function() {
-          return Promise.resolve(fakeSearchForFacetValuesResponse);
+          return Promise.resolve(createFakeSearchForFacetValuesResponse());
         }
       };
     }
@@ -96,7 +99,7 @@ test('searchForFacetValues resolve with the correct response from initIndex', fu
 
 test('index.searchForFacetValues should search for facetValues with the current state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(fakeSearchForFacetValuesResponse);
+    return Promise.resolve(createFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -126,7 +129,7 @@ test('index.searchForFacetValues should search for facetValues with the current 
 
 test('index.searchForFacetValues can override the current search state', function() {
   var indexSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve(fakeSearchForFacetValuesResponse);
+    return Promise.resolve(createFakeSearchForFacetValuesResponse());
   });
 
   var fakeClient = {
@@ -159,7 +162,7 @@ test('index.searchForFacetValues can override the current search state', functio
 
 test('client.searchForFacetValues should search for facetValues with the current state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([fakeSearchForFacetValuesResponse]);
+    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
   });
 
   var fakeClient = {
@@ -186,7 +189,7 @@ test('client.searchForFacetValues should search for facetValues with the current
 
 test('client.searchForFacetValues can override the current search state', function() {
   var clientSearchForFacetValues = jest.fn(function() {
-    return Promise.resolve([fakeSearchForFacetValuesResponse]);
+    return Promise.resolve([createFakeSearchForFacetValuesResponse()]);
   });
 
   var fakeClient = {


### PR DESCRIPTION
Since the engine will always respond with `facetHits` on searchForFacetValues, we can assume this will always be defined.

follow-up to @samouss' comments on #674