### PR TITLE
fix(ts): use a dedicated key to determine client version

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from 'events';
 
 type DummySearchClientV4 = {
   readonly addAlgoliaAgent: (segment: string, version?: string) => void;
+  transporter: any;
 };
 
 type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4
@@ -439,7 +440,9 @@ declare namespace algoliasearchHelper {
       [facet: string]: SearchParameters.FacetList;
     };
 
+    // types missing in @types/algoliasearch, so duplicated from v4
     ruleContexts?: string[];
+    optionalFilters?: Array<string | string[]>;
   }
 
   export class SearchParameters implements PlainSearchParameters {

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,6 @@ import {
 import { EventEmitter } from 'events';
 
 type DummySearchClientV4 = {
-  readonly addAlgoliaAgent: (segment: string, version?: string) => void;
   transporter: any;
 };
 


### PR DESCRIPTION
Since the type definition of `@types/algoliasearch` also has `addAlgoliaAgent`, it actually took the v4 imports, which turn out to be "any". Since the change in https://github.com/algolia/algoliasearch-helper-js/pull/775 showed this behaviour more clearly, I found a solution to use a dedicated key which only exists in v4 (transporter) to distinguish between the versions