### PR TITLE
fix(sortBy): compare whole prefix instead of first character

### DIFF
--- a/src/functions/formatSort.js
+++ b/src/functions/formatSort.js
@@ -5,22 +5,29 @@ var find = require('./find');
 /**
  * Transform sort format from user friendly notation to lodash format
  * @param {string[]} sortBy array of predicate of the form "attribute:order"
+ * @param {string[]} [defaults] array of predicate of the form "attribute:order"
  * @return {array.<string[]>} array containing 2 elements : attributes, orders
  */
 module.exports = function formatSort(sortBy, defaults) {
+  defaults = (defaults || []).map(function(sort) {
+    return sort.split(':');
+  });
+
   return sortBy.reduce(
-    function preparePredicate(out, sortInstruction) {
-      var sortInstructions = sortInstruction.split(':');
-      if (defaults && sortInstructions.length === 1) {
-        var similarDefault = find(defaults, function(predicate) {
-          return predicate[0] === sortInstruction[0];
+    function preparePredicate(out, sort) {
+      var sortInstruction = sort.split(':');
+      if (sortInstruction.length === 1) {
+        var matchingDefault = find(defaults, function(defaultInstruction) {
+          return defaultInstruction[0] === sortInstruction[0];
         });
-        if (similarDefault) {
-          sortInstructions = similarDefault.split(':');
+        if (matchingDefault) {
+          out[0].push(matchingDefault[0]);
+          out[1].push(matchingDefault[1]);
+          return out;
         }
       }
-      out[0].push(sortInstructions[0]);
-      out[1].push(sortInstructions[1]);
+      out[0].push(sortInstruction[0]);
+      out[1].push(sortInstruction[1]);
       return out;
     },
     [[], []]

--- a/src/functions/formatSort.js
+++ b/src/functions/formatSort.js
@@ -16,20 +16,14 @@ module.exports = function formatSort(sortBy, defaults) {
   return sortBy.reduce(
     function preparePredicate(out, sort) {
       var sortInstruction = sort.split(':');
-
-      if (sortInstruction.length > 1) {
-        out[0].push(sortInstruction[0]);
-        out[1].push(sortInstruction[1]);
-        return out;
-      }
-
+      
       var matchingDefault = find(defaultInstructions, function(
         defaultInstruction
       ) {
         return defaultInstruction[0] === sortInstruction[0];
       });
 
-      if (!matchingDefault) {
+      if (sortInstruction.length > 1 || !matchingDefault) {
         out[0].push(sortInstruction[0]);
         out[1].push(sortInstruction[1]);
         return out;

--- a/src/functions/formatSort.js
+++ b/src/functions/formatSort.js
@@ -9,25 +9,34 @@ var find = require('./find');
  * @return {array.<string[]>} array containing 2 elements : attributes, orders
  */
 module.exports = function formatSort(sortBy, defaults) {
-  defaults = (defaults || []).map(function(sort) {
+  var defaultInstructions = (defaults || []).map(function(sort) {
     return sort.split(':');
   });
 
   return sortBy.reduce(
     function preparePredicate(out, sort) {
       var sortInstruction = sort.split(':');
-      if (sortInstruction.length === 1) {
-        var matchingDefault = find(defaults, function(defaultInstruction) {
-          return defaultInstruction[0] === sortInstruction[0];
-        });
-        if (matchingDefault) {
-          out[0].push(matchingDefault[0]);
-          out[1].push(matchingDefault[1]);
-          return out;
-        }
+
+      if (sortInstruction.length > 1) {
+        out[0].push(sortInstruction[0]);
+        out[1].push(sortInstruction[1]);
+        return out;
       }
-      out[0].push(sortInstruction[0]);
-      out[1].push(sortInstruction[1]);
+
+      var matchingDefault = find(defaultInstructions, function(
+        defaultInstruction
+      ) {
+        return defaultInstruction[0] === sortInstruction[0];
+      });
+
+      if (!matchingDefault) {
+        out[0].push(sortInstruction[0]);
+        out[1].push(sortInstruction[1]);
+        return out;
+      }
+
+      out[0].push(matchingDefault[0]);
+      out[1].push(matchingDefault[1]);
       return out;
     },
     [[], []]

--- a/src/functions/formatSort.js
+++ b/src/functions/formatSort.js
@@ -16,7 +16,7 @@ module.exports = function formatSort(sortBy, defaults) {
   return sortBy.reduce(
     function preparePredicate(out, sort) {
       var sortInstruction = sort.split(':');
-      
+
       var matchingDefault = find(defaultInstructions, function(
         defaultInstruction
       ) {

--- a/test/spec/functions/formatSort.js
+++ b/test/spec/functions/formatSort.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var formatSort = require('../../../src/functions/formatSort');
+
+it('splits into attribute & direction', function() {
+  expect(formatSort(['isRefined:desc', 'isNotRefined:desc'])).toEqual([
+    ['isRefined', 'isNotRefined'],
+    ['desc', 'desc']
+  ]);
+});
+
+it('leaves direction empty if no direction was given', function() {
+  expect(formatSort(['isRefined:desc', 'isNotRefined'])).toEqual([
+    ['isRefined', 'isNotRefined'],
+    ['desc', undefined]
+  ]);
+});
+
+it('takes from defaults if no direction was given', function() {
+  expect(
+    formatSort(
+      ['isRefined:desc', 'isNotRefined'],
+      ['books:asc', 'isRefined:desc', 'isNotRefined:asc']
+    )
+  ).toEqual([
+    ['isRefined', 'isNotRefined'],
+    ['desc', 'asc']
+  ]);
+});
+
+it('leaves direction empty if no direction was given & no default matches', function() {
+  expect(
+    formatSort(
+      ['isRefined:desc', 'isNotRefined'],
+      ['books:asc', 'isRefined:desc']
+    )
+  ).toEqual([
+    ['isRefined', 'isNotRefined'],
+    ['desc', undefined]
+  ]);
+});


### PR DESCRIPTION

This was noticed in https://github.com/algolia/algoliasearch-helper-js/pull/690#discussion_r282467917 by @samouss, so I took the time to rewrite this function a little bit to be more clear (IMO)