### PR TITLE
feat(facets): when * is present, only send that parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -432,12 +432,6 @@ declare namespace algoliasearchHelper {
      * let you filter faceted attributes hierarchically.
      */
     hierarchicalFacets?: SearchParameters.HierarchicalFacet[];
-    /**
-     * When a * is detected as one of the facets requested, it will be the only
-     * facet requested, to cache more often.
-     * @default false
-     */
-     expandWildcardFacets: boolean;
 
     // Refinements
     /**
@@ -530,7 +524,6 @@ declare namespace algoliasearchHelper {
     managedParameters: [
       'index',
 
-      'expandWildcardFacets',
       'facets',
       'disjunctiveFacets',
       'facetsRefinements',

--- a/index.d.ts
+++ b/index.d.ts
@@ -432,6 +432,12 @@ declare namespace algoliasearchHelper {
      * let you filter faceted attributes hierarchically.
      */
     hierarchicalFacets?: SearchParameters.HierarchicalFacet[];
+    /**
+     * When a * is detected as one of the facets requested, all facets that are
+     * not starting with "-" are removed from the request, to cache more often.
+     * @default false
+     */
+     expandWildcardFacets: boolean;
 
     // Refinements
     /**
@@ -523,14 +529,17 @@ declare namespace algoliasearchHelper {
   export class SearchParameters implements PlainSearchParameters {
     managedParameters: [
       'index',
+
+      'expandWildcardFacets',
       'facets',
       'disjunctiveFacets',
       'facetsRefinements',
+      'hierarchicalFacets',
       'facetsExcludes',
+  
       'disjunctiveFacetsRefinements',
       'numericRefinements',
       'tagRefinements',
-      'hierarchicalFacets',
       'hierarchicalFacetsRefinements'
     ];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -433,8 +433,8 @@ declare namespace algoliasearchHelper {
      */
     hierarchicalFacets?: SearchParameters.HierarchicalFacet[];
     /**
-     * When a * is detected as one of the facets requested, all facets that are
-     * not starting with "-" are removed from the request, to cache more often.
+     * When a * is detected as one of the facets requested, it will be the only
+     * facet requested, to cache more often.
      * @default false
      */
      expandWildcardFacets: boolean;

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1312,9 +1312,18 @@ SearchParameters.prototype = {
 
   managedParameters: [
     'index',
-    'facets', 'disjunctiveFacets', 'facetsRefinements',
-    'facetsExcludes', 'disjunctiveFacetsRefinements',
-    'numericRefinements', 'tagRefinements', 'hierarchicalFacets', 'hierarchicalFacetsRefinements'
+
+    'expandWildcardFacets',
+    'facets',
+    'disjunctiveFacets',
+    'facetsRefinements',
+    'hierarchicalFacets',
+    'facetsExcludes',
+
+    'disjunctiveFacetsRefinements',
+    'numericRefinements',
+    'tagRefinements',
+    'hierarchicalFacetsRefinements'
   ],
   getQueryParams: function getQueryParams() {
     var managedParameters = this.managedParameters;

--- a/src/SearchParameters/index.js
+++ b/src/SearchParameters/index.js
@@ -1313,7 +1313,6 @@ SearchParameters.prototype = {
   managedParameters: [
     'index',
 
-    'expandWildcardFacets',
     'facets',
     'disjunctiveFacets',
     'facetsRefinements',

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -60,7 +60,7 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      facets: facets.indexOf('*') > 0 ? ['*'] : facets,
+      facets: facets.indexOf('*') > -1 ? ['*'] : facets,
       tagFilters: tagFilters
     };
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -60,7 +60,9 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      facets: facets,
+      facets: state.expandWildcardFacets
+        ? facets.filter((facet) => facet === '*' || facet[0] === '-')
+        : facets,
       tagFilters: tagFilters
     };
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -61,7 +61,7 @@ var requestBuilder = {
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
       facets: state.expandWildcardFacets
-        ? facets.filter((facet) => facet === '*' || facet[0] === '-')
+        ? ['*']
         : facets,
       tagFilters: tagFilters
     };

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -60,8 +60,7 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      facets: facets.indexOf('*') > 0 ? ['*']
-        : facets,
+      facets: facets.indexOf('*') > 0 ? ['*'] : facets,
       tagFilters: tagFilters
     };
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -60,8 +60,7 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      facets: state.expandWildcardFacets && facets.indexOf('*') > 0
-        ? ['*']
+      facets: facets.indexOf('*') > 0 ? ['*']
         : facets,
       tagFilters: tagFilters
     };

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -60,7 +60,7 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      facets: state.expandWildcardFacets
+      facets: state.expandWildcardFacets && facets.indexOf('*') > 0
         ? ['*']
         : facets,
       tagFilters: tagFilters

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -99,6 +99,19 @@ describe('wildcard facets', function() {
     expect(queries[0].params.facets).toEqual(['*']);
   });
 
+  test('detects * as first value', function() {
+    var searchParams = new SearchParameters({
+      facets: ['*', 'test'],
+      disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
+      hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
+    });
+
+    var queries = getQueries(searchParams.index, searchParams);
+
+    expect(queries.length).toBe(1);
+    expect(queries[0].params.facets).toEqual(['*']);
+  });
+
   test('only applies to first query', function() {
     var searchParams = new SearchParameters({
       facets: ['test', '*'],

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -96,7 +96,7 @@ describe('expandWildcardFacets', function() {
     expect(queries[0].params.facets).toEqual(['*']);
   });
 
-  test('injects * if not present', function() {
+  test('keeps as-is if no * present', function() {
     var searchParams = new SearchParameters({
       expandWildcardFacets: true,
       facets: ['test'],
@@ -107,7 +107,12 @@ describe('expandWildcardFacets', function() {
     var queries = getQueries(searchParams.index, searchParams);
 
     expect(queries.length).toBe(1);
-    expect(queries[0].params.facets).toEqual(['*']);
+    expect(queries[0].params.facets).toEqual([
+      'test',
+      'test_disjunctive',
+      'test_numeric',
+      'whatever'
+    ]);
   });
 
   test('only applies to first query', function() {

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -99,7 +99,7 @@ describe('wildcard facets', function() {
     expect(queries[0].params.facets).toEqual(['*']);
   });
 
-  test('detects * as first value', function() {
+  test('keeps only * when first value', function() {
     var searchParams = new SearchParameters({
       facets: ['*', 'test'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -71,7 +71,7 @@ describe('expandWildcardFacets', function() {
   test('does not send expandWildcardFacets as parameter', function() {
     var searchParams = new SearchParameters({
       expandWildcardFacets: true,
-      facets: ['test', '-negative', '*'],
+      facets: ['test', '*'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
       hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
     });
@@ -82,10 +82,10 @@ describe('expandWildcardFacets', function() {
     expect(queries[0].params.expandWildcardFacets).toBe(undefined);
   });
 
-  test('keeps only * and negative', function() {
+  test('keeps only *', function() {
     var searchParams = new SearchParameters({
       expandWildcardFacets: true,
-      facets: ['test', '-negative', '*'],
+      facets: ['test', '*'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
       hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
     });
@@ -93,10 +93,10 @@ describe('expandWildcardFacets', function() {
     var queries = getQueries(searchParams.index, searchParams);
 
     expect(queries.length).toBe(1);
-    expect(queries[0].params.facets).toEqual(['-negative', '*']);
+    expect(queries[0].params.facets).toEqual(['*']);
   });
 
-  test('does not inject * if not present', function() {
+  test('injects * if not present', function() {
     var searchParams = new SearchParameters({
       expandWildcardFacets: true,
       facets: ['test'],
@@ -107,7 +107,7 @@ describe('expandWildcardFacets', function() {
     var queries = getQueries(searchParams.index, searchParams);
 
     expect(queries.length).toBe(1);
-    expect(queries[0].params.facets).toEqual([]);
+    expect(queries[0].params.facets).toEqual(['*']);
   });
 
   test('only applies to first query', function() {

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -67,38 +67,9 @@ test('does only a single query if refinements are empty', function() {
   expect(queries).toHaveLength(1);
 });
 
-describe('expandWildcardFacets', function() {
-  test('does not send expandWildcardFacets as parameter', function() {
-    var searchParams = new SearchParameters({
-      expandWildcardFacets: true,
-      facets: ['test', '*'],
-      disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
-      hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
-    });
-
-    var queries = getQueries(searchParams.index, searchParams);
-
-    expect(queries.length).toBe(1);
-    expect(queries[0].params.expandWildcardFacets).toBe(undefined);
-  });
-
-  test('keeps only *', function() {
-    var searchParams = new SearchParameters({
-      expandWildcardFacets: true,
-      facets: ['test', '*'],
-      disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
-      hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
-    });
-
-    var queries = getQueries(searchParams.index, searchParams);
-
-    expect(queries.length).toBe(1);
-    expect(queries[0].params.facets).toEqual(['*']);
-  });
-
+describe('wildcard facets', function() {
   test('keeps as-is if no * present', function() {
     var searchParams = new SearchParameters({
-      expandWildcardFacets: true,
       facets: ['test'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
       hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
@@ -115,9 +86,21 @@ describe('expandWildcardFacets', function() {
     ]);
   });
 
+  test('keeps only *', function() {
+    var searchParams = new SearchParameters({
+      facets: ['test', '*'],
+      disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
+      hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}]
+    });
+
+    var queries = getQueries(searchParams.index, searchParams);
+
+    expect(queries.length).toBe(1);
+    expect(queries[0].params.facets).toEqual(['*']);
+  });
+
   test('only applies to first query', function() {
     var searchParams = new SearchParameters({
-      expandWildcardFacets: true,
       facets: ['test', '*'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
       hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}],


### PR DESCRIPTION
When `*` is present in facets, we don't need to request the individual facet values of each facet that's declared, as `*` will already request it.

We keep only `*` if it is present. If no `*` is present, the facets stay as-is.

see: https://github.com/algolia/instantsearch/issues/5723

Alternatively to this PR, similar logic could be part of the algoliasearch client cache, but that has as downside that it requires an update to the search client, also custom implementations and older clients