### PR TITLE
fix(isHierarchicalFacetRefined): return false if refinement isn't a facet

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1066,6 +1066,9 @@ SearchParameters.prototype = {
     if (this.isHierarchicalFacetRefined(facet)) {
       throw new Error(facet + ' is already refined.');
     }
+    if (!this.isHierarchicalFacet(facet)) {
+      throw new Error(facet + ' is not defined in the hierarchicalFacets attribute of the helper configuration.');
+    }
     var mod = {};
     mod[facet] = [path];
     return this.setQueryParameters({

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1187,8 +1187,7 @@ SearchParameters.prototype = {
    */
   isHierarchicalFacetRefined: function isHierarchicalFacetRefined(facet, value) {
     if (!this.isHierarchicalFacet(facet)) {
-      throw new Error(
-        facet + ' is not defined in the hierarchicalFacets attribute of the helper configuration');
+      return false;
     }
 
     var refinements = this.getHierarchicalRefinement(facet);

--- a/test/spec/SearchParameters/isHierarchicalFacetRefined.js
+++ b/test/spec/SearchParameters/isHierarchicalFacetRefined.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var SearchParameters = require('../../../src/SearchParameters');
+
+test('isHierarchicalFacetRefined returns true if value in hierarchicalFacetsRefinements', function() {
+  var state = new SearchParameters({
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1'],
+      separator: ' | '
+    }],
+    hierarchicalFacetsRefinements: {
+      categories: ['beers | fancy ones']
+    }
+  });
+
+  expect(state.isHierarchicalFacetRefined('categories', 'beers | fancy ones')).toBe(true);
+});
+
+test('isHierarchicalFacetRefined returns true if something is refined when not passing a value', function() {
+  var state = new SearchParameters({
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1'],
+      separator: ' | '
+    }],
+    hierarchicalFacetsRefinements: {
+      categories: ['beers | fancy ones']
+    }
+  });
+
+  expect(state.isHierarchicalFacetRefined('categories')).toBe(true);
+});
+
+test('isHierarchicalFacetRefined returns false if value not in hierarchicalFacetsRefinements', function() {
+  var state = new SearchParameters({
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1'],
+      separator: ' | '
+    }],
+    hierarchicalFacetsRefinements: {
+      categories: ['beers | fancy ones']
+    }
+  });
+
+  expect(state.isHierarchicalFacetRefined('categories', 'beers | cheap ones')).toBe(false);
+});
+
+test('isHierarchicalFacetRefined returns false if facet is not hierarchical', function() {
+  var state = new SearchParameters({
+    hierarchicalFacetsRefinements: {
+      categories: ['beers | fancy ones']
+    }
+  });
+
+  expect(state.isHierarchicalFacetRefined('categories', 'beers | fancy ones')).toBe(false);
+});


### PR DESCRIPTION
Similar to #727, except here we _do_ need to keep throwing the error on add

see #722