### PR TITLE
fix(getFacetValues): don't throw error when there's no facet

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1155,7 +1155,7 @@ declare namespace algoliasearchHelper {
     getFacetValues(
       attribute: string,
       opts: any
-    ): SearchResults.FacetValue[] | SearchResults.HierarchicalFacet;
+    ): SearchResults.FacetValue[] | SearchResults.HierarchicalFacet | undefined;
 
     /**
      * Returns the facet stats if attribute is defined and the facet contains some.

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -674,7 +674,7 @@ function vanillaSortFn(order, data) {
  * bigger or -1 otherwise.
  *
  * The default value for this attribute `['isRefined:desc', 'count:desc', 'name:asc']`
- * @return {FacetValue[]|HierarchicalFacet} depending on the type of facet of
+ * @return {FacetValue[]|HierarchicalFacet|undefined} depending on the type of facet of
  * the attribute requested (hierarchical, disjunctive or conjunctive)
  * @example
  * helper.on('result', function(event){
@@ -693,7 +693,9 @@ function vanillaSortFn(order, data) {
  */
 SearchResults.prototype.getFacetValues = function(attribute, opts) {
   var facetValues = extractNormalizedFacetValues(this, attribute);
-  if (!facetValues) throw new Error(attribute + ' is not a retrieved facet.');
+  if (!facetValues) {
+    return undefined;
+  }
 
   var options = defaultsPure({}, opts, {sortBy: SearchResults.DEFAULT_SORT});
 

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -149,7 +149,7 @@ test('getFacetValues(disjunctive) returns correct facet values with the name `le
   expect(facetValues.length).toBe(2);
 });
 
-test.only('getFacetValues(unknown) returns undefined (does not throw)', function() {
+test('getFacetValues(unknown) returns undefined (does not throw)', function() {
   var searchParams = new SearchParameters({
     index: 'instant_search'
   });
@@ -163,5 +163,5 @@ test.only('getFacetValues(unknown) returns undefined (does not throw)', function
 
   var results = new SearchResults(searchParams, [result, result]);
 
-  expect(results.getFacetValues('type')).toEqual(undefined);
+  expect(results.getFacetValues('type')).toBeUndefined();
 });

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -148,3 +148,20 @@ test('getFacetValues(disjunctive) returns correct facet values with the name `le
   expect(facetValues).toEqual(expected);
   expect(facetValues.length).toBe(2);
 });
+
+test.only('getFacetValues(unknown) returns undefined (does not throw)', function() {
+  var searchParams = new SearchParameters({
+    index: 'instant_search'
+  });
+
+  var result = {
+    query: '',
+    // it does not matter if the result here is given or not,
+    // if something is not a parameter, it will not be read.
+    facets: {}
+  };
+
+  var results = new SearchResults(searchParams, [result, result]);
+
+  expect(results.getFacetValues('type')).toEqual(undefined);
+});


### PR DESCRIPTION
connectMenu could throw if a facet is retrieved which isn't in the SearchParameters, but we are changing that to return undefined in those cases.

This is part 1 of the big error removal process.

see algolia/instantsearch.js#3084
see #722