### PR TITLE
docs: update event signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ var helper = algoliasearchHelper(client, 'indexName', {
   disjunctiveFacets: ['director']
 });
 
-helper.on('result', function(data){
-  console.log(data.hits);
+helper.on('result', function(event){
+  console.log(event.results);
 });
 
 helper.addDisjunctiveFacetRefinement('director', 'Clint Eastwood');
@@ -110,9 +110,9 @@ angular.module('searchApp', ['ngSanitize', 'algoliasearch'])
     disjunctiveFacets: ['category', 'manufacturer'],
     hitsPerPage: 5,
   });
-  $scope.helper.on('result', function(content) {
+  $scope.helper.on('result', function(event) {
     $scope.$apply(function() {
-      $scope.content = content;
+      $scope.content = event.results;
     });
   });
   $scope.toggleRefine = function($event, facet, value) {
@@ -168,8 +168,8 @@ var helper = algoliasearchHelper(client, 'indexName'/*, parameters*/);
 
 3. read the results (with the event "result" handler) and update the UI with the results<br/>
         ```
-        helper.on('result', function(results) {
-          updateUI(results);
+        helper.on('result', function(event) {
+          updateUI(event.results);
         });
         ```
 
@@ -196,8 +196,8 @@ Example:
 var helper = algoliasearchHelper(client, indexName);
 
 // Let's monitor the results with the console
-helper.on('result', function(content) {
-  console.log(content);
+helper.on('result', function(event) {
+  console.log(event.results);
 });
 
 // Let's make an empty search
@@ -431,8 +431,8 @@ You will get a hierarchical presentation of your facet values: a navigation menu
 of your facet values.
 
 ```js
-helper.on('result', function(data){
-  console.log(data.hierarchicalFacets[0]);
+helper.on('result', function(event){
+  console.log(event.results.hierarchicalFacets[0]);
   // {
   //   'name': 'products',
   //   'count': null,
@@ -624,9 +624,9 @@ helper.clearRefinements(function(value, attribute, type) {
 #### Get the values of a facet with the default sort
 
 ```js
-helper.on('result', function(result) {
+helper.on('result', function(event) {
   // Get the facet values for the attribute age
-  result.getFacetValues('age');
+  event.results.getFacetValues('age');
   // It will be ordered :
   //  - refined facets first
   //  - then ordered by number of occurence (bigger count -> higher in the list)
@@ -637,9 +637,9 @@ helper.on('result', function(result) {
 #### Get the values of a facet with a custom sort
 
 ```js
-helper.on('result', function(result) {
+helper.on('result', function(event) {
   // Get the facet values for the attribute age
-  result.getFacetValues('age', {sortBy: ['count:asc']});
+  event.results.getFacetValues('age', {sortBy: ['count:asc']});
   // It will be ordered by number of occurence (lower number => higher position)
   // Elements that can be sorted : count, name, isRefined
   // Type of sort : 'asc' for ascending order, 'desc' for descending order
@@ -651,9 +651,9 @@ helper.on('result', function(result) {
 *This only apply on numeric based facets/attributes.*
 
 ```js
-helper.on('result', function(result) {
+helper.on('result', function(event) {
   // Get the facet values for the attribute age
-  result.getFacetStats('age');
+  event.results.getFacetStats('age');
 });
 ```
 

--- a/documentation-src/metalsmith/content/gettingstarted.md
+++ b/documentation-src/metalsmith/content/gettingstarted.md
@@ -99,8 +99,8 @@ Once you've added those lines, you need to listen to the results coming from Alg
 For now, we'll implement a very basic display of the JSON response in the page.
 
 ```javascript
-helper.on('result', function(content) {
-  renderHits(content);
+helper.on('result', function(event) {
+  renderHits(event.results);
 });
 
 function renderHits(content) {
@@ -139,12 +139,12 @@ see how to add a search input to let our users do a textual search in the data.
 
 Before going further, let's customize a little bit the display of our results.
 We're going to focus on the actual results computed by Algolia. The
-results are returned in the `hits` attribute of the `content`. Let's display
+results are returned in the `hits` attribute of the `results`. Let's display
 only the `name` of each product for now.
 
 ```javascript
-helper.on('result', function(content) {
-  renderHits(content);
+helper.on('result', function(event) {
+  renderHits(event.results);
 });
 
 function renderHits(content) {
@@ -181,8 +181,8 @@ results returned by Algolia. This way the users can easily understand why the
 results match their query.
 
 ```javascript
-helper.on('result', function(content) {
-  renderHits(content);
+helper.on('result', function(event) {
+  renderHits(event.results);
 });
 
 function renderHits(content) {
@@ -267,9 +267,9 @@ an attribute. The object returned by this method contains three properties:
 Let's add the rendering of the facet list into the `result` handler.
 
 ```javascript
-helper.on('result', function(content) {
-  renderFacetList(content);
-  renderHits(content);
+helper.on('result', function(event) {
+  renderFacetList(event.results);
+  renderHits(event.results);
 });
 ```
 

--- a/documentation-src/metalsmith/content/reference.md
+++ b/documentation-src/metalsmith/content/reference.md
@@ -226,8 +226,8 @@ You will get a hierarchical presentation of your facet values: a navigation menu
 of your facet values.
 
 ```js
-helper.on('result', function(data){
-  console.log(data.hierarchicalFacets[0]);
+helper.on('result', function(event){
+  console.log(event.results.hierarchicalFacets[0]);
   // {
   //   'name': 'products',
   //   'count': null,

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ var SearchResults = require('./src/SearchResults');
  *   facets: ['shipping'],
  *   disjunctiveFacets: ['category']
  * });
- * helper.on('result', function(result) {
- *   console.log(result);
+ * helper.on('result', function(event) {
+ *   console.log(event.results);
  * });
  * helper
  *   .toggleFacetRefinement('category', 'Movies & TV Shows')

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -679,11 +679,11 @@ function vanillaSortFn(order, data) {
  * @return {FacetValue[]|HierarchicalFacet} depending on the type of facet of
  * the attribute requested (hierarchical, disjunctive or conjunctive)
  * @example
- * helper.on('results', function(content){
+ * helper.on('result', function(event){
  *   //get values ordered only by name ascending using the string predicate
- *   content.getFacetValues('city', {sortBy: ['name:asc']});
+ *   event.results.getFacetValues('city', {sortBy: ['name:asc']});
  *   //get values  ordered only by count ascending using a function
- *   content.getFacetValues('city', {
+ *   event.results.getFacetValues('city', {
  *     // this is equivalent to ['count:asc']
  *     sortBy: function(a, b) {
  *       if (a.count === b.count) return 0;

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -16,11 +16,11 @@ var version = require('./version');
 /**
  * Event triggered when a parameter is set or updated
  * @event AlgoliaSearchHelper#event:change
- * @property {SearchParameters} state the current parameters with the latest changes applied
- * @property {SearchResults} lastResults the previous results received from Algolia. `null` before
- * the first request
+ * @property {object} event
+ * @property {SearchParameters} event.state the current parameters with the latest changes applied
+ * @property {SearchResults} event.results the previous results received from Algolia. `null` before the first request
  * @example
- * helper.on('change', function(state, lastResults) {
+ * helper.on('change', function(event) {
  *   console.log('The parameters have changed');
  * });
  */
@@ -28,11 +28,11 @@ var version = require('./version');
 /**
  * Event triggered when a main search is sent to Algolia
  * @event AlgoliaSearchHelper#event:search
- * @property {SearchParameters} state the parameters used for this search
- * @property {SearchResults} lastResults the results from the previous search. `null` if
- * it is the first search.
+ * @property {object} event
+ * @property {SearchParameters} event.state the parameters used for this search
+ * @property {SearchResults} event.results the results from the previous search. `null` if it is the first search.
  * @example
- * helper.on('search', function(state, lastResults) {
+ * helper.on('search', function(event) {
  *   console.log('Search sent');
  * });
  */
@@ -40,12 +40,12 @@ var version = require('./version');
 /**
  * Event triggered when a search using `searchForFacetValues` is sent to Algolia
  * @event AlgoliaSearchHelper#event:searchForFacetValues
- * @property {SearchParameters} state the parameters used for this search
- * it is the first search.
- * @property {string} facet the facet searched into
- * @property {string} query the query used to search in the facets
+ * @property {object} event
+ * @property {SearchParameters} event.state the parameters used for this search it is the first search.
+ * @property {string} event.facet the facet searched into
+ * @property {string} event.query the query used to search in the facets
  * @example
- * helper.on('searchForFacetValues', function(state, facet, query) {
+ * helper.on('searchForFacetValues', function(event) {
  *   console.log('searchForFacetValues sent');
  * });
  */
@@ -53,10 +53,10 @@ var version = require('./version');
 /**
  * Event triggered when a search using `searchOnce` is sent to Algolia
  * @event AlgoliaSearchHelper#event:searchOnce
- * @property {SearchParameters} state the parameters used for this search
- * it is the first search.
+ * @property {object} event
+ * @property {SearchParameters} event.state the parameters used for this search it is the first search.
  * @example
- * helper.on('searchOnce', function(state) {
+ * helper.on('searchOnce', function(event) {
  *   console.log('searchOnce sent');
  * });
  */
@@ -64,11 +64,11 @@ var version = require('./version');
 /**
  * Event triggered when the results are retrieved from Algolia
  * @event AlgoliaSearchHelper#event:result
- * @property {SearchResults} results the results received from Algolia
- * @property {SearchParameters} state the parameters used to query Algolia. Those might
- * be different from the one in the helper instance (for example if the network is unreliable).
+ * @property {object} event
+ * @property {SearchResults} event.results the results received from Algolia
+ * @property {SearchParameters} event.state the parameters used to query Algolia. Those might be different from the one in the helper instance (for example if the network is unreliable).
  * @example
- * helper.on('result', function(results, state) {
+ * helper.on('result', function(event) {
  *   console.log('Search results received');
  * });
  */
@@ -77,9 +77,10 @@ var version = require('./version');
  * Event triggered when Algolia sends back an error. For example, if an unknown parameter is
  * used, the error can be caught using this event.
  * @event AlgoliaSearchHelper#event:error
- * @property {Error} error the error returned by the Algolia.
+ * @property {object} event
+ * @property {Error} event.error the error returned by the Algolia.
  * @example
- * helper.on('error', function(error) {
+ * helper.on('error', function(event) {
  *   console.log('Houston we got a problem.');
  * });
  */


### PR DESCRIPTION
Partially closes #680.

This PR is a follow up on #673. 

We moved the list of parameters to a single argument for the `change` event. To be consistent we have migrated all the emitted events to the same structure. This PR takes care of updating the documentation for the signature of those events.

Related: https://github.com/algolia/algoliasearch-helper-js/pull/681, https://github.com/algolia/algoliasearch-helper-js/pull/683, https://github.com/algolia/algoliasearch-helper-js/pull/684, https://github.com/algolia/algoliasearch-helper-js/pull/699, https://github.com/algolia/algoliasearch-helper-js/pull/700