### PR TITLE
chore(removeHierarchicalFacetRefinement): remove error if not refined

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1096,7 +1096,7 @@ SearchParameters.prototype = {
    */
   removeHierarchicalFacetRefinement: function(facet) {
     if (!this.isHierarchicalFacetRefined(facet)) {
-      throw new Error(facet + ' is not refined.');
+      return this;
     }
     var mod = {};
     mod[facet] = [];

--- a/test/spec/SearchParameters/hierarchical-facets/remove.js
+++ b/test/spec/SearchParameters/hierarchical-facets/remove.js
@@ -15,7 +15,7 @@ test('Should remove a refinement', function() {
   expect(state1.getHierarchicalRefinement('categories')).toEqual([]);
 });
 
-test('Should throw if there is no refinement', function() {
+test('Should not throw if there is no refinement', function() {
   var state0 = SearchParameters.make({
     hierarchicalFacets: [{
       name: 'categories',
@@ -23,11 +23,20 @@ test('Should throw if there is no refinement', function() {
     }]
   });
 
-  expect(state0.removeHierarchicalFacetRefinement.bind(state0, 'categories')).toThrow();
+  expect(state0.removeHierarchicalFacetRefinement('categories')).toEqual(
+    SearchParameters.make({
+      hierarchicalFacets: [{
+        name: 'categories',
+        attributes: ['categories.lvl0', 'categories.lvl1', 'categories.lvl2', 'categories.lvl3']
+      }]
+    })
+  );
 });
 
-test('Should throw if the facet is not defined', function() {
+test('Should not throw if the facet is not defined', function() {
   var state0 = SearchParameters.make({});
 
-  expect(state0.removeHierarchicalFacetRefinement.bind(state0, 'categories')).toThrow();
+  expect(state0.removeHierarchicalFacetRefinement('categories')).toEqual(
+    new SearchParameters()
+  );
 });


### PR DESCRIPTION
This used to throw an error when nothing is refined, but that's inconsistent with the other refinements.

See https://github.com/algolia/instantsearch.js/blob/9e4dda512f3ceddf42d59101a1cc6b34aba70e1d/src/lib/utils/clearRefinements.ts#L26 for a reason to change this.