### PR TITLE
refactor(result): emit object

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1306,7 +1306,11 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
     var specificResults = results.splice(0, queriesCount);
 
     var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
-    helper.emit('result', formattedResponse, state);
+
+    helper.emit('result', {
+      results: formattedResponse,
+      state: state
+    });
   });
 };
 

--- a/test/integration-spec/helper.derive.js
+++ b/test/integration-spec/helper.derive.js
@@ -43,21 +43,11 @@ test(
       });
 
       var mainResponse = new Promise(function(resolve) {
-        mainHelper.on('result', function(results, state) {
-          resolve({
-            results: results,
-            state: state
-          });
-        });
+        mainHelper.on('result', resolve);
       });
 
       var derivedResponse = new Promise(function(resolve) {
-        derivedHelper.on('result', function(results, state) {
-          resolve({
-            results: results,
-            state: state
-          });
-        });
+        derivedHelper.on('result', resolve);
       });
 
       mainHelper.search();

--- a/test/integration-spec/helper.distinct.facet.js
+++ b/test/integration-spec/helper.distinct.facet.js
@@ -39,9 +39,9 @@ test('[INT][FILTERS] Using distinct should let me retrieve all facet without dis
       done.fail(err);
     });
 
-    helper.on('result', function(content) {
-      expect(content.hits.length).toBe(1);
-      expect(content.facets[0].data).toEqual({
+    helper.on('result', function(event) {
+      expect(event.results.hits.length).toBe(1);
+      expect(event.results.facets[0].data).toEqual({
         blue: 2,
         red: 2,
         gold: 1,

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -41,12 +41,14 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
       done.fail(err);
     });
 
-    helper.on('result', function(content) {
+    helper.on('result', function(event) {
       calls++;
 
+      var results = event.results;
+
       if (calls === 1) {
-        expect(content.hits.length).toBe(2);
-        expect(content.facets[0].data).toEqual({
+        expect(results.hits.length).toBe(2);
+        expect(results.facets[0].data).toEqual({
           f1: 2,
           f2: 1,
           f3: 1
@@ -56,8 +58,8 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
       }
 
       if (calls === 2) {
-        expect(content.hits.length).toBe(1);
-        expect(content.facets[0].data).toEqual({
+        expect(results.hits.length).toBe(1);
+        expect(results.facets[0].data).toEqual({
           f1: 1,
           f2: 1
         });
@@ -66,15 +68,15 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
       }
 
       if (calls === 3) {
-        expect(content.hits.length).toBe(0);
-        expect(content.facets[0]).toBe(undefined);
+        expect(results.hits.length).toBe(0);
+        expect(results.facets[0]).toBe(undefined);
 
         helper.removeRefine('facet', 'f2').search();
       }
 
       if (calls === 4) {
-        expect(content.hits.length).toBe(1);
-        expect(content.facets[0].data).toEqual({
+        expect(results.hits.length).toBe(1);
+        expect(results.facets[0].data).toEqual({
           f1: 1,
           f3: 1
         });

--- a/test/integration-spec/helper.geo.js
+++ b/test/integration-spec/helper.geo.js
@@ -26,9 +26,9 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {});
-      helper.on('result', function(content) {
-        expect(content.hits.length).toBe(1);
-        expect(content.hits[0].objectID).toBe('1');
+      helper.on('result', function(event) {
+        expect(event.results.hits.length).toBe(1);
+        expect(event.results.hits[0].objectID).toBe('1');
         done();
       });
 
@@ -43,9 +43,9 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {});
-      helper.on('result', function(content) {
-        expect(content.hits.length).toBe(1);
-        expect(content.hits[0].objectID).toBe('1');
+      helper.on('result', function(event) {
+        expect(event.results.hits.length).toBe(1);
+        expect(event.results.hits[0].objectID).toBe('1');
         done();
       });
 
@@ -61,9 +61,9 @@ test(
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {});
 
-      helper.on('result', function(content) {
-        expect(content.hits.length).toBe(2);
-        var sortedHits = content.hits.sort(function(a, b) { return a.objectID.localeCompare(b.objectID); });
+      helper.on('result', function(event) {
+        expect(event.results.hits.length).toBe(2);
+        var sortedHits = event.results.hits.sort(function(a, b) { return a.objectID.localeCompare(b.objectID); });
         expect(sortedHits[0].objectID).toBe('1');
         expect(sortedHits[1].objectID).toBe('4');
         done();

--- a/test/integration-spec/helper.highlight.js
+++ b/test/integration-spec/helper.highlight.js
@@ -37,17 +37,17 @@ test('[INT][HIGHLIGHT] The highlight should be consistent with the parameters', 
     });
 
     var calls = 0;
-    helper.on('result', function(content) {
+    helper.on('result', function(event) {
       calls++;
       if (calls === 1) {
-        expect(content.hits[0]._highlightResult.facet[0].value).toBe('<em>f1</em>');
-        expect(content.hits[1]._highlightResult.facet[0].value).toBe('<em>f1</em>');
+        expect(event.results.hits[0]._highlightResult.facet[0].value).toBe('<em>f1</em>');
+        expect(event.results.hits[1]._highlightResult.facet[0].value).toBe('<em>f1</em>');
         helper.setQueryParameter('highlightPostTag', '</strong>')
           .setQueryParameter('highlightPreTag', '<strong>')
           .search();
       } else if (calls === 2) {
-        expect(content.hits[0]._highlightResult.facet[0].value).toBe('<strong>f1</strong>');
-        expect(content.hits[1]._highlightResult.facet[0].value).toBe('<strong>f1</strong>');
+        expect(event.results.hits[0]._highlightResult.facet[0].value).toBe('<strong>f1</strong>');
+        expect(event.results.hits[1]._highlightResult.facet[0].value).toBe('<strong>f1</strong>');
         client.deleteIndex(indexName);
         if (!process.browser) {
           client.destroy();

--- a/test/integration-spec/helper.insights.js
+++ b/test/integration-spec/helper.insights.js
@@ -24,8 +24,8 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {clickAnalytics: true});
-      helper.on('result', function(content) {
-        expect(typeof content.queryID).toBe('string');
+      helper.on('result', function(event) {
+        expect(event.results.queryID).toEqual(expect.any(String));
         done();
       });
 
@@ -40,8 +40,8 @@ test(
     setup(indexName, dataset, config).
     then(function(client) {
       var helper = algoliasearchHelper(client, indexName, {});
-      helper.on('result', function(content) {
-        expect(content.queryID).toBe(undefined);
+      helper.on('result', function(event) {
+        expect(event.results.queryID).toBeUndefined();
         done();
       });
 

--- a/test/integration-spec/helper.numerics.js
+++ b/test/integration-spec/helper.numerics.js
@@ -39,36 +39,38 @@ test('[INT][NUMERICS][RAW-API]Test numeric operations on the helper and their re
         done.fail(err);
       });
 
-      helper.on('result', function(content) {
+      helper.on('result', function(event) {
         calls++;
 
+        var results = event.results;
+
         if (calls === 1) {
-          expect(content.hits.length).toBe(4);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
+          expect(results.hits.length).toBe(4);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
           helper.setQueryParameter('numericFilters', 'n=6,n=10').search();
         }
 
         if (calls === 2) {
-          expect(content.hits.length).toBe(1);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([1]);
+          expect(results.hits.length).toBe(1);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([1]);
           helper.setQueryParameter('numericFilters', '(n=6,n>40)').search();
         }
 
         if (calls === 3) {
-          expect(content.hits.length).toBe(3);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1, 2]);
+          expect(results.hits.length).toBe(3);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1, 2]);
           helper.setQueryParameter('numericFilters', 'n:11 to 46').search();
         }
 
         if (calls === 4) {
-          expect(content.hits.length).toBe(2);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([2, 3]);
+          expect(results.hits.length).toBe(2);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([2, 3]);
           helper.setQueryParameter('numericFilters', 'n=5,(n=10,n=45)').search();
         }
 
         if (calls === 5) {
-          expect(content.hits.length).toBe(1);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([2]);
+          expect(results.hits.length).toBe(1);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([2]);
           client.deleteIndex(indexName);
           if (!process.browser) {
             client.destroy();
@@ -108,27 +110,29 @@ test('[INT][NUMERICS][MANAGED-API]Test numeric operations on the helper and thei
         done.fail(err);
       });
 
-      helper.on('result', function(content) {
+      helper.on('result', function(event) {
         calls++;
 
+        var results = event.results;
+
         if (calls === 1) {
-          expect(content.hits.length).toBe(4);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
+          expect(results.hits.length).toBe(4);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
           helper.addNumericRefinement('n', '=', '6');
           helper.addNumericRefinement('n', '=', '10');
           helper.search();
         }
 
         if (calls === 2) {
-          expect(content.hits.length).toBe(1);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([1]);
+          expect(results.hits.length).toBe(1);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([1]);
           helper.clearRefinements('n');
           helper.addNumericRefinement('n', '=', [6, 45]).search();
         }
 
         if (calls === 3) {
-          expect(content.hits.length).toBe(3);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1, 2]);
+          expect(results.hits.length).toBe(3);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1, 2]);
           helper.addNumericRefinement('n', '=', 5);
           helper.removeNumericRefinement('n', '=', [6, 45]);
           helper.addNumericRefinement('n', '=', [10, 45]);
@@ -136,8 +140,8 @@ test('[INT][NUMERICS][MANAGED-API]Test numeric operations on the helper and thei
         }
 
         if (calls === 4) {
-          expect(content.hits.length).toBe(1);
-          expect(map(content.hits, hitsToParsedID).sort()).toEqual([2]);
+          expect(results.hits.length).toBe(1);
+          expect(map(results.hits, hitsToParsedID).sort()).toEqual([2]);
           client.deleteIndex(indexName);
           if (!process.browser) {
             client.destroy();

--- a/test/integration-spec/helper.results.getFacetValues.js
+++ b/test/integration-spec/helper.results.getFacetValues.js
@@ -30,10 +30,10 @@ test(
         }
       );
 
-      helper.on('result', function(rs) {
-        expect(rs.getFacetValues('f')).toEqual([]);
-        expect(rs.getFacetValues('df')).toEqual([]);
-        expect(rs.getFacetValues('products')).toEqual({
+      helper.on('result', function(event) {
+        expect(event.results.getFacetValues('f')).toEqual([]);
+        expect(event.results.getFacetValues('df')).toEqual([]);
+        expect(event.results.getFacetValues('products')).toEqual({
           name: 'products',
           count: null,
           isRefined: true,

--- a/test/integration-spec/helper.searchOnce.js
+++ b/test/integration-spec/helper.searchOnce.js
@@ -39,9 +39,9 @@ test(
         done.fail(err);
       });
 
-      helper.on('result', function(content) {
+      helper.on('result', function(event) {
         if (calls === 3) {
-          expect(content.hits.length).toBe(3);
+          expect(event.results.hits.length).toBe(3);
           done();
         } else {
           done.fail('Should not trigger the result event until the third call');

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -38,36 +38,38 @@ test('[INT][TAGS]Test tags operations on the helper and their results on the alg
       done.fail(err);
     });
 
-    helper.on('result', function(content) {
+    helper.on('result', function(event) {
       calls++;
 
+      var results = event.results;
+
       if (calls === 1) {
-        expect(content.hits.length).toBe(4);
-        expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
+        expect(results.hits.length).toBe(4);
+        expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1, 2, 3]);
         helper.addTag('t1').search();
       }
 
       if (calls === 2) {
-        expect(content.hits.length).toBe(2);
-        expect(map(content.hits, hitsToParsedID).sort()).toEqual([0, 1]);
+        expect(results.hits.length).toBe(2);
+        expect(map(results.hits, hitsToParsedID).sort()).toEqual([0, 1]);
         helper.addTag('t2').search();
       }
 
       if (calls === 3) {
-        expect(content.hits.length).toBe(1);
-        expect(map(content.hits, hitsToParsedID).sort()).toEqual([0]);
+        expect(results.hits.length).toBe(1);
+        expect(map(results.hits, hitsToParsedID).sort()).toEqual([0]);
         helper.removeTag('t2').toggleTag('t3').toggleTag('t1').search();
       }
 
       if (calls === 4) {
-        expect(content.hits.length).toBe(3);
-        expect(map(content.hits, hitsToParsedID).sort()).toEqual([1, 2, 3]);
+        expect(results.hits.length).toBe(3);
+        expect(map(results.hits, hitsToParsedID).sort()).toEqual([1, 2, 3]);
         helper.clearTags().setQueryParameter('tagFilters', 't3,(t1,t2)').search();
       }
 
       if (calls === 5) {
-        expect(content.hits.length).toBe(2);
-        expect(map(content.hits, hitsToParsedID).sort()).toEqual([1, 2]);
+        expect(results.hits.length).toBe(2);
+        expect(map(results.hits, hitsToParsedID).sort()).toEqual([1, 2]);
         client.deleteIndex(indexName);
         if (!process.browser) {
           client.destroy();

--- a/test/spec/algoliasearch.helper/events.js
+++ b/test/spec/algoliasearch.helper/events.js
@@ -300,3 +300,32 @@ test('searchForFacetValues event should be emitted once when the search is trigg
   });
   expect(fakeClient.searchForFacetValues).toHaveBeenCalledTimes(1);
 });
+
+test('result event should be emitted once the request is complete', function() {
+  var resulted = jest.fn();
+  var fakeClient = makeFakeClient();
+  var helper = algoliaSearchHelper(fakeClient, 'Index', {
+    disjunctiveFacets: ['city'],
+    facets: ['tower']
+  });
+
+  fakeClient.search.mockImplementationOnce(function() {
+    return Promise.resolve({
+      results: [{}]
+    });
+  });
+
+  helper.on('result', resulted);
+
+  expect(resulted).toHaveBeenCalledTimes(0);
+
+  helper.search();
+
+  return Promise.resolve().then(function() {
+    expect(resulted).toHaveBeenCalledTimes(1);
+    expect(resulted).toHaveBeenLastCalledWith({
+      results: expect.any(algoliaSearchHelper.SearchResults),
+      state: helper.state
+    });
+  });
+});

--- a/test/spec/hierarchical-facets/attributes-order.js
+++ b/test/spec/hierarchical-facets/attributes-order.js
@@ -100,9 +100,9 @@ test('hierarchical facets: attributes order', function(done) {
 
   helper.setQuery('a').search();
 
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
-    expect(content.getFacetByName('categories')).toEqual(expectedHelperResponse[0]);
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.getFacetByName('categories')).toEqual(expectedHelperResponse[0]);
 
     done();
   });

--- a/test/spec/hierarchical-facets/custom-prefix-path.js
+++ b/test/spec/hierarchical-facets/custom-prefix-path.js
@@ -104,9 +104,9 @@ test('hierarchical facets: custom prefix path', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     expect(client.search).toHaveBeenCalledTimes(1);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/custom-separator.js
+++ b/test/spec/hierarchical-facets/custom-separator.js
@@ -95,7 +95,7 @@ test('hierarchical facets: custom separator', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     var queries = client.search.mock.calls[0][0];
     var hitsQuery = queries[0];
     var parentValuesQuery = queries[1];
@@ -105,7 +105,7 @@ test('hierarchical facets: custom separator', function(done) {
     expect(hitsQuery.params.facetFilters).toEqual([['categories.lvl1:beers | IPA']]);
     expect(parentValuesQuery.params.facets).toEqual(['categories.lvl0', 'categories.lvl1']);
     expect(parentValuesQuery.params.facetFilters).toEqual([['categories.lvl0:beers']]);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/do-not-show-parent-level.js
+++ b/test/spec/hierarchical-facets/do-not-show-parent-level.js
@@ -89,9 +89,9 @@ test('hierarchical facets: do not show parent level', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     expect(client.search).toHaveBeenCalledTimes(1);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/facet-value-length.js
+++ b/test/spec/hierarchical-facets/facet-value-length.js
@@ -71,8 +71,8 @@ test('hierarchical facets: facet value called length', function(done) {
   });
 
   helper.search();
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/no-refinement.js
+++ b/test/spec/hierarchical-facets/no-refinement.js
@@ -61,7 +61,7 @@ test('hierarchical facets: no refinement', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     var queries = client.search.mock.calls[0][0];
     var hitsQuery = queries[0];
 
@@ -69,7 +69,7 @@ test('hierarchical facets: no refinement', function(done) {
     expect(client.search).toHaveBeenCalledTimes(1);
     expect(hitsQuery.params.facets).toEqual(['categories.lvl0']);
     expect(hitsQuery.params.facetFilters).toBe(undefined);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/no-trim.js
+++ b/test/spec/hierarchical-facets/no-trim.js
@@ -97,14 +97,14 @@ test('hierarchical facets: do not trim facetFilters values', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     var queries = client.search.mock.calls[0][0];
     var hitsQuery = queries[0];
     var parentValuesQuery = queries[1];
 
     expect(hitsQuery.params.facetFilters).toEqual([['categories.lvl1:  beers > IPA   ']]);
     expect(parentValuesQuery.params.facetFilters).toEqual([['categories.lvl0:  beers ']]);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/objects-with-multiple-categories.js
+++ b/test/spec/hierarchical-facets/objects-with-multiple-categories.js
@@ -101,8 +101,8 @@ test('hierarchical facets: objects with multiple categories', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/one-level.js
+++ b/test/spec/hierarchical-facets/one-level.js
@@ -74,7 +74,7 @@ test('hierarchical facets: only one level deep', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     var queries = client.search.mock.calls[0][0];
     var hitsQuery = queries[0];
     var parentValuesQuery = queries[1];
@@ -85,7 +85,7 @@ test('hierarchical facets: only one level deep', function(done) {
     expect(hitsQuery.params.facetFilters).toEqual([['categories.lvl0:beers']]);
     expect(parentValuesQuery.params.facets).toEqual(['categories.lvl0']);
     expect(parentValuesQuery.params.facetFilters).toBe(undefined);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/refined-no-result.js
+++ b/test/spec/hierarchical-facets/refined-no-result.js
@@ -61,8 +61,8 @@ test('hierarchical facets: no results', function(done) {
 
   helper.setQuery('badquery').search();
 
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual([
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual([
       {
         name: 'categories',
         count: null,

--- a/test/spec/hierarchical-facets/show-parent-level.js
+++ b/test/spec/hierarchical-facets/show-parent-level.js
@@ -96,9 +96,9 @@ test('hierarchical facets: show parent level', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     expect(client.search).toHaveBeenCalledTimes(1);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/simple-usage.js
+++ b/test/spec/hierarchical-facets/simple-usage.js
@@ -123,7 +123,7 @@ test('hierarchical facets: simple usage', function(done) {
 
   helper.setQuery('a').search();
 
-  helper.once('result', function(content) {
+  helper.once('result', function(event) {
     var queries = client.search.mock.calls[0][0];
     var hitsQuery = queries[0];
     var parentValuesQuery = queries[1];
@@ -138,8 +138,8 @@ test('hierarchical facets: simple usage', function(done) {
     expect(parentValuesQuery.params.facetFilters).toEqual([['categories.lvl1:beers > IPA']]);
     expect(rootValuesQuery.params.facets).toEqual(['categories.lvl0']);
     expect(rootValuesQuery.params.facetFilters).toBe(undefined);
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
-    expect(content.getFacetByName('categories')).toEqual(expectedHelperResponse[0]);
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
+    expect(event.results.getFacetByName('categories')).toEqual(expectedHelperResponse[0]);
 
     // we do not yet support multiple values for hierarchicalFacetsRefinements
     // but at some point we may want to open multiple leafs of a hierarchical menu

--- a/test/spec/hierarchical-facets/sort-by.js
+++ b/test/spec/hierarchical-facets/sort-by.js
@@ -115,8 +115,8 @@ test('hierarchical facets: using sortBy', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/hierarchical-facets/two-facets.js
+++ b/test/spec/hierarchical-facets/two-facets.js
@@ -112,8 +112,8 @@ test('hierarchical facets: two hierarchical facets', function(done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function(content) {
-    expect(content.hierarchicalFacets).toEqual(expectedHelperResponse);
+  helper.once('result', function(event) {
+    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
     done();
   });
 });

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -18,11 +18,13 @@ test('Search should call the algolia client according to the number of refinemen
   helper.addDisjunctiveRefine('city', 'Paris', true);
   helper.addDisjunctiveRefine('city', 'New York', true);
 
-  helper.on('result', function(data) {
-    // shame deepclone, to remove any associated methods coming from the results
-    expect(JSON.parse(JSON.stringify(data))).toEqual(JSON.parse(JSON.stringify(testData.responseHelper)));
+  helper.on('result', function(event) {
+    var results = event.results;
 
-    var cityValues = data.getFacetValues('city');
+    // shame deepclone, to remove any associated methods coming from the results
+    expect(JSON.parse(JSON.stringify(results))).toEqual(JSON.parse(JSON.stringify(testData.responseHelper)));
+
+    var cityValues = results.getFacetValues('city');
     var expectedCityValues = [
       {name: 'Paris', count: 3, isRefined: true},
       {name: 'New York', count: 1, isRefined: true},
@@ -31,7 +33,7 @@ test('Search should call the algolia client according to the number of refinemen
 
     expect(cityValues).toEqual(expectedCityValues);
 
-    var cityValuesCustom = data.getFacetValues('city', {sortBy: ['count:asc', 'name:asc']});
+    var cityValuesCustom = results.getFacetValues('city', {sortBy: ['count:asc', 'name:asc']});
     var expectedCityValuesCustom = [
       {name: 'New York', count: 1, isRefined: true},
       {name: 'San Francisco', count: 1, isRefined: false},
@@ -41,7 +43,7 @@ test('Search should call the algolia client according to the number of refinemen
 
     expect(cityValuesCustom).toEqual(expectedCityValuesCustom);
 
-    var cityValuesFn = data.getFacetValues('city', {sortBy: function(a, b) { return a.count - b.count; }});
+    var cityValuesFn = results.getFacetValues('city', {sortBy: function(a, b) { return a.count - b.count; }});
     var expectedCityValuesFn = [
       {name: 'New York', count: 1, isRefined: true},
       {name: 'San Francisco', count: 1, isRefined: false},


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have to migrate all the emitted events to the same structure. This PR takes care of the event: `result`.

Related: https://github.com/algolia/algoliasearch-helper-js/pull/681, https://github.com/algolia/algoliasearch-helper-js/pull/683, https://github.com/algolia/algoliasearch-helper-js/pull/684