### PR TITLE
fix(getHierarchicalFacetBreadcrumb): don't throw an error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,7 +259,7 @@ declare namespace algoliasearchHelper {
     getTags(...args: any[]): any;
     getRefinements(...args: any[]): any;
     getNumericRefinement(...args: any[]): any;
-    getHierarchicalFacetBreadcrumb(...args: any[]): any;
+    getHierarchicalFacetBreadcrumb(facetName: string): string[];
     containsRefinement(...args: any[]): any;
     clearCache(...args: any[]): any;
     setClient(client: SearchClient): this;

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1443,6 +1443,10 @@ SearchParameters.prototype = {
    * @return {array.<string>} the path as an array of string
    */
   getHierarchicalFacetBreadcrumb: function(facetName) {
+    if (!this.isHierarchicalFacet(facetName)) {
+      return [];
+    }
+
     var refinement = this.getHierarchicalRefinement(facetName)[0];
     if (!refinement) return [];
 

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1443,11 +1443,6 @@ SearchParameters.prototype = {
    * @return {array.<string>} the path as an array of string
    */
   getHierarchicalFacetBreadcrumb: function(facetName) {
-    if (!this.isHierarchicalFacet(facetName)) {
-      throw new Error(
-        'Cannot get the breadcrumb of an unknown hierarchical facet: `' + facetName + '`');
-    }
-
     var refinement = this.getHierarchicalRefinement(facetName)[0];
     if (!refinement) return [];
 

--- a/test/spec/hierarchical-facets/breadcrumb.js
+++ b/test/spec/hierarchical-facets/breadcrumb.js
@@ -54,5 +54,7 @@ test('hierarchical facets: using getHierarchicalFacetBreadcrumb on an undefined 
   var client = algoliasearch(appId, apiKey);
   var helper = algoliasearchHelper(client, indexName, {});
 
-  expect(helper.getHierarchicalFacetBreadcrumb.bind('categories')).toThrow();
+  expect(
+    helper.getHierarchicalFacetBreadcrumb('categories')
+  ).toEqual([]);
 });

--- a/test/spec/hierarchical-facets/breadcrumb.js
+++ b/test/spec/hierarchical-facets/breadcrumb.js
@@ -52,7 +52,9 @@ test('hierarchical facets: using getHierarchicalFacetBreadcrumb on an undefined 
   var indexName = 'hierarchical-simple-indexName';
 
   var client = algoliasearch(appId, apiKey);
-  var helper = algoliasearchHelper(client, indexName, {});
+  var helper = algoliasearchHelper(client, indexName, {
+    hierarchicalFacetsRefinements: {categories: ['beers > IPA > Flying dog']}
+  });
 
   expect(
     helper.getHierarchicalFacetBreadcrumb('categories')


### PR DESCRIPTION
Funnily enough, this test didn't fail becuse the bind always threw

We return an empty array if the facet wasn't declared

see #722