### PR TITLE
chore(lodash): remove lodash from dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jest-watch-typeahead": "0.3.0",
     "jsdoc-parse": "1.2.7",
     "jsdoc-to-markdown": "1.3.9",
+    "lodash": "4.17.5",
     "marked": "0.3.19",
     "metalsmith": "2.3.0",
     "metalsmith-changed": "2.0.0",
@@ -90,8 +91,7 @@
     "webpack-stream": "3.2.0"
   },
   "dependencies": {
-    "events": "^1.1.1",
-    "lodash": "^4.17.5"
+    "events": "^1.1.1"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7852,6 +7852,11 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
+lodash@4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
+
 lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -7866,11 +7871,6 @@ lodash@^4.17.10, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
 
 "lodash@~ 2.4.1", lodash@~2.4.1:
   version "2.4.2"


### PR DESCRIPTION
It's still required for some tests etc., so it's kept in devDependencies

(blocked by #694)

closes #552