### PR TITLE
fix(removeNumericRefinement): clear empty refinements

### DIFF
--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -665,9 +665,6 @@ SearchParameters.prototype = {
       }
       return {};
     } else if (typeof attribute === 'string') {
-      if (!objectHasKeys(this.numericRefinements[attribute])) {
-        return this.numericRefinements;
-      }
       return omit(this.numericRefinements, [attribute]);
     } else if (typeof attribute === 'function') {
       var hasChanged = false;

--- a/test/spec/SearchParameters/_clearNumericRefinements.js
+++ b/test/spec/SearchParameters/_clearNumericRefinements.js
@@ -7,6 +7,16 @@ test('When removing all numeric refinements of a state without any', function() 
   expect(state._clearNumericRefinements()).toBe(state.numericRefinements);
 });
 
+test('When removing numericRefinements of a specific attribute, which has no refinements', function() {
+  var state = SearchParameters.make({
+    numericRefinements: {
+      size: {}
+    }
+  });
+
+  expect(state._clearNumericRefinements('size')).toEqual({});
+});
+
 test('When removing numericRefinements of a specific attribute, and there are no refinements for this attribute', function() {
   var state = SearchParameters.make({
     numericRefinements: {
@@ -14,7 +24,7 @@ test('When removing numericRefinements of a specific attribute, and there are no
     }
   });
 
-  expect(state._clearNumericRefinements('size')).toBe(state.numericRefinements);
+  expect(state._clearNumericRefinements('size')).toEqual(state.numericRefinements);
 });
 
 test('When removing refinements of a specific attribute, and another refinement is a substring of this attribute', function() {


### PR DESCRIPTION
Previously this seemingly on purpose checked if this attrubte had refinements, but due to the way it is checking this, it will leave `{[attribute]: {}}` in the numeric refinements, which isn't what we want in e.g. a dispose.

related PR: https://github.com/algolia/instantsearch.js/pull/4587

Since this wasn't covered by any sort of test, I think this behaviour was unintentional