### PR TITLE
fix(errors): remove isRefined

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -933,21 +933,6 @@ AlgoliaSearchHelper.prototype.overrideStateWithoutTriggeringChangeEvent = functi
 };
 
 /**
- * @deprecated since 2.4.0, see {@link AlgoliaSearchHelper#hasRefinements}
- */
-AlgoliaSearchHelper.prototype.isRefined = function(facet, value) {
-  if (this.state.isConjunctiveFacet(facet)) {
-    return this.state.isFacetRefined(facet, value);
-  } else if (this.state.isDisjunctiveFacet(facet)) {
-    return this.state.isDisjunctiveFacetRefined(facet, value);
-  }
-
-  throw new Error(facet +
-    ' is not properly defined in this helper configuration' +
-    '(use the facets or disjunctiveFacets keys to configure it)');
-};
-
-/**
  * Check if an attribute has any numeric, conjunctive, disjunctive or hierarchical filters.
  * @param {string} attribute the name of the attribute
  * @return {boolean} true if the attribute is filtered by at least one value

--- a/test/spec/algoliasearch.helper/incorrectFacetDefinition.js
+++ b/test/spec/algoliasearch.helper/incorrectFacetDefinition.js
@@ -2,30 +2,26 @@
 
 var algoliasearchHelper = require('../../../index');
 
-var _ = require('lodash');
-
 var fakeClient = {};
 
 test('Conjunctive facet should be declared to be refined', function() {
   var h = algoliasearchHelper(fakeClient, '', {});
 
-  expect(_.bind(h.addRefine, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.removeRefine, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.isRefined, h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.addRefine.bind(h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.removeRefine.bind(h, 'undeclaredFacet', 'value')).toThrow();
 });
 
-test('Conjuctive facet should be declared to be excluded', function() {
+test('Conjunctive facet should be declared to be excluded', function() {
   var h = algoliasearchHelper(fakeClient, '', {});
 
-  expect(_.bind(h.addExclude, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.removeExclude, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.isExcluded, h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.addExclude.bind(h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.removeExclude.bind(h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.isExcluded.bind(h, 'undeclaredFacet', 'value')).toThrow();
 });
 
 test('Conjuctive facet should be declared to be refine', function() {
   var h = algoliasearchHelper(fakeClient, '', {});
 
-  expect(_.bind(h.addDisjunctiveRefine, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.removeDisjunctiveRefine, h, 'undeclaredFacet', 'value')).toThrow();
-  expect(_.bind(h.isRefined, h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.addDisjunctiveRefine.bind(h, 'undeclaredFacet', 'value')).toThrow();
+  expect(h.removeDisjunctiveRefine.bind(h, 'undeclaredFacet', 'value')).toThrow();
 });

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -97,37 +97,19 @@ test('isDisjunctiveRefined', function() {
   expect(helper.isDisjunctiveRefined(facet, value)).toBe(false);
 });
 
-test('IsRefined should return true if the (facet, value ) is refined.', function() {
+test('hasRefinements(facet) should return true if the facet is refined.', function() {
   var helper = algoliasearchHelper(emptyClient, null, {
     facets: ['facet1']
   });
 
-  helper.addRefine('facet1', 'boom');
-
-  expect(helper.isRefined('facet1', 'boom')).toBe(true);
-
-  expect(helper.isRefined('facet1', 'booohh')).toBe(false);
-  expect(_.bind(helper.isRefined, helper, 'notAFacet', 'maoooh')).toThrow();
-  expect(_.bind(helper.isRefined, helper, null, null)).toThrow();
-});
-
-test('isRefined(facet)/hasRefinements should return true if the facet is refined.', function() {
-  var helper = algoliasearchHelper(emptyClient, null, {
-    facets: ['facet1']
-  });
-
-  expect(helper.isRefined('facet1')).toBe(false);
   expect(helper.hasRefinements('facet1')).toBe(false);
 
   helper.addRefine('facet1', 'boom');
 
-  expect(helper.isRefined('facet1')).toBe(true);
   expect(helper.hasRefinements('facet1')).toBe(true);
 
-  expect(_.bind(helper.isRefined, helper, 'notAFacet')).toThrow();
   // in complete honesty we should be able to detect numeric facets but we can't
   // t.throws(helper.hasRefinements.bind(helper, 'notAFacet'), 'not a facet');
-  expect(_.bind(helper.isRefined, null)).toThrow();
   expect(_.bind(helper.hasRefinements, null)).toThrow();
 });
 
@@ -185,17 +167,17 @@ test('[Conjunctive] Facets should be resilient to user attempt to use numbers', 
   });
 
   helper.addRefine('facet1', 42);
-  expect(helper.isRefined('facet1', 42)).toBe(true);
-  expect(helper.isRefined('facet1', '42')).toBe(true);
+  expect(helper.hasRefinements('facet1', 42)).toBe(true);
+  expect(helper.hasRefinements('facet1', '42')).toBe(true);
 
   var stateWithFacet1and42 = helper.state;
 
   helper.removeRefine('facet1', '42');
-  expect(helper.isRefined('facet1', '42')).toBe(false);
+  expect(helper.hasRefinements('facet1', '42')).toBe(false);
 
   helper.setState(stateWithFacet1and42);
   helper.removeRefine('facet1', 42);
-  expect(helper.isRefined('facet1', 42)).toBe(false);
+  expect(helper.hasRefinements('facet1', 42)).toBe(false);
 });
 
 test('[Disjunctive] Facets should be resilient to user attempt to use numbers', function() {


### PR DESCRIPTION
This method is now throwing an error when nothing is refined, while really it should be false like `hasRefinements`. Because of the other inconsistencies & the fact that it's deprecated, we are removing it

see #722

BREAKING CHANGE: removed helper.isRefined, use helper.hasRefinements instead