### PR TITLE
feat(requestBuilder): prevent needless extra requests for empty refinements

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1245,13 +1245,19 @@ SearchParameters.prototype = {
    * @return {string[]}
    */
   getRefinedDisjunctiveFacets: function getRefinedDisjunctiveFacets() {
+    var self = this;
+
     // attributes used for numeric filter can also be disjunctive
     var disjunctiveNumericRefinedFacets = intersection(
-      Object.keys(this.numericRefinements),
+      Object.keys(this.numericRefinements).filter(function(facet) {
+        return Object.keys(self.numericRefinements[facet]).length > 0;
+      }),
       this.disjunctiveFacets
     );
 
-    return Object.keys(this.disjunctiveFacetsRefinements)
+    return Object.keys(this.disjunctiveFacetsRefinements).filter(function(facet) {
+      return self.disjunctiveFacetsRefinements[facet].length > 0;
+    })
       .concat(disjunctiveNumericRefinedFacets)
       .concat(this.getRefinedHierarchicalFacets());
   },
@@ -1263,11 +1269,14 @@ SearchParameters.prototype = {
    * @return {string[]}
    */
   getRefinedHierarchicalFacets: function getRefinedHierarchicalFacets() {
+    var self = this;
     return intersection(
       // enforce the order between the two arrays,
       // so that refinement name index === hierarchical facet index
       this.hierarchicalFacets.map(function(facet) { return facet.name; }),
-      Object.keys(this.hierarchicalFacetsRefinements)
+      Object.keys(this.hierarchicalFacetsRefinements).filter(function(facet) {
+        return self.hierarchicalFacetsRefinements[facet].length > 0;
+      })
     );
   },
   /**

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -64,5 +64,5 @@ test('does only a single query if refinements are empty', function() {
   });
 
   var queries = getQueries(searchParams.index, searchParams);
-  expect(queries.length).toBe(1);
+  expect(queries).toHaveLength(1);
 });

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var requestBuilder = require('../../src/requestBuilder.js');
+var SearchParameters = require('../../src/SearchParameters');
 var getQueries = requestBuilder._getQueries;
 
 test('The request builder should set analytics to subsequent queries', function() {
@@ -45,4 +46,23 @@ test('The request builder should should force clickAnalytics to false on subsequ
   expect(queries.length).toBe(2);
   expect(queries[0].params.clickAnalytics).toBe(undefined);
   expect(queries[1].params.clickAnalytics).toBe(false);
+});
+
+test('does only a single query if refinements are empty', function() {
+  var searchParams = new SearchParameters({
+    disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
+    hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}],
+    disjunctiveFacetsRefinements: {
+      test_disjunctive: []
+    },
+    numericRefinements: {
+      test_numeric: {}
+    },
+    hierarchicalFacetsRefinements: {
+      test_hierarchical: []
+    }
+  });
+
+  var queries = getQueries(searchParams.index, searchParams);
+  expect(queries.length).toBe(1);
 });


### PR DESCRIPTION
We are now moving towards passing empty arrays to refinements; so we need to make sure no extra requests are done.