### PR TITLE
refactor(lodash): replace find & findIndex

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -8,11 +8,11 @@ var isEmpty = require('lodash/isEmpty');
 var isEqual = require('lodash/isEqual');
 var isUndefined = require('lodash/isUndefined');
 var isFunction = require('lodash/isFunction');
-var find = require('lodash/find');
 
 var defaults = require('lodash/defaults');
 var merge = require('lodash/merge');
 
+var find = require('../functions/find');
 var valToNumber = require('../functions/valToNumber');
 var omit = require('../functions/omit');
 
@@ -1682,7 +1682,9 @@ SearchParameters.prototype = {
   getHierarchicalFacetByName: function(hierarchicalFacetName) {
     return find(
       this.hierarchicalFacets,
-      {name: hierarchicalFacetName}
+      function(f) {
+        return f.name === hierarchicalFacetName;
+      }
     );
   },
 

--- a/src/SearchResults/generate-hierarchical-tree.js
+++ b/src/SearchResults/generate-hierarchical-tree.js
@@ -3,8 +3,8 @@
 module.exports = generateTrees;
 
 var orderBy = require('lodash/orderBy');
-var find = require('lodash/find');
 
+var find = require('../functions/find');
 var prepareHierarchicalFacetSortBy = require('../functions/formatSort');
 
 function generateTrees(state) {
@@ -82,7 +82,9 @@ function generateHierarchicalTree(
          * @type {object[]]} hierarchical data
          */
         var data = parent && Array.isArray(parent.data) ? parent.data : [];
-        parent = find(data, {isRefined: true});
+        parent = find(data, function(subtree) {
+          return subtree.isRefined;
+        });
         level++;
       }
     }

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -1,10 +1,8 @@
 'use strict';
 
 var compact = require('lodash/compact');
-var findIndex = require('lodash/findIndex');
 
 var sumBy = require('lodash/sumBy');
-var find = require('lodash/find');
 var orderBy = require('lodash/orderBy');
 
 var defaults = require('lodash/defaults');
@@ -15,6 +13,8 @@ var isFunction = require('lodash/isFunction');
 var partial = require('lodash/partial');
 var partialRight = require('lodash/partialRight');
 
+var find = require('../functions/find');
+var findIndex = require('../functions/findIndex');
 var formatSort = require('../functions/formatSort');
 
 var generateHierarchicalTree = require('./generate-hierarchical-tree');
