### PR TITLE
feat(algoliasearch): add support for algoliasearch v4 the helper v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Unit & Integration Tests
           command: yarn test --maxWorkers=4
 
-  'test algoliasearch v4':
+  'test algoliasearch v3':
     <<: *defaults
     steps:
       - checkout
@@ -63,8 +63,8 @@ jobs:
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
       - run:
-          name: Install algoliasearch v4
-          command: yarn add "algoliasearch@beta"
+          name: Install algoliasearch v3
+          command: yarn add "algoliasearch@3.35.1"
       - run:
           name: Unit & Integration Tests
           command: yarn test --maxWorkers=4
@@ -87,5 +87,5 @@ workflows:
     jobs:
       - build
       - test
-      - test algoliasearch v4
+      - test algoliasearch v3
       - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Unit & Integration Tests
           command: yarn test --maxWorkers=4
 
-  "test algoliasearch v4":
+  'test algoliasearch v4':
     <<: *defaults
     steps:
       - checkout
@@ -87,4 +87,5 @@ workflows:
     jobs:
       - build
       - test
+      - test algoliasearch v4
       - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,21 @@ jobs:
           name: Unit & Integration Tests
           command: yarn test --maxWorkers=4
 
+  "test algoliasearch v4":
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Install algoliasearch v4
+          command: yarn add "algoliasearch@beta"
+      - run:
+          name: Unit & Integration Tests
+          command: yarn test --maxWorkers=4
+
   docs:
     <<: *defaults
     steps:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,8 @@
