### PR TITLE
fix(merge): consider "null" as not an object

### DIFF
--- a/src/functions/merge.js
+++ b/src/functions/merge.js
@@ -1,11 +1,11 @@
 'use strict';
 
-function isPlainObject(value) {
+function isObjectLike(value) {
   return typeof value === 'object' && value !== null;
 }
 
 function clone(value) {
-  if (typeof value === 'object' && value !== null) {
+  if (isObjectLike(value)) {
     return merge(Array.isArray(value) ? [] : {}, value);
   }
   return value;
@@ -43,11 +43,11 @@ function merge() {
       return clone(source);
     }
 
-    if (!isPlainObject(acc) && typeof acc !== 'function') {
+    if (!isObjectLike(acc) && typeof acc !== 'function') {
       return clone(source);
     }
 
-    if (!isPlainObject(source) && typeof source !== 'function') {
+    if (!isObjectLike(source) && typeof source !== 'function') {
       return acc;
     }
 

--- a/src/functions/merge.js
+++ b/src/functions/merge.js
@@ -1,5 +1,9 @@
 'use strict';
 
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null;
+}
+
 function clone(value) {
   if (typeof value === 'object' && value !== null) {
     return merge(Array.isArray(value) ? [] : {}, value);
@@ -39,11 +43,11 @@ function merge() {
       return clone(source);
     }
 
-    if (typeof acc !== 'object' && typeof acc !== 'function') {
+    if (!isPlainObject(acc) && typeof acc !== 'function') {
       return clone(source);
     }
 
-    if (typeof source !== 'object' && typeof source !== 'function') {
+    if (!isPlainObject(source) && typeof source !== 'function') {
       return acc;
     }
 

--- a/test/spec/functions/merge.js
+++ b/test/spec/functions/merge.js
@@ -171,7 +171,7 @@ it('should not convert strings to arrays when merging arrays of `source`', funct
   expect(actual).toEqual({a: ['x', 'y', 'z']});
 });
 
-it('should return an object for null', function() {
+it('should not consider null as an object', function() {
   expect(merge(null, {})).toEqual({});
   expect(merge({this: 'b'}, {this: 'k'}, {this: null})).toEqual({this: null});
   expect(merge({this: 'b'}, {this: null}, {this: undefined})).toEqual({this: null});

--- a/test/spec/functions/merge.js
+++ b/test/spec/functions/merge.js
@@ -171,3 +171,9 @@ it('should not convert strings to arrays when merging arrays of `source`', funct
   expect(actual).toEqual({a: ['x', 'y', 'z']});
 });
 
+it('should return an object for null', function() {
+  expect(merge(null, {})).toEqual({});
+  expect(merge({this: 'b'}, {this: 'k'}, {this: null})).toEqual({this: null});
+  expect(merge({this: 'b'}, {this: null}, {this: undefined})).toEqual({this: null});
+  expect(merge({this: 'b'}, {this: null}, {this: 'k'})).toEqual({this: 'k'});
+});


### PR DESCRIPTION
This behaves the same as lodash (but they didn't have a test for it)

This fixes the behaviour seen in http://localhost:6006/?path=/story/breadcrumb--with-hierarchical-menu on `refactor/usage-search-parameters` (on InstantSearch.js when you  link this version of the helper)

IFW-777