@@ -386,7 +386,9 @@ function SearchResults(state, results) {
       // Place the hierarchicalFacet data at the correct index depending on
       // the attributes order that was defined at the helper initialization
       var facetIndex = hierarchicalFacet.attributes.indexOf(facetKey);
-      var idxAttributeName = findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name});
+      var idxAttributeName = findIndex(state.hierarchicalFacets, function(f) {
+        return f.name === hierarchicalFacet.name;
+      });
       self.hierarchicalFacets[idxAttributeName][facetIndex] = {
         attribute: facetKey,
         data: facetValueObject,
@@ -434,8 +436,12 @@ function SearchResults(state, results) {
       var position;
 
       if (hierarchicalFacet) {
-        position = findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name});
-        var attributeIndex = findIndex(self.hierarchicalFacets[position], {attribute: dfacet});
+        position = findIndex(state.hierarchicalFacets, function(f) {
+          return f.name === hierarchicalFacet.name;
+        });
+        var attributeIndex = findIndex(self.hierarchicalFacets[position], function(f) {
+          return f.attribute === dfacet;
+        });
 
         // previous refinements and no results so not able to find it
         if (attributeIndex === -1) {
@@ -491,8 +497,12 @@ function SearchResults(state, results) {
       : {};
     Object.keys(facets).forEach(function(dfacet) {
       var facetResults = facets[dfacet];
-      var position = findIndex(state.hierarchicalFacets, {name: hierarchicalFacet.name});
-      var attributeIndex = findIndex(self.hierarchicalFacets[position], {attribute: dfacet});
+      var position = findIndex(state.hierarchicalFacets, function(f) {
+        return f.name === hierarchicalFacet.name;
+      });
+      var attributeIndex = findIndex(self.hierarchicalFacets[position], function(f) {
+        return f.attribute === dfacet;
+      });
 
       // previous refinements and no results so not able to find it
       if (attributeIndex === -1) {
@@ -565,7 +575,9 @@ function SearchResults(state, results) {
  * @return {SearchResults.Facet} the facet object
  */
 SearchResults.prototype.getFacetByName = function(name) {
-  var predicate = {name: name};
+  function predicate(facet) {
+    return facet.name === name;
+  }
 
   return find(this.facets, predicate) ||
     find(this.disjunctiveFacets, predicate) ||
@@ -580,7 +592,10 @@ SearchResults.prototype.getFacetByName = function(name) {
  * @return {array|object} facet values. For the hierarchical facets it is an object.
  */
 function extractNormalizedFacetValues(results, attribute) {
-  var predicate = {name: attribute};
+  function predicate(facet) {
+    return facet.name === attribute;
+  }
+
   if (results._state.isConjunctiveFacet(attribute)) {
     var facet = find(results.facets, predicate);
     if (!facet) return [];
@@ -728,7 +743,9 @@ SearchResults.prototype.getFacetStats = function(attribute) {
  * @param {string} facetName
  */
 function getFacetStatsIfAvailable(facetList, facetName) {
-  var data = find(facetList, {name: facetName});
+  var data = find(facetList, function(facet) {
+    return facet.name === facetName;
+  });
   return data && data.stats;
 }
 
@@ -808,7 +825,9 @@ SearchResults.prototype.getRefinements = function() {
  * @param {Facet[]} resultsFacets
  */
 function getRefinement(state, type, attributeName, name, resultsFacets) {
-  var facet = find(resultsFacets, {name: attributeName});
+  var facet = find(resultsFacets, function(f) {
+    return f.name === attributeName;
+  });
   var count = facet && facet.data && facet.data[name] ? facet.data[name] : 0;
   var exhaustive = (facet && facet.exhaustive) || false;
 
@@ -831,11 +850,15 @@ function getHierarchicalRefinement(state, attributeName, name, resultsFacets) {
   var facetDeclaration = state.getHierarchicalFacetByName(attributeName);
   var separator = state._getHierarchicalFacetSeparator(facetDeclaration);
   var split = name.split(separator);
-  var rootFacet = find(resultsFacets, {name: attributeName});
+  var rootFacet = find(resultsFacets, function(facet) {
+    return facet.name === attributeName;
+  });
 
   var facet = split.reduce(function(intermediateFacet, part) {
     var newFacet =
-      intermediateFacet && find(intermediateFacet.data, {name: part});
+      intermediateFacet && find(intermediateFacet.data, function(f) {
+        return f.name === part;
+      });
     return newFacet !== undefined ? newFacet : intermediateFacet;
   }, rootFacet);
 

--- a/src/functions/find.js
+++ b/src/functions/find.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// @MAJOR can be replaced by native Array#find when we change support
+module.exports = function find(array, comparator) {
+  for (var i = 0; i < array.length; i++) {
+    if (comparator(array[i])) {
+      return array[i];
+    }
+  }
+};

--- a/src/functions/find.js
+++ b/src/functions/find.js
@@ -2,6 +2,10 @@
 
 // @MAJOR can be replaced by native Array#find when we change support
 module.exports = function find(array, comparator) {
+  if (!Array.isArray(array)) {
+    return undefined;
+  }
+
   for (var i = 0; i < array.length; i++) {
     if (comparator(array[i])) {
       return array[i];

--- a/src/functions/findIndex.js
+++ b/src/functions/findIndex.js
@@ -2,6 +2,10 @@
 
 // @MAJOR can be replaced by native Array#findIndex when we change support
 module.exports = function find(array, comparator) {
+  if (!Array.isArray(array)) {
+    return -1;
+  }
+
   for (var i = 0; i < array.length; i++) {
     if (comparator(array[i])) {
       return i;

--- a/src/functions/findIndex.js
+++ b/src/functions/findIndex.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// @MAJOR can be replaced by native Array#findIndex when we change support
+module.exports = function find(array, comparator) {
+  for (var i = 0; i < array.length; i++) {
+    if (comparator(array[i])) {
+      return i;
+    }
+  }
+  return -1;
+};

--- a/src/functions/formatSort.js
+++ b/src/functions/formatSort.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var find = require('lodash/find');
+var find = require('./find');
 var startsWith = require('lodash/startsWith');
 
 /**

--- a/test/spec/functions/find.js
+++ b/test/spec/functions/find.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var find = require('../../../src/functions/find');
+
+test('find returns the first match based on the comparator', function() {
+  expect(find([1], function() { return true; })).toBe(1);
+  expect(find([1, 2], function() { return true; })).toBe(1);
+
+  expect(
+    find([{nice: false}, {nice: true}], function(el) {
+      return el.nice;
+    })
+  ).toEqual({nice: true});
+});
+
+test('find returns undefined in non-found cases', function() {
+  expect(find([], function() { return false; })).toBeUndefined();
+  expect(find(undefined, function() { return false; })).toBeUndefined();
+
+  expect(function() {
+    find([1, 2, 3], undefined);
+  }).toThrowError();
+});

--- a/test/spec/functions/findIndex.js
+++ b/test/spec/functions/findIndex.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var findIndex = require('../../../src/functions/findIndex');
+
+test('findIndex returns the first match based on the comparator', function() {
+  expect(findIndex([1], function() { return true; })).toBe(0);
+  expect(findIndex([1, 2], function() { return true; })).toBe(0);
+
+  expect(
+    findIndex([{nice: false}, {nice: true}], function(el) {
+      return el.nice;
+    })
+  ).toBe(1);
+});
+
+test('findIndex returns -1 in non-found cases', function() {
+  expect(findIndex([], function() { return false; })).toBe(-1);
+  expect(findIndex(undefined, function() { return false; })).toBe(-1);
+
+  expect(function() {
+    findIndex([1, 2, 3], undefined);
+  }).toThrowError();
+});


### PR DESCRIPTION
These are very naive implementations which only work on arrays, but much shorter than a real polyfill

Notable difference between the previous implementation and this one is that the `find` implementation only takes in arrays, no longer objects