### PR TITLE
fix(getDisjunctiveRefinements): remove error

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -547,9 +547,7 @@ SearchParameters.prototype = {
    */
   getDisjunctiveRefinements: function(facetName) {
     if (!this.isDisjunctiveFacet(facetName)) {
-      throw new Error(
-        facetName + ' is not defined in the disjunctiveFacets attribute of the helper configuration'
-      );
+      return [];
     }
     return this.disjunctiveFacetsRefinements[facetName] || [];
   },

--- a/test/spec/SearchParameters/getDisjunctiveRefinements.js
+++ b/test/spec/SearchParameters/getDisjunctiveRefinements.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('getDisjunctiveRefinements returns value in facets', function() {
+  var state = new SearchParameters({
+    disjunctiveFacets: ['test'],
+    disjunctiveFacetsRefinements: {
+      test: ['zongo']
+    }
+  });
+
+  expect(state.getDisjunctiveRefinements('test')).toEqual(['zongo']);
+});
+
+test('getDisjunctiveRefinements returns [] if facet is not disjunctive', function() {
+  var state = new SearchParameters({
+    disjunctiveFacetsRefinements: {
+      test: ['zongo']
+    }
+  });
+
+  expect(state.getDisjunctiveRefinements('test')).toEqual([]);
+});


### PR DESCRIPTION
The condition is there to prevent a refinement of a non-declared facet, however we should just return the empty state there instead ([]).

See #722