+// Note: Bellow, we will be importing both algoliasearch
+// `v3` and algoliasearch `v4` types. The goal is being
+// able to export the algoliasearch-helper types using
+// the developer installed version of the client.
+
 import algoliasearch, {
   // @ts-ignore
   SearchClient as SearchClientV4,

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,10 @@ import algoliasearch, {
   // @ts-ignore
   Response as SearchResponseV3,
 } from 'algoliasearch';
-// @ts-ignore
 import {
   SearchOptions as SearchOptionsV4,
-  SearchResponse as SearchResponseV4,
+  SearchResponse as SearchResponseV4
+// @ts-ignore
 } from '@algolia/client-search';
 import { EventEmitter } from 'events';
 
@@ -1048,8 +1048,65 @@ declare namespace algoliasearchHelper {
     type Operator = '=' | '>' | '>=' | '<' | '<=' | '!=';
   }
 
-  export interface SearchResults<T = any>
-    extends Omit<SearchResponse<T>, 'facets' | 'params'> {
+  export class SearchResults<T = any>
+    implements Omit<SearchResponse<T>, 'facets' | 'params'> {
+    /**
+     * query used to generate the results
+     */
+    query: string;
+    /**
+     * The query as parsed by the engine given all the rules.
+     */
+    parsedQuery: string;
+    /**
+     * all the records that match the search parameters. Each record is
+     * augmented with a new attribute `_highlightResult`
+     * which is an object keyed by attribute and with the following properties:
+     *  - `value` : the value of the facet highlighted (html)
+     *  - `matchLevel`: full, partial or none depending on how the query terms match
+     */
+    hits: (T & {
+      readonly objectID: string;
+    })[];
+    /**
+     * index where the results come from
+     */
+    index: string;
+    /**
+     * number of hits per page requested
+     */
+    hitsPerPage: number;
+    /**
+     * total number of hits of this query on the index
+     */
+    nbHits: number;
+    /**
+     * total number of pages with respect to the number of hits per page and the total number of hits
+     */
+    nbPages: number;
+    /**
+     * current page
+     */
+    page: number;
+    /**
+     * sum of the processing time of all the queries
+     */
+    processingTimeMS: number;
+    /**
+     * The position if the position was guessed by IP.
+     * @example "48.8637,2.3615",
+     */
+    aroundLatLng: string;
+    /**
+     * The radius computed by Algolia.
+     * @example "126792922",
+     */
+    automaticRadius: string;
+    /**
+     * String identifying the server used to serve this request.
+     * @example "c7-use-2.algolia.net",
+     */
+    serverUsed: string;
     /**
      * Boolean that indicates if the computation of the counts did time out.
      * @deprecated
@@ -1060,6 +1117,27 @@ declare namespace algoliasearchHelper {
      * @deprecated
      */
     timeoutHits: boolean;
+
+    /**
+     * True if the counts of the facets is exhaustive
+     */
+    exhaustiveFacetsCount: boolean;
+
+    /**
+     * True if the number of hits is exhaustive
+     */
+    exhaustiveNbHits: boolean;
+
+    /**
+     * Contains the userData if they are set by a [query rule](https://www.algolia.com/doc/guides/query-rules/query-rules-overview/).
+     */
+    userData: any[];
+
+    /**
+     * queryID is the unique identifier of the query used to generate the current search results.
+     * This value is only available if the `clickAnalytics` search parameter is set to `true`.
+     */
+    queryID: string;
     /**
      * disjunctive facets results
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,25 +6,34 @@ import algoliasearch, {
   // @ts-ignore
   QueryParameters as SearchOptionsV3,
   // @ts-ignore
-  Response as SearchResponseV3
+  Response as SearchResponseV3,
 } from 'algoliasearch';
 // @ts-ignore
 import {
   SearchOptions as SearchOptionsV4,
-  SearchResponse as SearchResponseV4
+  SearchResponse as SearchResponseV4,
 } from '@algolia/client-search';
 import { EventEmitter } from 'events';
 
-type DummySearchClientV4 = {readonly addAlgoliaAgent: (segment: string, version?: string) => void};
+type DummySearchClientV4 = {
+  readonly addAlgoliaAgent: (segment: string, version?: string) => void;
+};
 
-type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4 ? SearchClientV4 : SearchClientV3
-type SearchOptions = ReturnType<typeof algoliasearch> extends DummySearchClientV4 ? SearchOptionsV4 : SearchOptionsV3
-type SearchResponse<T> = ReturnType<typeof algoliasearch> extends DummySearchClientV4 ? SearchResponseV4<T> : SearchResponseV3<T>
+type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4
+  ? SearchClientV4
+  : SearchClientV3;
+type SearchOptions = ReturnType<
+  typeof algoliasearch
+> extends DummySearchClientV4
+  ? SearchOptionsV4
+  : SearchOptionsV3;
+type SearchResponse<T> = ReturnType<
+  typeof algoliasearch
+> extends DummySearchClientV4
+  ? SearchResponseV4<T>
+  : SearchResponseV3<T>;
 
-type SearchClient = Pick<
-  Client,
-  'search' | 'searchForFacetValues'
->;
+type SearchClient = Pick<Client, 'search' | 'searchForFacetValues'>;
 
 /**
  * The algoliasearchHelper module is the function that will let its
@@ -305,7 +314,7 @@ declare namespace algoliasearchHelper {
       event: 'result',
       cb: (res: { results: SearchResults; state: SearchParameters }) => void
     ): this;
-    on( event: 'error', cb: (res: { error: Error }) => void): this;
+    on(event: 'error', cb: (res: { error: Error }) => void): this;
 
     lastResults: SearchResults | null;
     detach(): void;
@@ -1039,7 +1048,8 @@ declare namespace algoliasearchHelper {
     type Operator = '=' | '>' | '>=' | '<' | '<=' | '!=';
   }
 
-  export interface SearchResults<T = any> extends Omit<SearchResponse<T>, 'facets' | 'params'> {
+  export interface SearchResults<T = any>
+    extends Omit<SearchResponse<T>, 'facets' | 'params'> {
     /**
      * Boolean that indicates if the computation of the counts did time out.
      * @deprecated

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,14 +27,10 @@ type DummySearchClientV4 = {
 type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4
   ? SearchClientV4
   : SearchClientV3;
-type SearchOptions = ReturnType<
-  typeof algoliasearch
-> extends DummySearchClientV4
+type SearchOptions = Client extends DummySearchClientV4
   ? SearchOptionsV4
   : SearchOptionsV3;
-type SearchResponse<T> = ReturnType<
-  typeof algoliasearch
-> extends DummySearchClientV4
+type SearchResponse<T> = Client extends DummySearchClientV4
   ? SearchResponseV4<T>
   : SearchResponseV3<T>;
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/algoliasearch": "^3.30.12",
     "algolia-frontend-components": "0.0.35",
-    "algoliasearch": "3.32.0",
+    "algoliasearch": ">= 3.32.0 < 5",
     "babel-core": "6.26.3",
     "babel-loader": "6.4.1",
     "babel-preset-es2015": "6.24.1",
@@ -98,6 +98,6 @@
     "events": "^1.1.1"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 4"
+    "algoliasearch": ">= 3.32.0 < 5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/algoliasearch": "^3.30.12",
     "algolia-frontend-components": "0.0.35",
-    "algoliasearch": ">= 3.32.0 < 5",
+    "algoliasearch": "4.0.0-beta.14",
     "babel-core": "6.26.3",
     "babel-loader": "6.4.1",
     "babel-preset-es2015": "6.24.1",
@@ -98,6 +98,6 @@
     "events": "^1.1.1"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.32.0 < 5"
+    "algoliasearch": ">= 3.1 < 5"
   }
 }

--- a/test/integration-utils.js
+++ b/test/integration-utils.js
@@ -10,7 +10,20 @@ function setup(indexName, fn) {
     // all indexing requests must be done in https
     protocol: 'https:'
   });
+  client.deleteIndex = client.deleteIndex || function(deleteIndexName) {
+    return client.initIndex(deleteIndexName).delete();
+  };
+  client.listIndexes = client.listIndexes || client.listIndices;
+
   var index = client.initIndex(indexName);
+  index.addObjects = index.addObjects || function(objects) {
+    return index.saveObjects(objects, {autoGenerateObjectIDIfNotExist: true}).then(function(content) {
+      return {
+        taskID: content.taskIDs[0]
+      };
+    });
+  };
+  index.clearIndex = index.clearIndex || index.clearObjects;
 
   return index
     .clearIndex()

--- a/test/run.js
+++ b/test/run.js
@@ -31,6 +31,10 @@ jest.runCLI(dynamicJestConfig, projectsRootPaths).then(function(response) {
       process.env.INTEGRATION_TEST_APPID,
       process.env.INTEGRATION_TEST_API_KEY
     );
+    client.deleteIndex = client.deleteIndex || function(deleteIndexName) {
+      return client.initIndex(deleteIndexName).delete();
+    };
+    client.listIndexes = client.listIndexes || client.listIndices;
 
     client.listIndexes().then(content => {
       content.items

--- a/test/spec/algoliasearch.helper/client.js
+++ b/test/spec/algoliasearch.helper/client.js
@@ -11,6 +11,12 @@ function makeFakeClient() {
     return new Promise(function() {});
   });
 
+  client._ua || Object.defineProperty(client, '_ua', {
+    get() {
+      return client.transporter.userAgent.value;
+    }
+  });
+
   return client;
 }
 
@@ -58,11 +64,17 @@ test('clearCache gets called if exists', function() {
 
 test('setting the agent once', function() {
   var client = algoliasearch('what', 'wait', {});
+  client._ua || Object.defineProperty(client, '_ua', {
+    get() {
+      return client.transporter.userAgent.value;
+    }
+  });
+
   var originalUA = client._ua;
   algoliaSearchHelper(client, 'IndexName', {});
   algoliaSearchHelper(client, 'IndexName2', {});
 
-  expect(client._ua).toBe(originalUA + ';JS Helper (' + version + ')');
+  expect(client._ua).toBe(originalUA + '; JS Helper (' + version + ')');
 });
 
 test('getClient / setClient', function() {
@@ -76,7 +88,7 @@ test('getClient / setClient', function() {
 
   expect(helper.getClient()).toBe(client0);
 
-  expect(client0._ua).toBe(originalUA + ';JS Helper (' + version + ')');
+  expect(client0._ua).toBe(originalUA + '; JS Helper (' + version + ')');
 
   var client1 = makeFakeClient();
   helper.setClient(client1);
@@ -88,10 +100,10 @@ test('getClient / setClient', function() {
   expect(client1.search).toHaveBeenCalledTimes(1);
   expect(client0.search).toHaveBeenCalledTimes(1);
 
-  expect(client1._ua).toBe(originalUA + ';JS Helper (' + version + ')');
+  expect(client1._ua).toBe(originalUA + '; JS Helper (' + version + ')');
 
   helper.setClient(client1);
-  expect(client1._ua).toBe(originalUA + ';JS Helper (' + version + ')');
+  expect(client1._ua).toBe(originalUA + '; JS Helper (' + version + ')');
 });
 
 test('initial client === getClient', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,13 +503,13 @@ algolia-frontend-components@0.0.35:
     webpack "^2.2.1"
     webpack-dev-server "^2.4.1"
 
-algoliasearch@3.32.0:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.32.0.tgz#5818168c26ff921bd0346a919071bac928b747ce"
-  integrity sha512-C8oQnPTf0wPuyD2jSZwtBAPvz+lHOE7zRIPpgXGBuNt6ZNcC4omsbytG26318rT77a8h4759vmIp6n9p8iw4NA==
+"algoliasearch@>= 3.32.0 < 5":
+  version "3.35.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
+  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
   dependencies:
     agentkeepalive "^2.2.0"
-    debug "^2.6.8"
+    debug "^2.6.9"
     envify "^4.0.0"
     es6-promise "^4.1.0"
     events "^1.1.0"
@@ -4093,9 +4093,9 @@ es6-map@^0.1.3:
     event-emitter "~0.3.5"
 
 es6-promise@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-  integrity sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -5295,12 +5295,12 @@ global-prefix@^0.1.4:
     which "^1.2.12"
 
 global@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
-  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
   dependencies:
     min-document "^2.19.0"
-    process "~0.5.1"
+    process "^0.11.10"
 
 globals@^11.1.0:
   version "11.11.0"
@@ -6561,9 +6561,9 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isarray@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.2.tgz#5aa99638daf2248b10b9598b763a045688ece3ee"
-  integrity sha512-DKCXsIpN+352zm3Sd75dY9HyaIcxU6grh118GhTPXc85jJ5nEGKOsPQOwSuE7aRd+XVRcC/Em6W44onQEQ9RBg==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -9023,12 +9023,12 @@ object-inspect@~0.4.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-0.4.0.tgz#f5157c116c1455b243b06ee97703392c5ad89fec"
   integrity sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=
 
-object-keys@^1.0.11, object-keys@^1.0.6, object-keys@^1.0.8, object-keys@~1.0.0:
+object-keys@^1.0.11, object-keys@^1.0.6, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
   integrity sha1-xUYBd4rVYPEULODgG8yotW0TQm0=
 
-object-keys@^1.0.12:
+object-keys@^1.0.12, object-keys@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -9764,15 +9764,10 @@ process-nextick-args@~1.0.6:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
   integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
 
-process@^0.11.0, process@^0.11.1, process@~0.11.0:
+process@^0.11.0, process@^0.11.1, process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
-
-process@~0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
-  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
 
 progress@^1.1.8:
   version "1.1.8"
@@ -10339,11 +10334,11 @@ reduce-without@^1.0.0, reduce-without@^1.0.1:
     test-value "^2.0.0"
 
 reduce@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.1.tgz#14fa2e5ff1fc560703a020cbb5fbaab691565804"
-  integrity sha1-FPouX/H8VgcDoCDLtfuqtpFWWAQ=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.2.tgz#0cd680ad3ffe0b060e57a5c68bdfce37168d361b"
+  integrity sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==
   dependencies:
-    object-keys "~1.0.0"
+    object-keys "^1.1.0"
 
 regenerate@^1.2.1:
   version "1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,100 @@
 # yarn lockfile v1
 
 
+"@algolia/cache-browser-local-storage@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.0.0-beta.14.tgz#ef3342f59ce778a50a13620b35d3372d39d878dc"
+  integrity sha512-TnMpgpaGhcn9uoUEyIV/4cigrTQXdHYOyGGCQ6hneCDeAxwmnoDKPLy/Z1G2nGc9ImTSQEhfN2QSImxtpED33Q==
+  dependencies:
+    "@algolia/cache-common" "4.0.0-beta.14"
+
+"@algolia/cache-common@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.0.0-beta.14.tgz#2bf58be8e650a68df055c231a609e5845ef58590"
+  integrity sha512-UQIRCbcjF3EBp4Qba+J2Qf9VXPLbfhv/mYF6HSV71mYHwizAWAuSFCpLMDhnrWy8wdhsfswIC/ycocMn5HO1CQ==
+
+"@algolia/cache-in-memory@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.0.0-beta.14.tgz#ab417dfca93991c78b455a7390f902127f97e788"
+  integrity sha512-3/mOnR0C9XjEU/H5vGLZbLWEXzXwxEy44drfWlyeecQgIZcL3NY03qukBm8ukQThc27kiAx16l6zhkDSaP+0FA==
+  dependencies:
+    "@algolia/cache-common" "4.0.0-beta.14"
+
+"@algolia/client-analytics@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.0.0-beta.14.tgz#f26749af5df76320decd9f49ec06be2ab9ff7093"
+  integrity sha512-TB1Wo8hsuqNtbDiqUW12CwBx9BbX/cySim39HlEDe621aRZBBqbGXOiXoQdksCmR+vQIY9xVNFtuAQY1p2dCoQ==
+  dependencies:
+    "@algolia/cache-common" "4.0.0-beta.14"
+    "@algolia/client-common" "4.0.0-beta.14"
+    "@algolia/requester-common" "4.0.0-beta.14"
+    "@algolia/transporter" "4.0.0-beta.14"
+
+"@algolia/client-common@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.0.0-beta.14.tgz#ab767d4c267fa65fad481372b174cdc031db4c0d"
+  integrity sha512-JR95GNE6z6uYkRivW+cBRwC7QtTrpVtE9E2KJGbuVCGHwEtZvcntSFo6R/Ll7FHxpmuUJNLBqhj7XpBKOjlyWQ==
+
+"@algolia/client-recommendation@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.0.0-beta.14.tgz#54735944f333894f1fcec3e5018f4d01c3961842"
+  integrity sha512-4dc9FwPTREaynjvRIWFm3NYyzecrx9KYzKeOA/cKu5NdxFVvfxlsAzdPHq1xZ0o3NjnBICmjdWI5ebsd2YtuZw==
+  dependencies:
+    "@algolia/cache-common" "4.0.0-beta.14"
+    "@algolia/client-common" "4.0.0-beta.14"
+    "@algolia/requester-common" "4.0.0-beta.14"
+    "@algolia/transporter" "4.0.0-beta.14"
+
+"@algolia/client-search@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.0.0-beta.14.tgz#d68fa8a8a8e180602205e4236548f82abf60a90e"
+  integrity sha512-zYmYVR3dRTG7gs+eXtUG4NZ37In8cOMluNBn5QU9lIszNJ7eCmeZUjSbIZzIt5QJ3P5WHoRtI2ym9ND3pakLnQ==
+  dependencies:
+    "@algolia/client-common" "4.0.0-beta.14"
+    "@algolia/logger-common" "4.0.0-beta.14"
+    "@algolia/requester-common" "4.0.0-beta.14"
+    "@algolia/transporter" "4.0.0-beta.14"
+
+"@algolia/logger-common@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.0.0-beta.14.tgz#819a16e859081143d3067c9752b58cea296f6ced"
+  integrity sha512-Rm1DGJz1kRlaj88B8Cq/7Ifk1rsOskG1Td052SslSfx0Dc39wqgz4WLrlEEP78jtU0l8Km59nV6F8lkrGPzTsw==
+
+"@algolia/logger-console@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.0.0-beta.14.tgz#34e16cd4cb54ff2e4ee00ad8eb21fb898df622cd"
+  integrity sha512-tbkqzmsA2VjRabqawUGfuf6OehvdLFEjuBcAto/9d4akixf10W2n8kp7X88mCT0fkY3NvyI94I7Gfzgupylnog==
+  dependencies:
+    "@algolia/logger-common" "4.0.0-beta.14"
+
+"@algolia/requester-browser-xhr@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.0.0-beta.14.tgz#f54fea566df7901b504a481e6a3c3a20cc9ebb99"
+  integrity sha512-+oD9vqO7ZE8/r2tLnC+VSKl+g+6enYATyYhbIJ837TeE48llx/y0ZZaNTsimk/EM10FAbKpoIGBPVv+7Lqi1cA==
+  dependencies:
+    "@algolia/requester-common" "4.0.0-beta.14"
+
+"@algolia/requester-common@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.0.0-beta.14.tgz#76ae71056c976ca4613ed8e8ad8383383abdd6af"
+  integrity sha512-Eo8VX8NywUBxYskVk2M0Albg/G2rl/8LGXDjhwZx6qLJuSKYSYEqUpTKmXuGJ8jqLncM7ypVz830Mwpf68TMvg==
+
+"@algolia/requester-node-http@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.0.0-beta.14.tgz#83cf4fbba67fc3f9a1d8c2441b4a9003f038edc2"
+  integrity sha512-se5u8pDpvrgQhUZg9kED3L2tIV+YWhgIhdjqEmXM9kKgdn9mVugJv0noqd/QCDqCSFND/tVK9yq4SAKsdzyrvA==
+  dependencies:
+    "@algolia/requester-common" "4.0.0-beta.14"
+
+"@algolia/transporter@4.0.0-beta.14":
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.0.0-beta.14.tgz#fc587b386374d0648c4325aaa4609eeec782fb28"
+  integrity sha512-VQRwHzzFC5Z9XHWSqxGjr0Lnq6AsoobYhrqKX9s9EmT4qlbSiDDBMSVngFZIWdmy4WFoijGdWv0JhpTWw/UIwQ==
+  dependencies:
+    "@algolia/cache-common" "4.0.0-beta.14"
+    "@algolia/logger-common" "4.0.0-beta.14"
+    "@algolia/requester-common" "4.0.0-beta.14"
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -456,11 +550,6 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-agentkeepalive@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
-  integrity sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=
-
 ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -503,26 +592,24 @@ algolia-frontend-components@0.0.35:
     webpack "^2.2.1"
     webpack-dev-server "^2.4.1"
 
-"algoliasearch@>= 3.32.0 < 5":
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
-  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
+algoliasearch@4.0.0-beta.14:
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.0.0-beta.14.tgz#e91bafb8fe3cfc9c48609a201dc1047d8bccd310"
+  integrity sha512-pa8hGwAxIg3jUKp2cn9/3+vUASwBm1e7Ob00uSDyxyXOp3MVgYm45iQrdM1QM9UJgaUoLBJR07on2vEXL89fdg==
   dependencies:
-    agentkeepalive "^2.2.0"
-    debug "^2.6.9"
-    envify "^4.0.0"
-    es6-promise "^4.1.0"
-    events "^1.1.0"
-    foreach "^2.0.5"
-    global "^4.3.2"
-    inherits "^2.0.1"
-    isarray "^2.0.1"
-    load-script "^1.0.0"
-    object-keys "^1.0.11"
-    querystring-es3 "^0.2.1"
-    reduce "^1.0.1"
-    semver "^5.1.0"
-    tunnel-agent "^0.6.0"
+    "@algolia/cache-browser-local-storage" "4.0.0-beta.14"
+    "@algolia/cache-common" "4.0.0-beta.14"
+    "@algolia/cache-in-memory" "4.0.0-beta.14"
+    "@algolia/client-analytics" "4.0.0-beta.14"
+    "@algolia/client-common" "4.0.0-beta.14"
+    "@algolia/client-recommendation" "4.0.0-beta.14"
+    "@algolia/client-search" "4.0.0-beta.14"
+    "@algolia/logger-common" "4.0.0-beta.14"
+    "@algolia/logger-console" "4.0.0-beta.14"
+    "@algolia/requester-browser-xhr" "4.0.0-beta.14"
+    "@algolia/requester-common" "4.0.0-beta.14"
+    "@algolia/requester-node-http" "4.0.0-beta.14"
+    "@algolia/transporter" "4.0.0-beta.14"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -3774,11 +3861,6 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
-
 domain-browser@^1.1.1, domain-browser@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -4013,14 +4095,6 @@ entities@^1.1.1, entities@~1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
-envify@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
-  integrity sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==
-  dependencies:
-    esprima "^4.0.0"
-    through "~2.3.4"
-
 errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -4091,11 +4165,6 @@ es6-map@^0.1.3:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
-
-es6-promise@^4.1.0:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -4347,7 +4416,7 @@ eventemitter3@1.x.x:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
   integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
 
-events@^1.0.0, events@^1.1.0, events@^1.1.1, events@~1.1.0:
+events@^1.0.0, events@^1.1.1, events@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -5293,14 +5362,6 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
-
-global@^4.3.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
 
 globals@^11.1.0:
   version "11.11.0"
@@ -6560,11 +6621,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isarray@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -7477,11 +7533,6 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-load-script@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
-
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -8372,13 +8423,6 @@ mimic-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
-  dependencies:
-    dom-walk "^0.1.0"
-
 mini-lr@^0.1.8:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/mini-lr/-/mini-lr-0.1.9.tgz#02199d27347953d1fd1d6dbded4261f187b2d0f6"
@@ -9028,7 +9072,7 @@ object-keys@^1.0.11, object-keys@^1.0.6, object-keys@^1.0.8:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
   integrity sha1-xUYBd4rVYPEULODgG8yotW0TQm0=
 
-object-keys@^1.0.12, object-keys@^1.1.0:
+object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -9764,7 +9808,7 @@ process-nextick-args@~1.0.6:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
   integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
 
-process@^0.11.0, process@^0.11.1, process@^0.11.10, process@~0.11.0:
+process@^0.11.0, process@^0.11.1, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -10032,7 +10076,7 @@ qs@~6.5.1, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-querystring-es3@^0.2.0, querystring-es3@^0.2.1, querystring-es3@~0.2.0:
+querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
@@ -10332,13 +10376,6 @@ reduce-without@^1.0.0, reduce-without@^1.0.1:
   integrity sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=
   dependencies:
     test-value "^2.0.0"
-
-reduce@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.2.tgz#0cd680ad3ffe0b060e57a5c68bdfce37168d361b"
-  integrity sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==
-  dependencies:
-    object-keys "^1.1.0"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -11874,7 +11911,7 @@ through2@~0.4.1:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=


### PR DESCRIPTION
This change add support for algoliasearch v4 to algoliasearch helper.

No changes were necessary in the code. The test suite was updated to support both v3 and v4 versions of algoliasearch client. We also added a new job to CircleCI to test the version 4 of the client.