### PR TITLE
feat(search): allow the search only with Derived Helpers

### DIFF
--- a/test/spec/algoliasearch.helper/derive/multiqueries.js
+++ b/test/spec/algoliasearch.helper/derive/multiqueries.js
@@ -2,48 +2,54 @@
 
 var algoliasearchHelper = require('../../../../index.js');
 
-test('[Derived helper] no derived helpers', function() {
-  expect.assertions(1);
-  var client = {
-    search: searchTest
+function makeFakeClient(assertions) {
+  return {
+    search: function() {
+      assertions.apply(null, arguments);
+
+      return new Promise(function() {});
+    }
   };
+}
+
+test('[Derived helper] no derived helpers', function() {
+  var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
+
   helper.search();
 
-  function searchTest(requests) {
+  function assertions(requests) {
     expect(requests.length).toBe(1);
-
-    return new Promise(function() {});
   }
 });
 
 test('[Derived helper] 1 derived helpers, no modifications', function() {
-  expect.assertions(2);
-  var client = {
-    search: searchTest
-  };
+  var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
-  helper.derive(function(s) { return s; });
+
+  helper.derive(function(state) {
+    return state;
+  });
+
   helper.search();
 
-  function searchTest(requests) {
+  function assertions(requests) {
     expect(requests.length).toBe(2);
     expect(requests[0]).toEqual(requests[1]);
-
-    return new Promise(function() {});
   }
 });
 
-test('[Derived helper] no derived helpers, modification', function() {
-  expect.assertions(4);
-  var client = {
-    search: searchTest
-  };
+test('[Derived helper] 1 derived helpers, modification', function() {
+  var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
-  helper.derive(function(s) { return s.setQuery('otherQuery'); });
+
+  helper.derive(function(state) {
+    return state.setQuery('otherQuery');
+  });
+
   helper.search();
 
-  function searchTest(requests) {
+  function assertions(requests) {
     expect(requests.length).toBe(2);
     expect(requests[0].params.query).toBeUndefined();
     expect(requests[1].params.query).toBe('otherQuery');
@@ -52,7 +58,5 @@ test('[Derived helper] no derived helpers, modification', function() {
     delete requests[1].params.query;
 
     expect(requests[0]).toEqual(requests[1]);
-
-    return new Promise(function() {});
   }
 });

--- a/test/spec/algoliasearch.helper/derive/multiqueries.js
+++ b/test/spec/algoliasearch.helper/derive/multiqueries.js
@@ -60,3 +60,18 @@ test('[Derived helper] 1 derived helpers, modification', function() {
     expect(requests[0]).toEqual(requests[1]);
   }
 });
+
+test('[Derived helper] only search with the derived helpers', function() {
+  var client = makeFakeClient(assertions);
+  var helper = algoliasearchHelper(client, '');
+
+  helper.derive(function(state) {
+    return state;
+  });
+
+  helper.searchOnlyWithDerivedHelpers();
+
+  function assertions(requests) {
+    expect(requests.length).toBe(1);
+  }
+});

--- a/test/spec/algoliasearch.helper/derive/multiqueries.js
+++ b/test/spec/algoliasearch.helper/derive/multiqueries.js
@@ -12,7 +12,7 @@ function makeFakeClient(assertions) {
   };
 }
 
-test('trigger a search without without derivation', function() {
+test('trigger a search without derivation', function() {
   var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
 

--- a/test/spec/algoliasearch.helper/derive/multiqueries.js
+++ b/test/spec/algoliasearch.helper/derive/multiqueries.js
@@ -12,7 +12,7 @@ function makeFakeClient(assertions) {
   };
 }
 
-test('[Derived helper] no derived helpers', function() {
+test('trigger a search without without derivation', function() {
   var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
 
@@ -23,7 +23,7 @@ test('[Derived helper] no derived helpers', function() {
   }
 });
 
-test('[Derived helper] 1 derived helpers, no modifications', function() {
+test('trigger a search with one derivation without a state change', function() {
   var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
 
@@ -39,7 +39,7 @@ test('[Derived helper] 1 derived helpers, no modifications', function() {
   }
 });
 
-test('[Derived helper] 1 derived helpers, modification', function() {
+test('trigger a search with one derivation with a state change', function() {
   var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
 
@@ -61,7 +61,7 @@ test('[Derived helper] 1 derived helpers, modification', function() {
   }
 });
 
-test('[Derived helper] only search with the derived helpers', function() {
+test('trigger a search with derivation only', function() {
   var client = makeFakeClient(assertions);
   var helper = algoliasearchHelper(client, '');
 


### PR DESCRIPTION
This PR introduces a new method called `searchOnlyWithDerivedHelpers`. As the name suggests the function allows to bypass the "main" instance search to only use the Derived Helpers. The main idea behind the API is to be able to control which state is used by the query, without having to alter the internal state of the helper (it would be useful for federated search for example). With the `.derive` API we have a full control on the query with the derivation function. We can alter the state without impact on the internal instance of the Helper.

I choose to implement this behavior with a dedicated method to limit the number of changes. We'll release a major version but we should keep the support of the original behavior because it will not only benefit InstantSearch.js. We also want to benefit the Lodash reduction in React InstantSearch.

```js
const helper = algoliasearchHelper(client, 'index');
const derivedHelper = helper.derive(state => {
  // Alter the state without impact on the main instance
  return state;
});

helper.on('search', () => {
  // The search is not triggered on the main instance
});

derivedHelper.on('search', () => {
  // The search is only triggered on the derived instance
});

// Trigger only 1 queries vs 2 queries with a regular search
helper.searchOnlyWithDerivedHelpers();
```