### PR TITLE
refactor(error): emit object

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1267,9 +1267,11 @@ AlgoliaSearchHelper.prototype._search = function() {
     this.client.search(queries)
       .then(this._dispatchAlgoliaResponse.bind(this, states, queryId))
       .catch(this._dispatchAlgoliaError.bind(this, queryId));
-  } catch (err) {
+  } catch (error) {
     // If we reach this part, we're in an internal error state
-    this.emit('error', err);
+    this.emit('error', {
+      error: error
+    });
   }
 };
 
@@ -1314,7 +1316,7 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
   });
 };
 
-AlgoliaSearchHelper.prototype._dispatchAlgoliaError = function(queryId, err) {
+AlgoliaSearchHelper.prototype._dispatchAlgoliaError = function(queryId, error) {
   if (queryId < this._lastQueryIdReceived) {
     // Outdated answer
     return;
@@ -1323,7 +1325,9 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaError = function(queryId, err) {
   this._currentNbQueries -= queryId - this._lastQueryIdReceived;
   this._lastQueryIdReceived = queryId;
 
-  this.emit('error', err);
+  this.emit('error', {
+    error: error
+  });
 
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 };

--- a/test/integration-spec/helper.distinct.facet.js
+++ b/test/integration-spec/helper.distinct.facet.js
@@ -35,8 +35,8 @@ test('[INT][FILTERS] Using distinct should let me retrieve all facet without dis
       facets: ['colors']
     });
 
-    helper.on('error', function(err) {
-      done.fail(err);
+    helper.on('error', function(event) {
+      done.fail(event.error);
     });
 
     helper.on('result', function(event) {

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -37,8 +37,8 @@ test('[INT][FILTERS] Should retrieve different values for multi facetted records
 
     var calls = 0;
 
-    helper.on('error', function(err) {
-      done.fail(err);
+    helper.on('error', function(event) {
+      done.fail(event.error);
     });
 
     helper.on('result', function(event) {

--- a/test/integration-spec/helper.numerics.js
+++ b/test/integration-spec/helper.numerics.js
@@ -35,8 +35,8 @@ test('[INT][NUMERICS][RAW-API]Test numeric operations on the helper and their re
 
       var calls = 0;
 
-      helper.on('error', function(err) {
-        done.fail(err);
+      helper.on('error', function(event) {
+        done.fail(event.error);
       });
 
       helper.on('result', function(event) {
@@ -106,8 +106,8 @@ test('[INT][NUMERICS][MANAGED-API]Test numeric operations on the helper and thei
 
       var calls = 0;
 
-      helper.on('error', function(err) {
-        done.fail(err);
+      helper.on('error', function(event) {
+        done.fail(event.error);
       });
 
       helper.on('result', function(event) {

--- a/test/integration-spec/helper.searchOnce.js
+++ b/test/integration-spec/helper.searchOnce.js
@@ -35,8 +35,8 @@ test(
       var state0 = helper.state;
 
       var calls = 1;
-      helper.on('error', function(err) {
-        done.fail(err);
+      helper.on('error', function(event) {
+        done.fail(event.error);
       });
 
       helper.on('result', function(event) {

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -34,8 +34,8 @@ test('[INT][TAGS]Test tags operations on the helper and their results on the alg
 
     var calls = 0;
 
-    helper.on('error', function(err) {
-      done.fail(err);
+    helper.on('error', function(event) {
+      done.fail(event.error);
     });
 
     helper.on('result', function(event) {


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have to migrate all the emitted events to the same structure. This PR takes care of the event: `error`.

Related: https://github.com/algolia/algoliasearch-helper-js/pull/681, https://github.com/algolia/algoliasearch-helper-js/pull/683, https://github.com/algolia/algoliasearch-helper-js/pull/684, https://github.com/algolia/algoliasearch-helper-js/pull/699