### PR TITLE
fix(ts): make queryID optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1213,7 +1213,7 @@ declare namespace algoliasearchHelper {
      * queryID is the unique identifier of the query used to generate the current search results.
      * This value is only available if the `clickAnalytics` search parameter is set to `true`.
      */
-    queryID: string;
+    queryID?: string;
     /**
      * disjunctive facets results
      */


### PR DESCRIPTION
## Summary

This PR makes `queryID` optionable. It's given only when `clickAnalytics: true`. 