### PR TITLE
docs(serverUsed): mention getRankingInfo

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -297,6 +297,9 @@ function SearchResults(state, results) {
   this.automaticRadius = mainSubResponse.automaticRadius;
   /**
    * String identifying the server used to serve this request.
+   *
+   * getRankingInfo needs to be set to `true` for this to be returned
+   *
    * @member {string}
    * @example "c7-use-2.algolia.net",
    */


### PR DESCRIPTION
This is a basically useless response, and we maybe should remove it, and similar field (as you can read them from _rawResponse), or we can arbitrarily set all remaining parameters.

(PR is on `next` so we can discuss the removal without needing to change the base)

fixes #500