### PR TITLE
feat(disjunctive): no extra request done

### DIFF
--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -18,14 +18,6 @@ var requestBuilder = {
       params: requestBuilder._getHitsSearchParams(state)
     });
 
-    // One for each disjunctive facets
-    state.getRefinedDisjunctiveFacets().forEach(function(refinedFacet) {
-      queries.push({
-        indexName: index,
-        params: requestBuilder._getDisjunctiveFacetSearchParams(state, refinedFacet)
-      });
-    });
-
     // maybe more to get the root level of hierarchical facets when activated
     state.getRefinedHierarchicalFacets().forEach(function(refinedFacet) {
       var hierarchicalFacet = state.getHierarchicalFacetByName(refinedFacet);
@@ -52,7 +44,11 @@ var requestBuilder = {
    */
   _getHitsSearchParams: function(state) {
     var facets = state.facets
-      .concat(state.disjunctiveFacets)
+      .concat(state.disjunctiveFacets.map(function(facet) {
+        // TODO: use this syntax once it's live
+        // return 'disjunctive(' + facet + ')';
+        return facet;
+      }))
       .concat(requestBuilder._getHitsHierarchicalFacetsAttributes(state));
 
 


### PR DESCRIPTION
requires engine changes to support the new `disjunctive` facet modifier

Hierararchical is less straightforward to do in a single request, since the maxValuesPerFacet is global (not per refined level) and thus can be skewed by items with more values

If hierarchical is replaced as well, most of this file can be deleted, however we still need a translation between disjunctive facet values (array) & facetFilters (nested array)

This can be considered a breaking change, if the engine doesn't roll this out evenly, however I don't think that will be an issue