### PR TITLE
fix(toggleRefinement): keep an empty array when clearing

### DIFF
--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -52,7 +52,9 @@ var lib = {
    */
   removeRefinement: function removeRefinement(refinementList, attribute, value) {
     if (value === undefined) {
-      return lib.clearRefinement(refinementList, attribute);
+      return lib.clearRefinement(refinementList, function(v, f) {
+        return attribute === f;
+      });
     }
 
     var valueAsString = '' + value;

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -107,14 +107,11 @@ var lib = {
         var facetList = values.filter(function(value) {
           return !attribute(value, key, refinementType);
         });
-        if (facetList.length > 0) {
-          if (facetList.length !== values.length) {
-            hasChanged = true;
-          }
-          memo[key] = facetList;
-        } else {
+
+        if (facetList.length !== values.length) {
           hasChanged = true;
         }
+        memo[key] = facetList;
 
         return memo;
       }, {});

--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -52,6 +52,8 @@ var lib = {
    */
   removeRefinement: function removeRefinement(refinementList, attribute, value) {
     if (value === undefined) {
+      // we use the "filter" form of clearRefinement, since it leaves empty values as-is
+      // the form with a string will remove the attribute completely
       return lib.clearRefinement(refinementList, function(v, f) {
         return attribute === f;
       });

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -664,11 +664,10 @@ SearchParameters.prototype = {
             var predicateResult = attribute({val: value, op: operator}, key, 'numeric');
             if (!predicateResult) outValues.push(value);
           });
-          if (outValues.length > 0) {
-            if (outValues.length !== values.length) hasChanged = true;
-            operatorList[operator] = outValues;
+          if (outValues.length !== values.length) {
+            hasChanged = true;
           }
-          else hasChanged = true;
+          operatorList[operator] = outValues;
         });
 
         memo[key] = operatorList;

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -671,9 +671,7 @@ SearchParameters.prototype = {
           else hasChanged = true;
         });
 
-        if (objectHasKeys(operatorList)) {
-          memo[key] = operatorList;
-        }
+        memo[key] = operatorList;
 
         return memo;
       }, {});

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -762,6 +762,9 @@ function getFacetStatsIfAvailable(facetList, facetName) {
  * See the [refinement type](#Refinement) for an exhaustive view of the available
  * data.
  *
+ * Note that for a numeric refinement, results are grouped per operator, this
+ * means that it will return responses for operators which are empty.
+ *
  * @return {Array.<Refinement>} all the refinements
  */
 SearchResults.prototype.getRefinements = function() {

--- a/test/spec/SearchParameters/numericFilters.js
+++ b/test/spec/SearchParameters/numericFilters.js
@@ -2,16 +2,19 @@
 
 var SearchParameters = require('../../../src/SearchParameters');
 
-var attribute = 'attribute';
-var operator = '=';
 
 /* Ensure that we add and then remove the same value, and get a state equivalent to the initial one */
 function testSameValue(value) {
+  var attribute = 'attribute';
+  var operator = '=';
+
   var state0 = new SearchParameters();
   var state1 = state0.addNumericRefinement(attribute, operator, value);
   var stateEmpty = new SearchParameters({
     numericRefinements: {
-      [attribute]: {}
+      [attribute]: {
+        [operator]: []
+      }
     }
   });
   expect(state1.isNumericRefined(attribute, operator, value)).toBeTruthy();

--- a/test/spec/SearchParameters/numericFilters.js
+++ b/test/spec/SearchParameters/numericFilters.js
@@ -9,10 +9,15 @@ var operator = '=';
 function testSameValue(value) {
   var state0 = new SearchParameters();
   var state1 = state0.addNumericRefinement(attribute, operator, value);
+  var stateEmpty = new SearchParameters({
+    numericRefinements: {
+      [attribute]: {}
+    }
+  });
   expect(state1.isNumericRefined(attribute, operator, value)).toBeTruthy();
   var state2 = state1.removeNumericRefinement(attribute, operator, value);
   expect(state2.isNumericRefined(attribute, operator, value)).toBeFalsy();
-  expect(state2).toEqual(state0);
+  expect(state2).toEqual(stateEmpty);
 }
 
 test('Should be able to add remove strings', function() {

--- a/test/spec/SearchParameters/removeXFacetRefinement.js
+++ b/test/spec/SearchParameters/removeXFacetRefinement.js
@@ -1,0 +1,304 @@
+'use strict';
+
+var SearchParameters = require('../../../src/SearchParameters');
+
+describe('removeDisjunctiveFacetRefinement', function() {
+  test('removeDisjunctiveFacetRefinement(attribute)', function() {
+    var state = new SearchParameters({
+      disjunctiveFacets: ['attribute'],
+      disjunctiveFacetsRefinements: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeDisjunctiveFacetRefinement('attribute')).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: ['attribute'],
+        disjunctiveFacetsRefinements: {
+          attribute: []
+        }
+      })
+    );
+  });
+
+  test('removeDisjunctiveFacetRefinement(attribute, value)', function() {
+    var state = new SearchParameters({
+      disjunctiveFacets: ['attribute'],
+      disjunctiveFacetsRefinements: {
+        attribute: ['value', 'value2']
+      }
+    });
+
+    expect(state.removeDisjunctiveFacetRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: ['attribute'],
+        disjunctiveFacetsRefinements: {
+          attribute: ['value2']
+        }
+      })
+    );
+  });
+
+  test('removeDisjunctiveFacetRefinement(attribute, lastValue)', function() {
+    var state = new SearchParameters({
+      disjunctiveFacets: ['attribute'],
+      disjunctiveFacetsRefinements: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeDisjunctiveFacetRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: ['attribute'],
+        disjunctiveFacetsRefinements: {
+          attribute: []
+        }
+      })
+    );
+  });
+});
+
+describe('removeFacetRefinement', function() {
+  test('removeFacetRefinement(attribute)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsRefinements: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeFacetRefinement('attribute')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsRefinements: {
+          attribute: []
+        }
+      })
+    );
+  });
+
+  test('removeFacetRefinement(attribute, value)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsRefinements: {
+        attribute: ['value', 'value2']
+      }
+    });
+
+    expect(state.removeFacetRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsRefinements: {
+          attribute: ['value2']
+        }
+      })
+    );
+  });
+
+  test('removeFacetRefinement(attribute, lastValue)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsRefinements: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeFacetRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsRefinements: {
+          attribute: []
+        }
+      })
+    );
+  });
+});
+
+describe('removeExcludeRefinement', function() {
+  test('removeExcludeRefinement(attribute)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsExcludes: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeExcludeRefinement('attribute')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsExcludes: {
+          attribute: []
+        }
+      })
+    );
+  });
+
+  test('removeExcludeRefinement(attribute, value)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsExcludes: {
+        attribute: ['value', 'value2']
+      }
+    });
+
+    expect(state.removeExcludeRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsExcludes: {
+          attribute: ['value2']
+        }
+      })
+    );
+  });
+
+  test('removeExcludeRefinement(attribute, lastValue)', function() {
+    var state = new SearchParameters({
+      facets: ['attribute'],
+      facetsExcludes: {
+        attribute: ['value']
+      }
+    });
+
+    expect(state.removeExcludeRefinement('attribute', 'value')).toEqual(
+      new SearchParameters({
+        facets: ['attribute'],
+        facetsExcludes: {
+          attribute: []
+        }
+      })
+    );
+  });
+});
+
+describe('removeTagRefinement', function() {
+  test('removeTagRefinement(tag)', function() {
+    var state = new SearchParameters({
+      tagRefinements: ['tag', 'tag2']
+    });
+
+    expect(state.removeTagRefinement('tag')).toEqual(
+      new SearchParameters({
+        tagRefinements: ['tag2']
+      })
+    );
+  });
+
+  test('removeTagRefinement(lastTag)', function() {
+    var state = new SearchParameters({
+      tagRefinements: ['lastTag']
+    });
+
+    expect(state.removeTagRefinement('lastTag')).toEqual(
+      new SearchParameters({
+        tagRefinements: []
+      })
+    );
+  });
+});
+
+describe('removeHierarchicalFacetRefinement', function() {
+  // NOTE: removeHierarchicalFacetRefinement only allows to remove a whole attribute
+  test('removeHierarchicalFacetRefinement(attribute)', function() {
+    var state = new SearchParameters({
+      hierarchicalFacets: [{name: 'attribute'}],
+      hierarchicalFacetsRefinements: {
+        attribute: ['value', 'value2']
+      }
+    });
+
+    expect(state.removeHierarchicalFacetRefinement('attribute')).toEqual(
+      new SearchParameters({
+        hierarchicalFacets: [{name: 'attribute'}],
+        hierarchicalFacetsRefinements: {
+          attribute: []
+        }
+      })
+    );
+  });
+});
+
+describe('removeNumericRefinement', function() {
+  test('removeNumericRefinement(attribute)', function() {
+    var state = new SearchParameters({
+      numericRefinements: {
+        attribute: {
+          '>=': [100]
+        }
+      }
+    });
+
+    expect(state.removeNumericRefinement('attribute')).toEqual(
+      new SearchParameters({
+        numericRefinements: {
+          attribute: {
+            '>=': []
+          }
+        }
+      })
+    );
+  });
+
+  test('removeNumericRefinement(attribute, operator)', function() {
+    var state = new SearchParameters({
+      numericRefinements: {
+        attribute: {
+          '>=': [100]
+        }
+      }
+    });
+
+    expect(state.removeNumericRefinement('attribute', '>=')).toEqual(
+      new SearchParameters({
+        numericRefinements: {
+          attribute: {
+            '>=': []
+          }
+        }
+      })
+    );
+  });
+
+  test('removeNumericRefinement(attribute, operator, value)', function() {
+    var state = new SearchParameters({
+      numericRefinements: {
+        attribute: {
+          '<': [100],
+          '>=': [100, 200]
+        }
+      }
+    });
+
+    expect(state.removeNumericRefinement('attribute', '>=', 100)).toEqual(
+      new SearchParameters({
+        numericRefinements: {
+          attribute: {
+            '<': [100],
+            '>=': [200]
+          }
+        }
+      })
+    );
+  });
+
+  test('removeNumericRefinement(attribute, operator, lastValue)', function() {
+    var state = new SearchParameters({
+      numericRefinements: {
+        attribute: {
+          '<': [100],
+          '>=': [100, 200]
+        }
+      }
+    });
+
+    expect(state.removeNumericRefinement('attribute', '<', 100)).toEqual(
+      new SearchParameters({
+        numericRefinements: {
+          attribute: {
+            '<': [],
+            '>=': [100, 200]
+          }
+        }
+      })
+    );
+  });
+});

