### PR TITLE
fix: fix omit calls to pass excluded value as an array

### DIFF
--- a/src/SearchParameters/RefinementList.js
+++ b/src/SearchParameters/RefinementList.js
@@ -99,7 +99,7 @@ var lib = {
       }
       return {};
     } else if (typeof attribute === 'string') {
-      return omit(refinementList, attribute);
+      return omit(refinementList, [attribute]);
     } else if (typeof attribute === 'function') {
       var hasChanged = false;
 

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -665,7 +665,7 @@ SearchParameters.prototype = {
       if (!objectHasKeys(this.numericRefinements[attribute])) {
         return this.numericRefinements;
       }
-      return omit(this.numericRefinements, attribute);
+      return omit(this.numericRefinements, [attribute]);
     } else if (typeof attribute === 'function') {
       var hasChanged = false;
       var numericRefinements = this.numericRefinements;

--- a/test/spec/SearchParameters/RefinementList/clear.js
+++ b/test/spec/SearchParameters/RefinementList/clear.js
@@ -16,6 +16,20 @@ test('When removing refinements of a specific attribute, and there are no refine
   expect(clear(initialRefinementList, 'notThisAttribute')).toEqual(initialRefinementList);
 });
 
+test('When removing refinements of a specific attribute, and another refinement is a substring of this attribute', function() {
+  var initialRefinementList = {
+    'Brand': ['HP'],
+    'CPU type': ['Core i5'],
+    'Motherboard CPU type': ['Intel Core X']
+  };
+  var expectedRefinementList = {
+    'Brand': ['HP'],
+    'CPU type': ['Core i5']
+  };
+
+  expect(clear(initialRefinementList, 'Motherboard CPU type')).toEqual(expectedRefinementList);
+});
+
 test('When removing numericRefinements using a function, and there are no changes', function() {
   var initialRefinementList = {
     'attribute': ['test']

--- a/test/spec/SearchParameters/_clearNumericRefinements.js
+++ b/test/spec/SearchParameters/_clearNumericRefinements.js
@@ -20,7 +20,7 @@ test('When removing numericRefinements of a specific attribute, and there are no
 test('When removing refinements of a specific attribute, and another refinement is a substring of this attribute', function() {
   var state = SearchParameters.make({
     numericRefinements: {
-      price: {'>': [300]},
+      'price': {'>': [300]},
       'price with taxes': {'>': [300]}
     }
   });

--- a/test/spec/SearchParameters/_clearNumericRefinements.js
+++ b/test/spec/SearchParameters/_clearNumericRefinements.js
@@ -17,6 +17,21 @@ test('When removing numericRefinements of a specific attribute, and there are no
   expect(state._clearNumericRefinements('size')).toBe(state.numericRefinements);
 });
 
+test('When removing refinements of a specific attribute, and another refinement is a substring of this attribute', function() {
+  var state = SearchParameters.make({
+    numericRefinements: {
+      price: {'>': [300]},
+      'price with taxes': {'>': [300]}
+    }
+  });
+
+  const expectedNumericRefinements = {
+    price: {'>': [300]}
+  };
+
+  expect(state._clearNumericRefinements('price with taxes')).toEqual(expectedNumericRefinements);
+});
+
 test('When removing numericRefinements using a function, and there are no changes', function() {
   var state = SearchParameters.make({
     numericRefinements: {


### PR DESCRIPTION
The `omit` function is meant to be called with an array of key to exclude.

```js
omit ({
  "Brand": ["HP"],
  "CPU type": ["Core i5"],
  "Motherboard CPU type": ["Intel Core X"]
},  ["Motherboard CPU type"]);
// -> {"Brand": ["HP"], "CPU type": ["Core i5"]}
```

Calling it with a string also works but can have an undesired behavior and exclude some keys that matches a substring of the one we want to exclude.

```js
omit ({
  "Brand": ["HP"],
  "CPU type": ["Core i5"],
  "Motherboard CPU type": ["Intel Core X"]
},  "Motherboard CPU type");
// -> {"Brand": ["HP"]}
```

This is because in that case we're doing an [`.indexOf`](https://github.com/algolia/algoliasearch-helper-js/blob/80d755c720419f5800557cc89e314cbf24ff0430/src/functions/omit.js#L12) on a string instead of on an array.

With a string:

```js
"Motherboard CPU type".indexOf("CPU type") >= 0 // true
```
With an array:
```js
["Motherboard CPU type"].indexOf("CPU type") >= 0 // false
```

This PR changes the few omit calls that were made with a string instead of an array, so we do not encounter this undesired behavior anymore.