### PR TITLE
fix(insideBoundingBox): prevent invalid parameter from throwing

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -249,9 +249,12 @@ SearchParameters._parseNumbers = function(partialState) {
   // the one which is an array of float geo rectangles
   if (Array.isArray(partialState.insideBoundingBox)) {
     numbers.insideBoundingBox = partialState.insideBoundingBox.map(function(geoRect) {
-      return geoRect.map(function(value) {
-        return parseFloat(value);
-      });
+      if (Array.isArray(geoRect)) {
+        return geoRect.map(function(value) {
+          return parseFloat(value);
+        });
+      }
+      return geoRect;
     });
   }
 

--- a/test/spec/SearchParameters/_parseNumbers.js
+++ b/test/spec/SearchParameters/_parseNumbers.js
@@ -51,6 +51,15 @@ test('_parseNumbers should not convert insideBoundingBox if it\'s a string', fun
   expect(actual.insideBoundingBox).toBe('5,4,5,4');
 });
 
+test('_parseNumbers should leave insideBoundingBox as-is if not nested array', function() {
+  var partialState = {
+    insideBoundingBox: ['5', '4', '5', '4'],
+  };
+  var actual = SearchParameters._parseNumbers(partialState);
+
+  expect(actual.insideBoundingBox).toEqual(['5', '4', '5', '4']);
+});
+
 test('_parseNumbers should not convert unparseable strings', function() {
   var partialState = {
     aroundRadius: 'all'

--- a/test/spec/SearchParameters/_parseNumbers.js
+++ b/test/spec/SearchParameters/_parseNumbers.js
@@ -53,7 +53,7 @@ test('_parseNumbers should not convert insideBoundingBox if it\'s a string', fun
 
 test('_parseNumbers should leave insideBoundingBox as-is if not nested array', function() {
   var partialState = {
-    insideBoundingBox: ['5', '4', '5', '4'],
+    insideBoundingBox: ['5', '4', '5', '4']
   };
   var actual = SearchParameters._parseNumbers(partialState);
 


### PR DESCRIPTION
If you set an invalid parameter, like `insideBoundingBox: [123,123,123,123]`, an error was thrown, since it's not a nested array. We shouldn't fix this case, but rather let the API return an error which is more easy to catch.

The example in the test, as well as the one from the original issue `[42.3435822,-122.879144, 37.2967792, -121.9574956]` both throw an error in the engine, as well as here, before this PR.

The reason for leaving them alone, instead of trying to fix by adding in array, is that the API could change what they accept in the future, and this way we will not need to adapt. Additionally, an error response is easily caught with InstantSearch, vs. a TypeError in the Helper, which throws outside of React life cycles