### PR TITLE
fix(defaultsPure): don't change keys order, fix #761

### DIFF
--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -14,12 +14,7 @@ module.exports = function defaultsPure() {
   }, {});
 
   var orderedKeys = sources.reduce(function(acc, source) {
-    Object.keys(Object(source)).forEach(function(key) {
-      if (!acc.includes(key)) {
-        acc.push(key);
-      }
-    });
-    return acc;
+    return acc.slice().concat(Object.keys(Object(source)));
   }, []);
 
   return orderedKeys.reduce(function(acc, key) {

--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -1,14 +1,30 @@
 'use strict';
 
 // NOTE: this behaves like lodash/defaults, but doesn't mutate the target
+// it also preserve keys order
 module.exports = function defaultsPure() {
   var sources = Array.prototype.slice.call(arguments);
-  return sources.reduceRight(function(acc, source) {
+  var mergedSources = sources.reduceRight(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
       if (source[key] !== undefined) {
         acc[key] = source[key];
       }
     });
+    return acc;
+  }, {});
+
+  var orderedKeys = sources.reduce(function(acc, source) {
+    Object.keys(Object(source)).forEach(function(key) {
+      if (!acc.includes(key)) {
+        acc.push(key);
+      }
+    });
+    return acc;
+  }, []);
+
+  return orderedKeys.reduce(function(acc, key) {
+    acc[key] = mergedSources[key];
+
     return acc;
   }, {});
 };

--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -4,22 +4,12 @@
 // it also preserve keys order
 module.exports = function defaultsPure() {
   var sources = Array.prototype.slice.call(arguments);
-  var mergedSources = sources.reduceRight(function(acc, source) {
+  return sources.reduce(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
-      if (source[key] !== undefined) {
+      if (source[key] !== undefined && !Object.hasOwnProperty.call(acc, key)) {
         acc[key] = source[key];
       }
     });
-    return acc;
-  }, {});
-
-  var orderedKeys = sources.reduce(function(acc, source) {
-    return acc.slice().concat(Object.keys(Object(source)));
-  }, []);
-
-  return orderedKeys.reduce(function(acc, key) {
-    acc[key] = mergedSources[key];
-
     return acc;
   }, {});
 };

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -89,6 +89,26 @@ test('getFacetValues(facetName) testing the sort function', function() {
   expect(facetValues).toEqual(expected);
 });
 
+test('getFacetValues(facetName) with disabled sorting', function() {
+  var data = require('./getFacetValues/disjunctive.json');
+  var searchParams = new SearchParameters(data.state);
+  var result = new SearchResults(searchParams, data.content.results);
+
+  var facetValues = result.getFacetValues('brand', {
+    sortBy: function() {
+      return 0;
+    }
+  });
+
+  var expected = [
+    {count: 551, isRefined: false, name: 'Insignia™'},
+    {count: 511, isRefined: false, name: 'Samsung'},
+    {count: 386, isRefined: true, name: 'Apple'}
+  ];
+
+  expect(facetValues).toEqual(expected);
+});
+
 test('getFacetValues(conjunctive) returns correct facet values with the name `length`', function() {
   var searchParams = new SearchParameters({
     index: 'instant_search',

--- a/test/spec/functions/defaultsPure.js
+++ b/test/spec/functions/defaultsPure.js
@@ -66,8 +66,8 @@ it('should assign properties that shadow those on `Object.prototype`', function(
 });
 
 it('should not touch keys order', function() {
-  var expected = {'a': 1, 'b': 2, 'c': 3};
-  var actual = defaults({'a': 1, 'b': 2, 'c': 3}, {'c': 3});
+  var expected = {'a': 1, 'b': 3, 'c': 3, 'd': 4};
+  var actual = defaults({'a': 1, 'b': 2}, {'b': 3, 'c': 3}, {'d': 4});
 
   var expectedKeys = Object.keys(expected);
   var actualKeys = Object.keys(actual);

--- a/test/spec/functions/defaultsPure.js
+++ b/test/spec/functions/defaultsPure.js
@@ -64,3 +64,13 @@ it('should assign properties that shadow those on `Object.prototype`', function(
   expected = clone(object);
   expect(defaults({}, object, source)).toEqual(expected);
 });
+
+it('should not touch keys order', function() {
+  var expected = {'a': 1, 'b': 2, 'c': 3};
+  var actual = defaults({'a': 1, 'b': 2, 'c': 3}, {'c': 3});
+
+  var expectedKeys = Object.keys(expected);
+  var actualKeys = Object.keys(actual);
+
+  expect(expectedKeys).toEqual(actualKeys);
+});


### PR DESCRIPTION
See #761 for issue, thanks!

I'm computing an array of keys in the order they come from sources, then using it with `mergedSources` to return a new _keys-order-preserved_ object.