### PR TITLE
feat(SearchParameters): avoid undefined values

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -197,7 +197,10 @@ function SearchParameters(newParameters) {
 
   var self = this;
   Object.keys(params).forEach(function(paramName) {
-    if (SearchParameters.PARAMETERS.indexOf(paramName) === -1) {
+    var isKeyUnknown = SearchParameters.PARAMETERS.indexOf(paramName) === -1;
+    var isValueDefined = params[paramName] !== undefined;
+
+    if (isKeyUnknown && isValueDefined) {
       self[paramName] = params[paramName];
     }
   });

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1358,15 +1358,32 @@ SearchParameters.prototype = {
       throw error;
     }
 
-    var parsedParams = SearchParameters._parseNumbers(params);
+    var self = this;
+    var nextWithNumbers = SearchParameters._parseNumbers(params);
+    var previousPlainObject = Object.keys(this).reduce(function(acc, key) {
+      acc[key] = self[key];
+      return acc;
+    }, {});
 
-    return this.mutateMe(function mergeWith(newInstance) {
-      Object.keys(params).forEach(function(k) {
-        newInstance[k] = parsedParams[k];
-      });
+    var nextPlainObject = Object.keys(nextWithNumbers).reduce(
+      function(previous, key) {
+        var isPreviousValueDefined = previous[key] !== undefined;
+        var isNextValueDefined = nextWithNumbers[key] !== undefined;
 
-      return newInstance;
-    });
+        if (isPreviousValueDefined && !isNextValueDefined) {
+          return omit(previous, [key]);
+        }
+
+        if (isNextValueDefined) {
+          previous[key] = nextWithNumbers[key];
+        }
+
+        return previous;
+      },
+      previousPlainObject
+    );
+
+    return new this.constructor(nextPlainObject);
   },
 
   /**

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1413,20 +1413,6 @@ SearchParameters.prototype = {
   filter: function(filters) {
     return filterState(this, filters);
   },
-  /**
-   * Helper function to make it easier to build new instances from a mutating
-   * function
-   * @private
-   * @param {function} fn newMutableState -> previousState -> () function that will
-   * change the value of the newMutable to the desired state
-   * @return {SearchParameters} a new instance with the specified modifications applied
-   */
-  mutateMe: function mutateMe(fn) {
-    var newState = new this.constructor(this);
-
-    fn(newState, this);
-    return newState;
-  },
 
   /**
    * Helper function to get the hierarchicalFacet separator or the default one (`>`)

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -197,10 +197,10 @@ function SearchParameters(newParameters) {
 
   var self = this;
   Object.keys(params).forEach(function(paramName) {
-    var isKeyUnknown = SearchParameters.PARAMETERS.indexOf(paramName) === -1;
+    var isKeyKnown = SearchParameters.PARAMETERS.indexOf(paramName) !== -1;
     var isValueDefined = params[paramName] !== undefined;
 
-    if (isKeyUnknown && isValueDefined) {
+    if (!isKeyKnown && isValueDefined) {
       self[paramName] = params[paramName];
     }
   });

--- a/test/spec/SearchParameters/constructorFn.js
+++ b/test/spec/SearchParameters/constructorFn.js
@@ -51,6 +51,15 @@ test('Constructor should accept an object with unknown keys', function() {
   });
 });
 
+test('Constructor should ignore keys with undefined values', function() {
+  var state = new SearchParameters({
+    query: '',
+    page: undefined
+  });
+
+  expect(state).not.toHaveProperty('page');
+});
+
 test('Factory should accept an object with known keys', function() {
   var legitConfig = {
     'query': '',
@@ -74,7 +83,7 @@ test('Factory should accept an object with known keys', function() {
   });
 });
 
-test('Constructor should accept an object with unknown keys', function() {
+test('Factory should accept an object with unknown keys', function() {
   var betaConfig = {
     'query': '',
     'disjunctiveFacets': [
@@ -97,4 +106,13 @@ test('Constructor should accept an object with unknown keys', function() {
   forOwn(betaConfig, function(v, k) {
     expect(params[k]).toEqual(v);
   });
+});
+
+test('Factory should ignore keys with undefined values', function() {
+  var state = SearchParameters.make({
+    query: '',
+    page: undefined
+  });
+
+  expect(state).not.toHaveProperty('page');
 });

--- a/test/spec/SearchParameters/setQueryParameters.js
+++ b/test/spec/SearchParameters/setQueryParameters.js
@@ -53,3 +53,33 @@ test('setQueryParameters should add unknown properties', function() {
     expect(state1[k]).toEqual(v);
   });
 });
+
+test('setQueryParameters should ignore undefined parameters without previous values', function() {
+  var state0 = new SearchParameters({
+    aroundLatLng: '10,12'
+  });
+
+  var state1 = state0.setQueryParameters({
+    query: undefined,
+    page: undefined
+  });
+
+  expect(state1).not.toHaveProperty('query');
+  expect(state1).not.toHaveProperty('page');
+});
+
+test('setQueryParameters should omit defined parameters with next values of undefined', function() {
+  var state0 = new SearchParameters({
+    aroundLatLng: '10,12',
+    query: 'Apple',
+    page: 5
+  });
+
+  var state1 = state0.setQueryParameters({
+    query: undefined,
+    page: undefined
+  });
+
+  expect(state1).not.toHaveProperty('query');
+  expect(state1).not.toHaveProperty('page');
+});

--- a/test/spec/SearchParameters/setQueryParameters.js
+++ b/test/spec/SearchParameters/setQueryParameters.js
@@ -1,22 +1,21 @@
 'use strict';
 
-var forOwn = require('lodash/forOwn');
 var SearchParameters = require('../../../src/SearchParameters');
 
 test('setQueryParameters should return the same instance if the options is falsey', function() {
-  var originalSP = new SearchParameters({
+  var state = new SearchParameters({
     facets: ['a', 'b'],
     ignorePlurals: false,
     attributesToHighlight: ''
   });
 
-  expect(originalSP).toBe(originalSP.setQueryParameters());
-  expect(originalSP).toBe(originalSP.setQueryParameters(null));
-  expect(originalSP).toBe(originalSP.setQueryParameters(undefined));
+  expect(state).toBe(state.setQueryParameters());
+  expect(state).toBe(state.setQueryParameters(null));
+  expect(state).toBe(state.setQueryParameters(undefined));
 });
 
 test('setQueryParameters should be able to mix an actual state with a new set of parameters', function() {
-  var originalSP = new SearchParameters({
+  var state0 = new SearchParameters({
     facets: ['a', 'b'],
     ignorePlurals: false,
     attributesToHighlight: ''
@@ -27,12 +26,15 @@ test('setQueryParameters should be able to mix an actual state with a new set of
     attributesToHighlight: ['city', 'country'],
     replaceSynonymsInHighlight: true
   };
-  var newSP = originalSP.setQueryParameters(params);
 
-  expect(newSP.facets).toEqual(params.facets);
-  expect(newSP.attributesToHighlight).toEqual(newSP.attributesToHighlight);
-  expect(newSP.replaceSynonymsInHighlight).toBe(newSP.replaceSynonymsInHighlight);
-  expect(newSP.ignorePlurals).toBe(originalSP.ignorePlurals);
+  var state1 = state0.setQueryParameters(params);
+
+  expect(state1).toEqual(new SearchParameters({
+    facets: ['a', 'c'],
+    ignorePlurals: false,
+    attributesToHighlight: ['city', 'country'],
+    replaceSynonymsInHighlight: true
+  }));
 });
 
 test('setQueryParameters should add unknown properties', function() {
@@ -49,9 +51,13 @@ test('setQueryParameters should add unknown properties', function() {
 
   var state1 = state0.setQueryParameters(params);
 
-  forOwn(params, function(v, k) {
-    expect(state1[k]).toEqual(v);
-  });
+  expect(state1).toEqual(new SearchParameters({
+    facets: ['a', 'b'],
+    ignorePlurals: false,
+    attributesToHighlight: '',
+    unknow1: ['a', 'c'],
+    facet: ['city', 'country']
+  }));
 });
 
 test('setQueryParameters should ignore undefined parameters without previous values', function() {


### PR DESCRIPTION
This PR updates the internals of the `SearchParameters` to avoid `undefined` values inside the search parameters. This change allows to easily merge multiple `SearchParameters` top-down since we don't have "ghost" value on the object. The outcome is the change of semantics for the parameters and setters:

- `query is omit`: params does not have query e.g. `searchBox` not mounted
- `query: ''`: params does have an empty query e.g. `searchBox` mounted with initial state
- `query: 'Apple'`: params does have a query refinement e.g. `searchBox` mounted with refinement

-----

- `setQuery()`: omit the query e.g. `widget.dispose`
- `setQuery('')`: sets the default value for the query e.g. `widget.getConfiguration`
- `setQuery('Apple')`: sets the given value for the query e.g. `widget.refine`