### PR TITLE
fix(getConjunctiveRefinements): no error when requested facet is not conjunctive

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -536,7 +536,7 @@ SearchParameters.prototype = {
    */
   getConjunctiveRefinements: function(facetName) {
     if (!this.isConjunctiveFacet(facetName)) {
-      throw new Error(facetName + ' is not defined in the facets attribute of the helper configuration');
+      return [];
     }
     return this.facetsRefinements[facetName] || [];
   },

--- a/test/spec/SearchParameters/getConjunctiveRefinements.js
+++ b/test/spec/SearchParameters/getConjunctiveRefinements.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('getConjunctiveRefinements returns value in facets', function() {
+  var state = new SearchParameters({
+    facets: ['test'],
+    facetsRefinements: {
+      test: ['zongo']
+    }
+  });
+
+  expect(state.getConjunctiveRefinements('test')).toEqual(['zongo']);
+});
+
+test('getConjunctiveRefinements returns [] if facet is not conjunctive', function() {
+  var state = new SearchParameters({
+    facetsRefinements: {
+      test: ['zongo']
+    }
+  });
+
+  expect(state.getConjunctiveRefinements('test')).toEqual([]);
+});


### PR DESCRIPTION
Instead we will return [] there.

see #722