### PR TITLE
chore(release): allow canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "vinyl": "1.2.0",
     "watchify": "3.7.0",
     "webpack": "1.15.0",
-    "webpack-stream": "3.2.0"
+    "webpack-stream": "3.2.0",
+    "yargs": "13.2.4"
   },
   "dependencies": {
     "events": "^1.1.1"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -31,20 +31,20 @@ if (isCanary) {
 }
 
 function releaseCanaryVersion() {
-  shell.echo(`Algoliasearch-Helper release CANARY version`);
+  shell.echo(`Algolia JS Helper release CANARY version`);
 
   checkCleanWorkdir();
   updateCanaryVersion(canaryVersion => {
     build();
     publishOnNpm('canary');
     revertStableVersion(packageJson.version, () => {
-      shell.echo(`Algoliasearch-Helper v${canaryVersion} released`);
+      shell.echo(`Algolia JS Helper v${canaryVersion} released`);
     });
   });
 }
 
 function releaseStableVersion() {
-  shell.echo(`Algoliasearch-Helper release STABLE version`);
+  shell.echo(`Algolia JS Helper release STABLE version`);
 
   checkDevelopBranch();
   checkCleanWorkdir();
@@ -58,7 +58,7 @@ function releaseStableVersion() {
       publish();
       goBackToDevelop();
 
-      shell.echo(`Algoliasearch-Helper v${version} released`);
+      shell.echo(`Algolia JS Helper v${version} released`);
     });
   });
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+
 'use strict';
 
 const prompt = require('prompt');
 const semver = require('semver');
 const mversion = require('mversion');
+const argv = require('yargs').argv;
 const path = require('path');
 const fs = require('fs');
 
@@ -20,29 +22,57 @@ const packageJson = require('../package.json');
 
 const {showChangelog, getChangelog, updateChangelog} = require('./lib/conventionalChangelog.js');
 
-shell.echo(`Algoliasearch-Helper release script`);
+const {canary: isCanary} = argv;
 
-checkEnvironment();
-mergeDevIntoMaster();
-showChangelog(shell);
-promptVersion(packageJson.version, (version) => {
-  bumpVersion(version, () => {
+if (isCanary) {
+  releaseCanaryVersion();
+} else {
+  releaseStableVersion();
+}
+
+function releaseCanaryVersion() {
+  shell.echo(`Algoliasearch-Helper release CANARY version`);
+
+  checkCleanWorkdir();
+  updateCanaryVersion(canaryVersion => {
     build();
-    updateChangelog(shell);
-    commitNewFiles(version);
-    publish();
-    goBackToDevelop();
+    publishOnNpm('canary');
+    revertStableVersion(packageJson.version, () => {
+      shell.echo(`Algoliasearch-Helper v${canaryVersion} released`);
+    });
   });
-});
+}
 
-function checkEnvironment() {
+function releaseStableVersion() {
+  shell.echo(`Algoliasearch-Helper release STABLE version`);
+
+  checkDevelopBranch();
+  checkCleanWorkdir();
+  mergeDevIntoMaster();
+  showChangelog(shell);
+  promptVersion(packageJson.version, (version) => {
+    bumpVersion(version, () => {
+      build();
+      updateChangelog(shell);
+      commitNewFiles(version);
+      publish();
+      goBackToDevelop();
+
+      shell.echo(`Algoliasearch-Helper v${version} released`);
+    });
+  });
+}
+
+function checkDevelopBranch() {
   const currentBranch = shell.exec('git rev-parse --abbrev-ref HEAD', {silent: true}).toString().trim();
 
   if (currentBranch !== 'develop') {
     shell.echo('The release script should be started from develop'.error);
     process.exit(1);
   }
+}
 
+function checkCleanWorkdir() {
   const changes = shell.exec('git status --porcelain', {silent: true}).toString().trim();
 
   if (changes.length > 0) {
@@ -85,7 +115,7 @@ function promptVersion(currentVersion, cb) {
 }
 
 function bumpVersion(newVersion, cb) {
-  shell.echo('Updating files');
+  shell.echo(`Updating files to version: ${newVersion}`);
   shell.echo('..src/version.js');
 
   var versionFile = path.join(__dirname, '../src/version.js');
@@ -118,11 +148,15 @@ function publish() {
   shell.exec('git push origin', {silent: true});
   shell.exec('git push origin --tags', {silent: true});
 
-  shell.echo('Publishing new version on NPM');
-  shell.exec('npm publish', {silent: true});
+  publishOnNpm('latest');
 
   shell.echo('Publishing new documentation');
   shell.exec('yarn run doc:publish');
+}
+
+function publishOnNpm(tag) {
+  shell.echo('Publishing new version on NPM');
+  shell.exec(`npm publish --tag ${tag}`, {silent: true});
 }
 
 function goBackToDevelop() {
@@ -135,4 +169,17 @@ function goBackToDevelop() {
 
 function build() {
   shell.exec('yarn run build');
+}
+
+function updateCanaryVersion(cb) {
+  const lastCommitHash = shell.exec('git rev-parse --short HEAD', {silent: true}).toString().trim();
+  const canaryVersion = `0.0.0-${lastCommitHash}`;
+
+  bumpVersion(canaryVersion, () => {
+    cb(canaryVersion);
+  });
+}
+
+function revertStableVersion(version, cb) {
+  bumpVersion(version, cb);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,6 +2579,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -3915,6 +3924,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emoji-regex@~6.1.0:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
@@ -5028,6 +5042,11 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
   integrity sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -9251,7 +9270,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-locale@^3.0.0:
+os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
@@ -11486,6 +11505,15 @@ string-width@^2.0.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -11548,7 +11576,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -12932,6 +12960,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrap-fn@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/wrap-fn/-/wrap-fn-0.1.5.tgz#f21b6e41016ff4a7e31720dbc63a09016bdf9845"
@@ -13016,7 +13053,7 @@ y18n@^3.2.0, y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-"y18n@^3.2.1 || ^4.0.0":
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
@@ -13039,6 +13076,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.0.tgz#7016b6dd03e28e1418a510e258be4bff5a31138f"
+  integrity sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -13052,6 +13097,23 @@ yargs-parser@^5.0.0:
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:
     camelcase "^3.0.0"
+
+yargs@13.2.4:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
+  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.0"
 
 yargs@^12.0.2:
   version "12.0.5"


### PR DESCRIPTION
This PR allows to release a "canary" version of the package. 

The version follows this format: `0.0.0-SHORT_SHA-1` where `SHORT_SHA-1` is the hash of the latest commit. The version is then published on npm with the tag `canary`. The command does not update the CHANGELOG or create a Git Tag. The usage of the version is mostly internal. Its purpose is to publish a non-stable version that can be used directly from other projects via npm (useful for the CI).

At some point, we might want to port the process on other projects as well. It would allow us to test packages directly from E2E tests or even on example projects that we maintain. I didn't use it (yet) to publish a version (I did test it though with the `pack` command). I'll do it once the PR is approved and merged.

![Screenshot 2019-05-17 at 14 30 40](https://user-images.githubusercontent.com/6513513/57928203-61173980-78b0-11e9-9c17-dade9f5c6640.png)