### PR TITLE
refactor(lodash): compact

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var compact = require('lodash/compact');
-
 var orderBy = require('lodash/orderBy');
 
 var defaults = require('lodash/defaults');
@@ -14,6 +12,7 @@ var partialRight = require('lodash/partialRight');
 
 var find = require('../functions/find');
 var findIndex = require('../functions/findIndex');
+var compact = require('../functions/compact');
 var formatSort = require('../functions/formatSort');
 
 var generateHierarchicalTree = require('./generate-hierarchical-tree');

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -10,6 +10,7 @@ var isFunction = require('lodash/isFunction');
 var partial = require('lodash/partial');
 var partialRight = require('lodash/partialRight');
 
+var compact = require('../functions/compact');
 var find = require('../functions/find');
 var findIndex = require('../functions/findIndex');
 var compact = require('../functions/compact');

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -13,7 +13,6 @@ var partialRight = require('lodash/partialRight');
 var compact = require('../functions/compact');
 var find = require('../functions/find');
 var findIndex = require('../functions/findIndex');
-var compact = require('../functions/compact');
 var formatSort = require('../functions/formatSort');
 
 var generateHierarchicalTree = require('./generate-hierarchical-tree');

--- a/src/functions/compact.js
+++ b/src/functions/compact.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function compact(array) {
+  if (!Array.isArray(array)) {
+    return [];
+  }
+
+  return array.filter(function(element) {
+    return Boolean(element);
+  });
+};

--- a/src/functions/compact.js
+++ b/src/functions/compact.js
@@ -5,7 +5,5 @@ module.exports = function compact(array) {
     return [];
   }
 
-  return array.filter(function(element) {
-    return Boolean(element);
-  });
+  return array.filter(Boolean);
 };

--- a/test/spec/functions/compact.js
+++ b/test/spec/functions/compact.js
@@ -4,7 +4,7 @@ var compact = require('../../../src/functions/compact');
 
 test('compact removes falsy values from arrays', function() {
   expect(compact([2])).toEqual([2]);
-  expect(compact([2, false, null, undefined])).toEqual([2]);
+  expect(compact([2, false, null, undefined, '', 0])).toEqual([2]);
   expect(compact([2, '45', 44])).toEqual([2, '45', 44]);
 });
 

--- a/test/spec/functions/compact.js
+++ b/test/spec/functions/compact.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var compact = require('../../../src/functions/compact');
+
+test('compact removes falsy values from arrays', function() {
+  expect(compact([2])).toEqual([2]);
+  expect(compact([2, false, null, undefined])).toEqual([2]);
+  expect(compact([2, '45', 44])).toEqual([2, '45', 44]);
+});
+
+test('returns an array for nullish values', function() {
+  expect(compact(null)).toEqual([]);
+  expect(compact(undefined)).toEqual([]);
+});


### PR DESCRIPTION
I added tests for this function, but none of the existing real tests test that compact is needed. I'm not too sure if it really is needed in the first place.

I left it for backwards-compatibility, but all tests pass with identity instead of compact

ref for when this was added (without tests 🙌 https://github.com/algolia/algoliasearch-helper-js/pull/45/commits/744da6d1fe1c627ede06c6cfefa8d65c5a9e82b6)