### PR TITLE
fix(ts): correct type for HierarchicalFacet parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -549,7 +549,9 @@ declare namespace algoliasearchHelper {
     addFacet(facet: string): SearchParameters;
     /* Add a refinement on a "normal" facet */
     addFacetRefinement(facet: string, value: string): SearchParameters;
-    addHierarchicalFacet(facet: any): SearchParameters;
+    addHierarchicalFacet(
+      facet: SearchParameters.HierarchicalFacet
+    ): SearchParameters;
     addHierarchicalFacetRefinement(
       facet: string,
       path: string
@@ -1128,7 +1130,7 @@ declare namespace algoliasearchHelper {
     type HierarchicalFacet = {
       name: string;
       attributes: string[];
-      separator: string;
+      separator?: string;
     };
 
     type OperatorList = {


### PR DESCRIPTION
I've checked, and the defaulting of " > " actually happens only in `_getHierarchicalFacetSeparator`, so that means you can get facets without separator. Examples:

https://github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/connectMenu.js#L283-L286
https://github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/__tests__/connectMenu-test.js#L98-L101