### PR TITLE
fix(ts): compat v3 and v4 without ts-ignore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare function algoliasearchHelper<TSearchClient extends GenericSearchClient>(
 declare namespace algoliasearchHelper {
   export const version: string;
 
-  export class AlgoliaSearchHelper<TSearchClient> extends EventEmitter {
+  export class AlgoliaSearchHelper<TSearchClient = GenericSearchClient> extends EventEmitter {
     state: SearchParameters;
     lastResults: SearchResults | null;
     derivedHelpers: DerivedHelper[];


### PR DESCRIPTION
For https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45699, it becomes illegal to have a ts-ignore in a dependency, without any way to disable it. I've talked to @orta and finally found this as a solution.

Once this PR has been released, it's possible to update the definitelytyped PR and React InstantSearch will finally work with v4 of algoliasearch without manually removing `@types/algoliasearch` and `@types/algoliasearch-helper`