### PR TITLE
chore(types): add `sumOrFiltersScores` search parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -864,6 +864,12 @@ declare namespace algoliasearchHelper {
      */
     optionalWords?: string[];
     /**
+     * Determines how to calculate the total score for filtering
+     * default: false
+     * https://www.algolia.com/doc/api-reference/api-parameters/sumOrFiltersScores/
+     */
+    sumOrFiltersScores?: boolean;
+    /**
      * Remove stop words from the query before executing it
      * default: false
      * true|false: enable or disable stop words for all 41 supported languages; or


### PR DESCRIPTION
This adds the missing [`sumOrFiltersScores`](https://www.algolia.com/doc/api-reference/api-parameters/sumOrFiltersScores/) search parameter type.