### PR TITLE
fix: accept all fields implicitly instead of the allow list

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -240,11 +240,15 @@ function SearchResults(state, results) {
    * query used to generate the results
    * @name query
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * The query as parsed by the engine given all the rules.
    * @name parsedQuery
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * all the records that match the search parameters. Each record is
@@ -254,42 +258,58 @@ function SearchResults(state, results) {
    *  - `matchLevel`: full, partial or none depending on how the query terms match
    * @name hits
    * @member {object[]}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * index where the results come from
    * @name index
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * number of hits per page requested
    * @name hitsPerPage
    * @member {number}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * total number of hits of this query on the index
    * @name nbHits
    * @member {number}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * total number of pages with respect to the number of hits per page and the total number of hits
    * @name nbPages
    * @member {number}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * current page
    * @name page
    * @member {number}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * The position if the position was guessed by IP.
    * @name aroundLatLng
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    * @example "48.8637,2.3615",
    */
   /**
    * The radius computed by Algolia.
    * @name automaticRadius
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    * @example "126792922",
    */
   /**
@@ -299,6 +319,8 @@ function SearchResults(state, results) {
    *
    * @name serverUsed
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    * @example "c7-use-2.algolia.net",
    */
   /**
@@ -306,33 +328,45 @@ function SearchResults(state, results) {
    * @deprecated
    * @name timeoutCounts
    * @member {boolean}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * Boolean that indicates if the computation of the hits did time out.
    * @deprecated
    * @name timeoutHits
    * @member {boolean}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * True if the counts of the facets is exhaustive
    * @name exhaustiveFacetsCount
    * @member {boolean}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * True if the number of hits is exhaustive
    * @name exhaustiveNbHits
    * @member {boolean}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * Contains the userData if they are set by a [query rule](https://www.algolia.com/doc/guides/query-rules/query-rules-overview/).
    * @name userData
    * @member {object[]}
+   * @memberof SearchResults
+   * @instance
    */
   /**
    * queryID is the unique identifier of the query used to generate the current search results.
    * This value is only available if the `clickAnalytics` search parameter is set to `true`.
    * @name queryID
    * @member {string}
+   * @memberof SearchResults
+   * @instance
    */
 
   /**

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -229,9 +229,11 @@ function SearchResults(state, results) {
 
   this._rawResults = results;
 
+  var self = this;
+
   // https://www.algolia.com/doc/api-reference/api-methods/search/#response
-  Object.keys(mainSubResponse).forEach((key) => {
-    this[key] = mainSubResponse[key];
+  Object.keys(mainSubResponse).forEach(function (key) {
+    self[key] = mainSubResponse[key];
   });
 
   /**
@@ -268,7 +270,6 @@ function SearchResults(state, results) {
   var disjunctiveFacetsIndices = getIndices(state.disjunctiveFacets);
   var nextDisjunctiveResult = 1;
 
-  var self = this;
   // Since we send request only for disjunctive facets that have been refined,
   // we get the facets information from the first, general, response.
 

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -229,50 +229,11 @@ function SearchResults(state, results) {
 
   this._rawResults = results;
 
-  /**
-   * query used to generate the results
-   * @member {string}
-   */
-  this.query = mainSubResponse.query;
-  /**
-   * The query as parsed by the engine given all the rules.
-   * @member {string}
-   */
-  this.parsedQuery = mainSubResponse.parsedQuery;
-  /**
-   * all the records that match the search parameters. Each record is
-   * augmented with a new attribute `_highlightResult`
-   * which is an object keyed by attribute and with the following properties:
-   *  - `value` : the value of the facet highlighted (html)
-   *  - `matchLevel`: full, partial or none depending on how the query terms match
-   * @member {object[]}
-   */
-  this.hits = mainSubResponse.hits;
-  /**
-   * index where the results come from
-   * @member {string}
-   */
-  this.index = mainSubResponse.index;
-  /**
-   * number of hits per page requested
-   * @member {number}
-   */
-  this.hitsPerPage = mainSubResponse.hitsPerPage;
-  /**
-   * total number of hits of this query on the index
-   * @member {number}
-   */
-  this.nbHits = mainSubResponse.nbHits;
-  /**
-   * total number of pages with respect to the number of hits per page and the total number of hits
-   * @member {number}
-   */
-  this.nbPages = mainSubResponse.nbPages;
-  /**
-   * current page
-   * @member {number}
-   */
-  this.page = mainSubResponse.page;
+  // https://www.algolia.com/doc/api-reference/api-methods/search/#response
+  Object.keys(mainSubResponse).forEach((key) => {
+    this[key] = mainSubResponse[key];
+  });
+
   /**
    * sum of the processing time of all the queries
    * @member {number}
@@ -282,65 +243,6 @@ function SearchResults(state, results) {
       ? sum
       : sum + result.processingTimeMS;
   }, 0);
-  /**
-   * The position if the position was guessed by IP.
-   * @member {string}
-   * @example "48.8637,2.3615",
-   */
-  this.aroundLatLng = mainSubResponse.aroundLatLng;
-  /**
-   * The radius computed by Algolia.
-   * @member {string}
-   * @example "126792922",
-   */
-  this.automaticRadius = mainSubResponse.automaticRadius;
-  /**
-   * String identifying the server used to serve this request.
-   *
-   * getRankingInfo needs to be set to `true` for this to be returned
-   *
-   * @member {string}
-   * @example "c7-use-2.algolia.net",
-   */
-  this.serverUsed = mainSubResponse.serverUsed;
-  /**
-   * Boolean that indicates if the computation of the counts did time out.
-   * @deprecated
-   * @member {boolean}
-   */
-  this.timeoutCounts = mainSubResponse.timeoutCounts;
-  /**
-   * Boolean that indicates if the computation of the hits did time out.
-   * @deprecated
-   * @member {boolean}
-   */
-  this.timeoutHits = mainSubResponse.timeoutHits;
-
-  /**
-   * True if the counts of the facets is exhaustive
-   * @member {boolean}
-   */
-  this.exhaustiveFacetsCount = mainSubResponse.exhaustiveFacetsCount;
-
-  /**
-   * True if the number of hits is exhaustive
-   * @member {boolean}
-   */
-  this.exhaustiveNbHits = mainSubResponse.exhaustiveNbHits;
-
-
-  /**
-   * Contains the userData if they are set by a [query rule](https://www.algolia.com/doc/guides/query-rules/query-rules-overview/).
-   * @member {object[]}
-   */
-  this.userData = mainSubResponse.userData;
-
-  /**
-   * queryID is the unique identifier of the query used to generate the current search results.
-   * This value is only available if the `clickAnalytics` search parameter is set to `true`.
-   * @member {string}
-   */
-  this.queryID = mainSubResponse.queryID;
 
   /**
    * disjunctive facets results

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -237,6 +237,105 @@ function SearchResults(state, results) {
   });
 
   /**
+   * query used to generate the results
+   * @name query
+   * @member {string}
+   */
+  /**
+   * The query as parsed by the engine given all the rules.
+   * @name parsedQuery
+   * @member {string}
+   */
+  /**
+   * all the records that match the search parameters. Each record is
+   * augmented with a new attribute `_highlightResult`
+   * which is an object keyed by attribute and with the following properties:
+   *  - `value` : the value of the facet highlighted (html)
+   *  - `matchLevel`: full, partial or none depending on how the query terms match
+   * @name hits
+   * @member {object[]}
+   */
+  /**
+   * index where the results come from
+   * @name index
+   * @member {string}
+   */
+  /**
+   * number of hits per page requested
+   * @name hitsPerPage
+   * @member {number}
+   */
+  /**
+   * total number of hits of this query on the index
+   * @name nbHits
+   * @member {number}
+   */
+  /**
+   * total number of pages with respect to the number of hits per page and the total number of hits
+   * @name nbPages
+   * @member {number}
+   */
+  /**
+   * current page
+   * @name page
+   * @member {number}
+   */
+  /**
+   * The position if the position was guessed by IP.
+   * @name aroundLatLng
+   * @member {string}
+   * @example "48.8637,2.3615",
+   */
+  /**
+   * The radius computed by Algolia.
+   * @name automaticRadius
+   * @member {string}
+   * @example "126792922",
+   */
+  /**
+   * String identifying the server used to serve this request.
+   *
+   * getRankingInfo needs to be set to `true` for this to be returned
+   *
+   * @name serverUsed
+   * @member {string}
+   * @example "c7-use-2.algolia.net",
+   */
+  /**
+   * Boolean that indicates if the computation of the counts did time out.
+   * @deprecated
+   * @name timeoutCounts
+   * @member {boolean}
+   */
+  /**
+   * Boolean that indicates if the computation of the hits did time out.
+   * @deprecated
+   * @name timeoutHits
+   * @member {boolean}
+   */
+  /**
+   * True if the counts of the facets is exhaustive
+   * @name exhaustiveFacetsCount
+   * @member {boolean}
+   */
+  /**
+   * True if the number of hits is exhaustive
+   * @name exhaustiveNbHits
+   * @member {boolean}
+   */
+  /**
+   * Contains the userData if they are set by a [query rule](https://www.algolia.com/doc/guides/query-rules/query-rules-overview/).
+   * @name userData
+   * @member {object[]}
+   */
+  /**
+   * queryID is the unique identifier of the query used to generate the current search results.
+   * This value is only available if the `clickAnalytics` search parameter is set to `true`.
+   * @name queryID
+   * @member {string}
+   */
+
+  /**
    * sum of the processing time of all the queries
    * @member {number}
    */

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -232,7 +232,7 @@ function SearchResults(state, results) {
   var self = this;
 
   // https://www.algolia.com/doc/api-reference/api-methods/search/#response
-  Object.keys(mainSubResponse).forEach(function (key) {
+  Object.keys(mainSubResponse).forEach(function(key) {
     self[key] = mainSubResponse[key];
   });
 

--- a/test/datasets/SearchParameters/search.dataset.js
+++ b/test/datasets/SearchParameters/search.dataset.js
@@ -355,6 +355,7 @@ function getData() {
     'nbHits': 4,
     'nbPages': 1,
     'page': 0,
+    'params': 'query=&hitsPerPage=20&page=0&facets=%5B%5D&facetFilters=%5B%5B%22city%3AParis%22%2C%22city%3ANew%20York%22%5D%5D',
     'processingTimeMS': 5,
     'disjunctiveFacets': [
       {


### PR DESCRIPTION
This PR updates SearchResults to expose all the fields from the search API response implicitly.
It used to manage an allow-list. I've removed it and only computed properties are added on top of that. It means if search API adds a new field, it might be overridden by the computed property if their names are the same.

- [x] I've removed the allow-list with the jsdoc and the doc building is failing. Let me see what to do.

Do you see any improvements that can be made? cc @Haroenv 