### PR TITLE
feat(getState): remove getState

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,15 +764,6 @@ var state1 = helper.searchOnce({hitsPerPage: 1})
 });
 ```
 
-### URL Helpers
-
-#### Get a plain object with a subset of the state
-
-```js
-// to an object with the query and all the refinements
-helper.getState(['query', 'attribute:*']);
-```
-
 ### Query parameters
 
 There are lots of other parameters you can set.

--- a/documentation-src/metalsmith/content/reference.md
+++ b/documentation-src/metalsmith/content/reference.md
@@ -417,7 +417,6 @@ Algolia.
 
 ### State management
 
-{{> jsdoc jsdoc/helper/getState}}
 {{> jsdoc jsdoc/helper/setState}}
 {{> jsdoc jsdoc/helper/overrideStateWithoutTriggeringChangeEvent}}
 
@@ -505,10 +504,10 @@ that you might encounter in the documentation.
 The SearchParameters is the class that structures all the parameters
 that are needed to build a query to Algolia.
 
-The SearchParameters instances are usually refered to as the state of
+The SearchParameters instances are usually referred to as the state of
 the search. This state is available when receiving `change` and `search`
 events, and with `result` as a secondary parameter. Alternatively,
-it can be retrieved using the [getState](#AlgoliaSearchHelper#getState) method on the Helper.
+it can be retrieved using `helper.state`.
 
 SearchParameter is an immutable class. Each setter method returns a new
 instance with the modification, and does not modify the object it is

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -911,19 +911,6 @@ AlgoliaSearchHelper.prototype.setState = function(newState) {
 };
 
 /**
- * Get the current search state stored in the helper. This object is immutable.
- * @return {SearchParameters|object} if filters is specified a plain object is
- * returned containing only the requested fields, otherwise return the unfiltered
- * state
- * @example
- * // Get the complete state as stored in the helper
- * helper.getState();
- */
-AlgoliaSearchHelper.prototype.getState = function() {
-  return this.state;
-};
-
-/**
  * Override the current state without triggering a change event.
  * Do not use this method unless you know what you are doing. (see the example
  * for a legit use case)

--- a/test/datasets/SearchResults/getFacetValues.dataset.js
+++ b/test/datasets/SearchResults/getFacetValues.dataset.js
@@ -21,7 +21,7 @@ if (require.main === module) {
     maxValuesPerFacet: 3
   });
 
-  var initialState = helper.getState();
+  var initialState = helper.state;
 
   helper.searchOnce().then(function() {
     helper.__saveLastToFile('noFilters.json');

--- a/test/datasets/SearchResults/getRefinements.dataset.js
+++ b/test/datasets/SearchResults/getRefinements.dataset.js
@@ -30,7 +30,7 @@ if (require.main === module) {
     }]
   });
 
-  var initialState = helper.getState();
+  var initialState = helper.state;
 
   helper.searchOnce().then(function() {
     helper.__saveLastToFile('noFilters.json');

--- a/test/spec/algoliasearch.helper/state.js
+++ b/test/spec/algoliasearch.helper/state.js
@@ -23,14 +23,6 @@ test('setState should set the state of the helper and trigger a change event', f
   helper.setState(state1);
 });
 
-test('getState should return the current state of the helper', function() {
-  var initialState = {query: 'a query'};
-  var helper = algoliasearchHelper(fakeClient, null, initialState);
-
-  expect(helper.getState()).toEqual(new SearchParameters(initialState));
-  expect(helper.getState()).toEqual(helper.state);
-});
-
 test('setState should set a default hierarchicalFacetRefinement when a rootPath is defined', function() {
   var searchParameters = {hierarchicalFacets: [
     {
@@ -47,7 +39,7 @@ test('setState should set a default hierarchicalFacetRefinement when a rootPath 
   ]};
 
   var helper = algoliasearchHelper(fakeClient, null, searchParameters);
-  var initialHelperState = Object.assign({}, helper.getState());
+  var initialHelperState = Object.assign({}, helper.state);
 
   expect(initialHelperState.hierarchicalFacetsRefinements).toEqual({
     'hierarchicalCategories.lvl0': ['Cameras & Camcorders']
@@ -55,11 +47,11 @@ test('setState should set a default hierarchicalFacetRefinement when a rootPath 
 
   // reset state
   helper.setState(helper.state.removeHierarchicalFacet('hierarchicalCategories.lvl0'));
-  expect(helper.getState().hierarchicalFacetsRefinements).toEqual({});
+  expect(helper.state.hierarchicalFacetsRefinements).toEqual({});
 
   // re-add `hierarchicalFacets`
   helper.setState(Object.assign({}, helper.state, searchParameters));
-  var finalHelperState = Object.assign({}, helper.getState());
+  var finalHelperState = Object.assign({}, helper.state);
 
   expect(initialHelperState).toEqual(finalHelperState);
   expect(finalHelperState.hierarchicalFacetsRefinements).toEqual({


### PR DESCRIPTION

You can always retrieve the state as `helper.state`, so there's no need for `helper.getState()`. See https://github.com/algolia/instantsearch.js/pull/3774 for the removal of this in InstantSearch (React didn't use this function)

BREAKING CHANGE: use helper.state instead of helper.getState()