--- a/test/spec/algoliasearch.helper/clears.js
+++ b/test/spec/algoliasearch.helper/clears.js
@@ -105,7 +105,9 @@ test('Clear with a function: remove all predicate', function() {
   });
 
   Object.keys(helper.state.numericRefinements).forEach(function(facet) {
-    expect(Object.keys(helper.state.numericRefinements[facet])).toHaveLength(0);
+    Object.keys(helper.state.numericRefinements[facet]).forEach(function(operator) {
+      expect(helper.state.numericRefinements[facet][operator]).toHaveLength(0);
+    });
   });
   Object.keys(helper.state.facetsRefinements).forEach(function(facet) {
     expect(helper.state.facetsRefinements[facet]).toHaveLength(0);
@@ -150,7 +152,7 @@ test('Clear with a function: filtering', function() {
     excluded2: ['0']
   });
   expect(helper.state.numericRefinements).toEqual({
-    numeric1: {},
+    numeric1: {'>=': [], '<': []},
     numeric2: {'>=': [0], '<': [10]}
   });
   expect(helper.state.hierarchicalFacetsRefinements).toEqual({

--- a/test/spec/algoliasearch.helper/clears.js
+++ b/test/spec/algoliasearch.helper/clears.js
@@ -2,8 +2,6 @@
 
 var algoliasearchHelper = require('../../../index');
 var forEach = require('lodash/forEach');
-var keys = require('lodash/keys');
-var isEmpty = require('lodash/isEmpty');
 var isUndefined = require('lodash/isUndefined');
 
 function fixture() {
@@ -11,8 +9,11 @@ function fixture() {
     facets: ['facet1', 'facet2', 'both_facet', 'excluded1', 'excluded2'],
     disjunctiveFacets: ['disjunctiveFacet1', 'disjunctiveFacet2', 'both_facet'],
     hierarchicalFacets: [{
-      facetName: 'hierarchy',
+      name: 'hierarchy1',
       attributes: ['a', 'b', 'c']
+    }, {
+      name: 'hierarchy2',
+      attributes: ['d', 'e', 'f']
     }]
   });
 
@@ -22,6 +23,8 @@ function fixture() {
     .toggleRefine('disjunctiveFacet2', '0')
     .toggleExclude('excluded1', '0')
     .toggleExclude('excluded2', '0')
+    .addHierarchicalFacetRefinement('hierarchy1', '0')
+    .addHierarchicalFacetRefinement('hierarchy2', '0')
     .addNumericRefinement('numeric1', '>=', '0')
     .addNumericRefinement('numeric1', '<', '10')
     .addNumericRefinement('numeric2', '>=', 0)
@@ -31,10 +34,22 @@ function fixture() {
 test('Check that the state objects match how we test them', function() {
   var helper = fixture();
 
-  expect(helper.state.facetsRefinements).toEqual({facet1: ['0'], facet2: ['0']});
-  expect(helper.state.disjunctiveFacetsRefinements).toEqual({disjunctiveFacet1: ['0'], disjunctiveFacet2: ['0']});
-  expect(helper.state.facetsExcludes).toEqual({excluded1: ['0'], excluded2: ['0']});
-  expect(helper.state.numericRefinements).toEqual({numeric1: {'>=': [0], '<': [10]}, numeric2: {'>=': [0], '<': [10]}});
+  expect(helper.state.facetsRefinements).toEqual({
+    facet1: ['0'],
+    facet2: ['0']
+  });
+  expect(helper.state.disjunctiveFacetsRefinements).toEqual({
+    disjunctiveFacet1: ['0'],
+    disjunctiveFacet2: ['0']
+  });
+  expect(helper.state.facetsExcludes).toEqual({
+    excluded1: ['0'],
+    excluded2: ['0']
+  });
+  expect(helper.state.numericRefinements).toEqual({
+    numeric1: {'>=': [0], '<': [10]},
+    numeric2: {'>=': [0], '<': [10]}
+  });
 });
 
 test('Clear with a name should work on every type and not remove others than targetted name', function() {
@@ -89,10 +104,18 @@ test('Clear with a function: remove all predicate', function() {
     return true;
   });
 
-  expect(isEmpty(helper.state.numericRefinements)).toBeTruthy();
-  expect(isEmpty(helper.state.facetsRefinements)).toBeTruthy();
-  expect(isEmpty(helper.state.facetsExcludes)).toBeTruthy();
-  expect(isEmpty(helper.state.disjunctiveFacetsRefinements)).toBeTruthy();
+  Object.keys(helper.state.numericRefinements).forEach(function(facet) {
+    expect(Object.keys(helper.state.numericRefinements[facet])).toHaveLength(0);
+  });
+  Object.keys(helper.state.facetsRefinements).forEach(function(facet) {
+    expect(helper.state.facetsRefinements[facet]).toHaveLength(0);
+  });
+  Object.keys(helper.state.facetsExcludes).forEach(function(facet) {
+    expect(helper.state.facetsExcludes[facet]).toHaveLength(0);
+  });
+  Object.keys(helper.state.disjunctiveFacetsRefinements).forEach(function(facet) {
+    expect(helper.state.disjunctiveFacetsRefinements[facet]).toHaveLength(0);
+  });
 });
 
 test('Clear with a function: filtering', function() {
@@ -102,7 +125,8 @@ test('Clear with a function: filtering', function() {
     numeric: false,
     disjunctiveFacet: false,
     conjunctiveFacet: false,
-    exclude: false
+    exclude: false,
+    hierarchicalFacet: false
   };
 
   helper.clearRefinements(function(value, key, type) {
@@ -111,13 +135,28 @@ test('Clear with a function: filtering', function() {
     return key.indexOf('1') !== -1;
   });
 
-  expect(keys(checkType).length).toBe(4);
-  forEach(checkType, function(typeTest) { expect(typeTest).toBeTruthy(); });
+  expect(Object.keys(checkType).length).toBe(5);
+  forEach(checkType, function(typeTest) {
+    expect(typeTest).toBeTruthy();
+  });
 
-  expect(helper.state.facetsRefinements).toEqual({facet2: ['0']});
-  expect(helper.state.disjunctiveFacetsRefinements).toEqual({disjunctiveFacet2: ['0']});
-  expect(helper.state.facetsExcludes).toEqual({excluded2: ['0']});
-  expect(helper.state.numericRefinements).toEqual({numeric2: {'>=': [0], '<': [10]}});
+  expect(helper.state.facetsRefinements).toEqual({facet1: [], facet2: ['0']});
+  expect(helper.state.disjunctiveFacetsRefinements).toEqual({
+    disjunctiveFacet1: [],
+    disjunctiveFacet2: ['0']
+  });
+  expect(helper.state.facetsExcludes).toEqual({
+    excluded1: [],
+    excluded2: ['0']
+  });
+  expect(helper.state.numericRefinements).toEqual({
+    numeric1: {},
+    numeric2: {'>=': [0], '<': [10]}
+  });
+  expect(helper.state.hierarchicalFacetsRefinements).toEqual({
+    hierarchy1: [],
+    hierarchy2: ['0']
+  });
 });
 
 test('Clearing twice the same attribute should be not problem', function() {

--- a/test/spec/algoliasearch.helper/excludes.js
+++ b/test/spec/algoliasearch.helper/excludes.js
@@ -33,7 +33,7 @@ test('removeExclude should remove an exclusion', function(done) {
   helper.addExclude(facetName, facetValueToExclude);
   expect(helper.state.facetsExcludes[facetName].length === 1).toBeTruthy();
   helper.removeExclude(facetName, facetValueToExclude);
-  expect(!helper.state.facetsExcludes[facetName]).toBeTruthy();
+  expect(helper.state.facetsExcludes[facetName]).toEqual([]);
 
   try {
     helper.removeExclude(facetName, facetValueToExclude);

--- a/test/spec/algoliasearch.helper/numericFilters.js
+++ b/test/spec/algoliasearch.helper/numericFilters.js
@@ -81,7 +81,7 @@ test('Should be able to remove values one by one even 0s', function() {
   helper.removeNumericRefinement('attribute', '>', 0);
   expect(helper.state.numericRefinements.attribute['>']).toEqual([4]);
   helper.removeNumericRefinement('attribute', '>', 4);
-  expect(helper.state.numericRefinements.attribute).toBe(undefined);
+  expect(helper.state.numericRefinements.attribute).toEqual({});
 });
 
 test(
@@ -111,7 +111,7 @@ test(
     helper.addNumericRefinement('attribute', '<', 4);
     expect(helper.state.numericRefinements.attribute).toEqual({'>': [0, 4], '<': [4]});
     helper.removeNumericRefinement('attribute');
-    expect(helper.state.numericRefinements.attribute).toBe(undefined);
+    expect(helper.state.numericRefinements.attribute).toEqual({});
 
     expect(helper.getRefinements('attribute')).toEqual([]);
   }

--- a/test/spec/algoliasearch.helper/numericFilters.js
+++ b/test/spec/algoliasearch.helper/numericFilters.js
@@ -81,7 +81,7 @@ test('Should be able to remove values one by one even 0s', function() {
   helper.removeNumericRefinement('attribute', '>', 0);
   expect(helper.state.numericRefinements.attribute['>']).toEqual([4]);
   helper.removeNumericRefinement('attribute', '>', 4);
-  expect(helper.state.numericRefinements.attribute).toEqual({});
+  expect(helper.state.numericRefinements.attribute['>']).toEqual([]);
 });
 
 test(
@@ -94,10 +94,13 @@ test(
     helper.addNumericRefinement('attribute', '<', 4);
     expect(helper.state.numericRefinements.attribute).toEqual({'>': [0, 4], '<': [4]});
     helper.removeNumericRefinement('attribute', '>');
-    expect(helper.state.numericRefinements.attribute['>']).toBe(undefined);
+    expect(helper.state.numericRefinements.attribute['>']).toEqual([]);
     expect(helper.state.numericRefinements.attribute['<']).toEqual([4]);
 
-    expect(helper.getRefinements('attribute')).toEqual([{type: 'numeric', operator: '<', value: [4]}]);
+    expect(helper.getRefinements('attribute')).toEqual([
+      {type: 'numeric', operator: '>', value: []},
+      {type: 'numeric', operator: '<', value: [4]}
+    ]);
   }
 );
 
@@ -111,9 +114,20 @@ test(
     helper.addNumericRefinement('attribute', '<', 4);
     expect(helper.state.numericRefinements.attribute).toEqual({'>': [0, 4], '<': [4]});
     helper.removeNumericRefinement('attribute');
-    expect(helper.state.numericRefinements.attribute).toEqual({});
+    expect(helper.state.numericRefinements.attribute).toEqual({'>': [], '<': []});
 
-    expect(helper.getRefinements('attribute')).toEqual([]);
+    expect(helper.getRefinements('attribute')).toEqual([
+      {
+        operator: '>',
+        type: 'numeric',
+        value: []
+      },
+      {
+        operator: '<',
+        type: 'numeric',
+        value: []
+      }
+    ]);
   }
 );
 

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -15,12 +15,13 @@ test('Adding refinements should add an entry to the refinements attribute', func
 
   expect(_.isEmpty(helper.state.facetsRefinements)).toBeTruthy();
   helper.addRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements) === 1).toBeTruthy();
+  expect(_.size(helper.state.facetsRefinements)).toBe(1);
   expect(helper.state.facetsRefinements.facet1).toEqual([facetValue]);
   helper.addRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements) === 1).toBeTruthy();
+  expect(_.size(helper.state.facetsRefinements)).toBe(1);
   helper.removeRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements) === 0).toBeTruthy();
+  expect(_.size(helper.state.facetsRefinements)).toBe(1);
+  expect(helper.state.facetsRefinements[facetName]).toEqual([]);
 });
 
 test('Adding several refinements for a single attribute should be handled', function() {


### PR DESCRIPTION
When clearing a refinement using `toggleRefinement` we want to keep the empty refinement object for that attribute, because we use it to override a deeper refinement of that attribute in IS.js with federated search