### PR TITLE
fix(typescript): fix TypeScript 3.9 compatibility (fixes #774)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,10 +27,10 @@ type DummySearchClientV4 = {
 type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4
   ? SearchClientV4
   : SearchClientV3;
-type SearchOptions = Client extends DummySearchClientV4
+type SearchOptions = ReturnType<typeof algoliasearch> extends DummySearchClientV4
   ? SearchOptionsV4
   : SearchOptionsV3;
-type SearchResponse<T> = Client extends DummySearchClientV4
+type SearchResponse<T> = ReturnType<typeof algoliasearch> extends DummySearchClientV4
   ? SearchResponseV4<T>
   : SearchResponseV3<T>;
 


### PR DESCRIPTION
We are doing some tricky things here by using [Conditional Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#conditional-types) to keep this library compatible with [`algoliasearch`](https://github.com/algolia/algoliasearch-client-javascript) v3 and v4.

But since 3.9 TypeScript is not able to statically analyze our code anymore to determine the `SearchOptions` and `SearchResponse` types (https://github.com/algolia/algoliasearch-helper-js/issues/774) :sob: 

This PR fixes this by using directly `ReturnType<typeof algoliasearch>` instead of the `Client` type. With this notation the static analyze seems to work with no issues again.

fixes #774