### PR TITLE
fix(types): add `resetPage` state method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -533,6 +533,7 @@ declare namespace algoliasearchHelper {
       value?: string
     ): SearchParameters;
     removeTagRefinement(tag: string): SearchParameters;
+    resetPage(): SearchParameters;
     setDisjunctiveFacets(facets: string[]): SearchParameters;
     setFacets(facets: string[]): SearchParameters;
     setHitsPerPage(n: number): SearchParameters;


### PR DESCRIPTION
[We often rely on the `resetPage` method](https://github.com/algolia/instantsearch.js/blob/5ff4c8307c2be7bde7fb53aa9935a243e6532fe2/src/widgets/index/index.ts#L146) which was untyped.