### PR TITLE
fix(types): add relevancyStrictness to SearchParameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1110,6 +1110,13 @@ declare namespace algoliasearchHelper {
      */
     sortFacetValuesBy?: 'count' | 'alpha';
 
+    /**
+     * The relevancy threshold to apply to search in a virtual index [0-100]. A Bigger
+     * value means fewer, but more relevant results, smaller value means more, but
+     * less relevant results.
+     */
+    relevancyStrictness?: number;
+
     /* end implementation of algoliasearch.QueryParameters */
 
     ruleContexts?: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -513,8 +513,8 @@ declare namespace algoliasearchHelper {
     queryLanguages?: string[];
 
     /**
-     * The relevancy threshold to apply to search in a virtual index [0-100]. A Bigger
-     * value means fewer, but more relevant results, smaller value means more, but
+     * The relevancy threshold to apply to search in a virtual index [0-100]. A bigger
+     * value means fewer but more relevant results, a smaller value means more but
      * less relevant results.
      */
     relevancyStrictness?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1111,8 +1111,8 @@ declare namespace algoliasearchHelper {
     sortFacetValuesBy?: 'count' | 'alpha';
 
     /**
-     * The relevancy threshold to apply to search in a virtual index [0-100]. A Bigger
-     * value means fewer, but more relevant results, smaller value means more, but
+     * The relevancy threshold to apply to search in a virtual index [0-100]. A bigger
+     * value means fewer but more relevant results, a smaller value means more but
      * less relevant results.
      */
     relevancyStrictness?: number;


### PR DESCRIPTION
## Summary

This PR adds the missing `relevancyStrictness` to `SearchParameters`.