### PR TITLE
fix(defaultsPure): fix the regression where the order was wrong with addFacetRefinement

### DIFF
--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -2,36 +2,32 @@
 
 // NOTE: this behaves like lodash/defaults, but doesn't mutate the target
 // it also preserve keys order
+var PLACEHOLDER = '__PLACEHOLDER__';
+
 module.exports = function defaultsPure() {
   var sources = Array.prototype.slice.call(arguments);
 
-  var keysInOrder = Object.keys(sources.reduceRight(function(acc, source) {
+  var emptyObjectWithKeysInOrder = sources.reduceRight(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
       if (source[key] === undefined) {
         return;
       }
-      if (acc[key] === null) {
+      if (acc[key] === PLACEHOLDER) {
         // remove if already added, so that we can add it in correct order
         delete acc[key];
       }
-      acc[key] = null;  // placeholder
+      acc[key] = PLACEHOLDER;
     });
     return acc;
-  }, {}));
+  }, {});
 
-  var merged = sources.reduce(function(acc, source) {
+  return sources.reduce(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
-      if (source[key] !== undefined && !Object.hasOwnProperty.call(acc, key)) {
+      if (source[key] !== undefined && acc[key] === PLACEHOLDER) {
         acc[key] = source[key];
       }
     });
     return acc;
-  }, {});
-
-  var final = keysInOrder.reduce(function(acc, key) {
-    acc[key] = merged[key];
-    return acc;
-  }, {});
-
-  return final;
+  }, emptyObjectWithKeysInOrder);
 };
+

--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -2,32 +2,20 @@
 
 // NOTE: this behaves like lodash/defaults, but doesn't mutate the target
 // it also preserve keys order
-var PLACEHOLDER = '__PLACEHOLDER__';
-
 module.exports = function defaultsPure() {
   var sources = Array.prototype.slice.call(arguments);
 
-  var emptyObjectWithKeysInOrder = sources.reduceRight(function(acc, source) {
+  return sources.reduceRight(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
       if (source[key] === undefined) {
         return;
       }
-      if (acc[key] === PLACEHOLDER) {
+      if (acc[key] !== undefined) {
         // remove if already added, so that we can add it in correct order
         delete acc[key];
       }
-      acc[key] = PLACEHOLDER;
+      acc[key] = source[key];
     });
     return acc;
   }, {});
-
-  return sources.reduce(function(acc, source) {
-    Object.keys(Object(source)).forEach(function(key) {
-      if (source[key] !== undefined && acc[key] === PLACEHOLDER) {
-        acc[key] = source[key];
-      }
-    });
-    return acc;
-  }, emptyObjectWithKeysInOrder);
 };
-

--- a/src/functions/defaultsPure.js
+++ b/src/functions/defaultsPure.js
@@ -4,7 +4,22 @@
 // it also preserve keys order
 module.exports = function defaultsPure() {
   var sources = Array.prototype.slice.call(arguments);
-  return sources.reduce(function(acc, source) {
+
+  var keysInOrder = Object.keys(sources.reduceRight(function(acc, source) {
+    Object.keys(Object(source)).forEach(function(key) {
+      if (source[key] === undefined) {
+        return;
+      }
+      if (acc[key] === null) {
+        // remove if already added, so that we can add it in correct order
+        delete acc[key];
+      }
+      acc[key] = null;  // placeholder
+    });
+    return acc;
+  }, {}));
+
+  var merged = sources.reduce(function(acc, source) {
     Object.keys(Object(source)).forEach(function(key) {
       if (source[key] !== undefined && !Object.hasOwnProperty.call(acc, key)) {
         acc[key] = source[key];
@@ -12,4 +27,11 @@ module.exports = function defaultsPure() {
     });
     return acc;
   }, {});
+
+  var final = keysInOrder.reduce(function(acc, key) {
+    acc[key] = merged[key];
+    return acc;
+  }, {});
+
+  return final;
 };

--- a/test/spec/algoliasearch.helper/addFacetRefinement.js
+++ b/test/spec/algoliasearch.helper/addFacetRefinement.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var algoliaSearchHelper = require('../../../index.js');
+
+var fakeClient = {};
+
+test('addFacetRefinement keeps the order of refinements', function() {
+  var helper = algoliaSearchHelper(fakeClient, null, {
+    facets: ['facet1', 'facet2']
+  });
+
+  helper.addFacetRefinement('facet1', 'facetValue');
+  helper.addFacetRefinement('facet2', 'facetValue');
+
+  expect(helper.state.facets).toEqual(['facet1', 'facet2']);
+  expect(helper.state.facetsRefinements).toEqual({
+    facet1: ['facetValue'],
+    facet2: ['facetValue']
+  });
+  expect(Object.keys(helper.state.facetsRefinements)).toEqual(['facet1', 'facet2']);
+});

--- a/test/spec/functions/defaultsPure.js
+++ b/test/spec/functions/defaultsPure.js
@@ -80,7 +80,6 @@ it('should keep the keys order with facets', function() {
   expect(Object.keys(actual)).toEqual(['Insignia™', 'Samsung', 'Apple']);
 });
 
-
 it('should keep the keys order when adding facet refinements', function() {
   var actual = defaults(
     {},

--- a/test/spec/functions/defaultsPure.js
+++ b/test/spec/functions/defaultsPure.js
@@ -65,12 +65,31 @@ it('should assign properties that shadow those on `Object.prototype`', function(
   expect(defaults({}, object, source)).toEqual(expected);
 });
 
-it('should not touch keys order', function() {
-  var expected = {'a': 1, 'b': 3, 'c': 3, 'd': 4};
-  var actual = defaults({'a': 1, 'b': 2}, {'b': 3, 'c': 3}, {'d': 4});
+it('should keep the keys order with facets', function() {
+  var actual = defaults(
+    {},
+    {
+      'Insignia™': 551,
+      'Samsung': 511,
+      'Apple': 386
+    },
+    {
+      'Apple': 386
+    }
+  );
+  expect(Object.keys(actual)).toEqual(['Insignia™', 'Samsung', 'Apple']);
+});
 
-  var expectedKeys = Object.keys(expected);
-  var actualKeys = Object.keys(actual);
 
-  expect(expectedKeys).toEqual(actualKeys);
+it('should keep the keys order when adding facet refinements', function() {
+  var actual = defaults(
+    {},
+    {
+      'facet2': ['facetValue']
+    },
+    {
+      'facet1': ['facetValue']
+    }
+  );
+  expect(Object.keys(actual)).toEqual(['facet1', 'facet2']);
 });


### PR DESCRIPTION
This PR fixes the regression of #762 where the order became wrong when running `addFacetRefinement` multiple times.

I don't know how to make the implementation of the `defaultsPure` shorter/cleaner/easier, but the bottom line is we need to pass the test cases I've added in this PR.

I've removed a wrong test case added in #762 which is

```js
it('should not touch keys order', function() {
  var expected = {'a': 1, 'b': 3, 'c': 3, 'd': 4};
  var actual = defaults({'a': 1, 'b': 2}, {'b': 3, 'c': 3}, {'d': 4});
```

It's a conflict and it doesn't make sense with our current use cases.