### PR TITLE
feat(facetValues): offer escaped value

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -619,6 +619,16 @@ SearchResults.prototype.getFacetByName = function(name) {
 };
 
 /**
+ * Replaces a leading - with \-
+ * @private
+ * @param {string} value the facet value to replace
+ * @returns string
+ */
+function escapeFacetValue(value) {
+  return value.replace(/^-/, '\\-');
+}
+
+/**
  * Get the facet values of a specified attribute from a SearchResults object.
  * @private
  * @param {SearchResults} results the search results to search in
@@ -637,6 +647,7 @@ function extractNormalizedFacetValues(results, attribute) {
     return Object.keys(facet.data).map(function(name) {
       return {
         name: name,
+        value: escapeFacetValue(name),
         count: facet.data[name],
         isRefined: results._state.isFacetRefined(attribute, name),
         isExcluded: results._state.isExcludeRefined(attribute, name)
@@ -649,6 +660,7 @@ function extractNormalizedFacetValues(results, attribute) {
     return Object.keys(disjunctiveFacet.data).map(function(name) {
       return {
         name: name,
+        value: escapeFacetValue(name),
         count: disjunctiveFacet.data[name],
         isRefined: results._state.isDisjunctiveFacetRefined(attribute, name)
       };

--- a/test/spec/SearchResults/getFacetValues-facetOrdering.js
+++ b/test/spec/SearchResults/getFacetValues-facetOrdering.js
@@ -15,9 +15,9 @@ describe('disjunctive facet', function() {
         }
       },
       [
-        {count: 551, isRefined: false, name: 'Insignia™'},
-        {count: 511, isRefined: false, name: 'Samsung'},
-        {count: 386, isRefined: true, name: 'Apple'}
+        {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+        {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+        {count: 386, isRefined: true, name: 'Apple', value: 'Apple'}
       ]
     ],
     [
@@ -30,9 +30,9 @@ describe('disjunctive facet', function() {
         }
       },
       [
-        {count: 511, isRefined: false, name: 'Samsung'},
-        {count: 386, isRefined: true, name: 'Apple'},
-        {count: 551, isRefined: false, name: 'Insignia™'}
+        {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+        {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+        {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'}
       ]
     ],
     [
@@ -45,9 +45,9 @@ describe('disjunctive facet', function() {
         }
       },
       [
-        {count: 511, isRefined: false, name: 'Samsung'},
-        {count: 551, isRefined: false, name: 'Insignia™'},
-        {count: 386, isRefined: true, name: 'Apple'}
+        {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+        {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+        {count: 386, isRefined: true, name: 'Apple', value: 'Apple'}
       ]
     ],
     [
@@ -61,9 +61,9 @@ describe('disjunctive facet', function() {
         }
       },
       [
-        {count: 511, isRefined: false, name: 'Samsung'},
-        {count: 551, isRefined: false, name: 'Insignia™'},
-        {count: 386, isRefined: true, name: 'Apple'}
+        {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+        {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+        {count: 386, isRefined: true, name: 'Apple', value: 'Apple'}
       ]
     ],
     [
@@ -77,9 +77,9 @@ describe('disjunctive facet', function() {
         }
       },
       [
-        {count: 511, isRefined: false, name: 'Samsung'},
-        {count: 386, isRefined: true, name: 'Apple'},
-        {count: 551, isRefined: false, name: 'Insignia™'}
+        {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+        {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+        {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'}
       ]
     ],
     [
@@ -92,7 +92,7 @@ describe('disjunctive facet', function() {
           }
         }
       },
-      [{count: 511, isRefined: false, name: 'Samsung'}]
+      [{count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'}]
     ]
   ])('%p', function(_name, facetOrdering, expected) {
     var data = require('./getFacetValues/disjunctive.json');
@@ -134,9 +134,9 @@ describe('disjunctive facet', function() {
     var facetValues = result.getFacetValues('brand', {sortBy: ['name:desc']});
 
     var expected = [
-      {count: 511, isRefined: false, name: 'Samsung'},
-      {count: 551, isRefined: false, name: 'Insignia™'},
-      {count: 386, isRefined: true, name: 'Apple'}
+      {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+      {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+      {count: 386, isRefined: true, name: 'Apple', value: 'Apple'}
     ];
 
     expect(facetValues).toEqual(expected);
@@ -167,9 +167,9 @@ describe('disjunctive facet', function() {
     });
 
     var expected = [
-      {count: 511, isRefined: false, name: 'Samsung'},
-      {count: 386, isRefined: true, name: 'Apple'},
-      {count: 551, isRefined: false, name: 'Insignia™'}
+      {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+      {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+      {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'}
     ];
 
     expect(facetValues).toEqual(expected);
@@ -199,9 +199,9 @@ describe('disjunctive facet', function() {
     });
 
     var expected = [
-      {count: 386, isRefined: true, name: 'Apple'},
-      {count: 551, isRefined: false, name: 'Insignia™'},
-      {count: 511, isRefined: false, name: 'Samsung'}
+      {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+      {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+      {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'}
     ];
 
     expect(facetValues).toEqual(expected);
@@ -221,9 +221,9 @@ describe('disjunctive facet', function() {
     var facetValues = result.getFacetValues('brand');
 
     var expected = [
-      {count: 386, isRefined: true, name: 'Apple'},
-      {count: 551, isRefined: false, name: 'Insignia™'},
-      {count: 511, isRefined: false, name: 'Samsung'}
+      {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+      {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+      {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'}
     ];
 
     expect(facetValues).toEqual(expected);
@@ -787,14 +787,14 @@ test('does not return empty items', function() {
   }), rawResults.results);
 
   expect(results.getFacetValues('brands', {facetOrdering: true})).toEqual([
-    {name: 'Addo', count: 321, isRefined: false},
-    {name: 'Paw Patrol', count: 130, isRefined: false},
-    {name: 'Mattel', count: 586, isRefined: false},
-    {name: 'Nick Jr.', count: 147, isRefined: false},
-    {name: 'Early Learning Centre', count: 292, isRefined: false},
-    {name: 'Hot Wheels', count: 94, isRefined: false},
-    {name: 'Fisher-Price', count: 104, isRefined: false},
-    {name: 'Funko', count: 187, isRefined: false},
-    {name: 'Nickelodeon', count: 230, isRefined: false}
+    {name: 'Addo', value: 'Addo', count: 321, isRefined: false},
+    {name: 'Paw Patrol', value: 'Paw Patrol', count: 130, isRefined: false},
+    {name: 'Mattel', value: 'Mattel', count: 586, isRefined: false},
+    {name: 'Nick Jr.', value: 'Nick Jr.', count: 147, isRefined: false},
+    {name: 'Early Learning Centre', value: 'Early Learning Centre', count: 292, isRefined: false},
+    {name: 'Hot Wheels', value: 'Hot Wheels', count: 94, isRefined: false},
+    {name: 'Fisher-Price', value: 'Fisher-Price', count: 104, isRefined: false},
+    {name: 'Funko', value: 'Funko', count: 187, isRefined: false},
+    {name: 'Nickelodeon', value: 'Nickelodeon', count: 230, isRefined: false}
   ]);
 });

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -11,9 +11,9 @@ test('getFacetValues(facetName) returns a list of values using the defaults', fu
   var facetValues = result.getFacetValues('brand');
 
   var expected = [
-    {count: 386, isRefined: true, name: 'Apple'},
-    {count: 551, isRefined: false, name: 'Insignia™'},
-    {count: 511, isRefined: false, name: 'Samsung'}
+    {count: 386, isRefined: true, name: 'Apple', value: 'Apple'},
+    {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+    {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'}
   ];
 
   expect(facetValues).toEqual(expected);
@@ -101,9 +101,9 @@ test('getFacetValues(facetName) with disabled sorting', function() {
   });
 
   var expected = [
-    {count: 551, isRefined: false, name: 'Insignia™'},
-    {count: 511, isRefined: false, name: 'Samsung'},
-    {count: 386, isRefined: true, name: 'Apple'}
+    {count: 551, isRefined: false, name: 'Insignia™', value: 'Insignia™'},
+    {count: 511, isRefined: false, name: 'Samsung', value: 'Samsung'},
+    {count: 386, isRefined: true, name: 'Apple', value: 'Apple'}
   ];
 
   expect(facetValues).toEqual(expected);
@@ -131,8 +131,8 @@ test('getFacetValues(conjunctive) returns correct facet values with the name `le
   var facetValues = results.getFacetValues('type');
 
   var expected = [
-    {name: 'length', count: 5, isRefined: false, isExcluded: false},
-    {name: 'dogs', count: 0, isRefined: false, isExcluded: false}
+    {name: 'length', value: 'length', count: 5, isRefined: false, isExcluded: false},
+    {name: 'dogs', value: 'dogs', count: 0, isRefined: false, isExcluded: false}
   ];
 
   expect(facetValues).toEqual(expected);
@@ -161,12 +161,127 @@ test('getFacetValues(disjunctive) returns correct facet values with the name `le
   var facetValues = results.getFacetValues('type');
 
   var expected = [
-    {name: 'length', count: 5, isRefined: false},
-    {name: 'dogs', count: 0, isRefined: false}
+    {name: 'length', value: 'length', count: 5, isRefined: false},
+    {name: 'dogs', value: 'dogs', count: 0, isRefined: false}
   ];
 
   expect(facetValues).toEqual(expected);
   expect(facetValues.length).toBe(2);
+});
+
+test('getFacetValues(conjunctive) returns escaped facet values', function() {
+  var searchParams = new SearchParameters({
+    index: 'instant_search',
+    facets: ['type']
+  });
+
+  var result = {
+    query: '',
+    facets: {
+      type: {
+        'dogs': 1,
+        '-something': 5
+      }
+    }
+  };
+
+  var results = new SearchResults(searchParams, [result, result]);
+
+  var facetValues = results.getFacetValues('type');
+
+  var expected = [
+    {name: '-something', value: '\\-something', count: 5, isRefined: false, isExcluded: false},
+    {name: 'dogs', value: 'dogs', count: 1, isRefined: false, isExcluded: false}
+  ];
+
+  expect(facetValues).toEqual(expected);
+  expect(facetValues.length).toBe(2);
+});
+
+test('getFacetValues(disjunctive) returns escaped facet values', function() {
+  var searchParams = new SearchParameters({
+    index: 'instant_search',
+    disjunctiveFacets: ['type']
+  });
+
+  var result = {
+    query: '',
+    facets: {
+      type: {
+        'dogs': 1,
+        '-something': 5
+      }
+    }
+  };
+
+  var results = new SearchResults(searchParams, [result, result]);
+
+  var facetValues = results.getFacetValues('type');
+
+  var expected = [
+    {name: '-something', value: '\\-something', count: 5, isRefined: false},
+    {name: 'dogs', value: 'dogs', count: 1, isRefined: false}
+  ];
+
+  expect(facetValues).toEqual(expected);
+  expect(facetValues.length).toBe(2);
+});
+
+test('getFacetValues(hierachical) returns escaped facet values', function() {
+  var searchParams = new SearchParameters({
+    index: 'instant_search',
+    hierarchicalFacets: [{
+      name: 'type',
+      attributes: ['type1', 'type2']
+    }],
+    hierarchicalFacetsRefinements: {type: ['-something']}
+  });
+
+  var result = {
+    query: '',
+    facets: {
+      type1: {
+        'dogs': 1,
+        '-something': 5
+      },
+      type2: {
+        'dogs > hounds': 1,
+        '-something > discounts': 5
+      }
+    }
+  };
+
+  var results = new SearchResults(searchParams, [result, result]);
+
+  var facetValues = results.getFacetValues('type');
+
+  var expected = {
+    data: [
+      {
+        count: 5,
+        data: null,
+        exhaustive: undefined,
+        isRefined: false,
+        name: '-something',
+        path: '-something'
+      },
+      {
+        count: 1,
+        data: null,
+        exhaustive: undefined,
+        isRefined: false,
+        name: 'dogs',
+        path: 'dogs'
+      }
+    ],
+    exhaustive: false,
+    isRefined: true,
+    name: 'type',
+    path: null,
+    count: null
+  };
+
+  expect(facetValues).toEqual(expected);
 });
 
 test('getFacetValues(unknown) returns undefined (does not throw)', function() {

--- a/test/spec/algoliasearch.helper/searchOnce.js
+++ b/test/spec/algoliasearch.helper/searchOnce.js
@@ -30,27 +30,27 @@ test('searchOnce should call the algolia client according to the number of refin
 
     var cityValues = data.getFacetValues('city');
     var expectedCityValues = [
-      {name: 'Paris', count: 3, isRefined: true},
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false}
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true},
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false}
     ];
 
     expect(cityValues).toEqual(expectedCityValues);
 
     var cityValuesCustom = data.getFacetValues('city', {sortBy: ['count:asc', 'name:asc']});
     var expectedCityValuesCustom = [
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false},
-      {name: 'Paris', count: 3, isRefined: true}
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false},
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true}
     ];
 
     expect(cityValuesCustom).toEqual(expectedCityValuesCustom);
 
     var cityValuesFn = data.getFacetValues('city', {sortBy: function(a, b) { return a.count - b.count; }});
     var expectedCityValuesFn = [
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false},
-      {name: 'Paris', count: 3, isRefined: true}
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false},
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true}
     ];
 
     expect(cityValuesFn).toEqual(expectedCityValuesFn);

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -26,18 +26,18 @@ test('Search should call the algolia client according to the number of refinemen
 
     var cityValues = results.getFacetValues('city');
     var expectedCityValues = [
-      {name: 'Paris', count: 3, isRefined: true},
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false}
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true},
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false}
     ];
 
     expect(cityValues).toEqual(expectedCityValues);
 
     var cityValuesCustom = results.getFacetValues('city', {sortBy: ['count:asc', 'name:asc']});
     var expectedCityValuesCustom = [
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false},
-      {name: 'Paris', count: 3, isRefined: true}
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false},
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true}
     ];
 
 
@@ -45,9 +45,9 @@ test('Search should call the algolia client according to the number of refinemen
 
     var cityValuesFn = results.getFacetValues('city', {sortBy: function(a, b) { return a.count - b.count; }});
     var expectedCityValuesFn = [
-      {name: 'New York', count: 1, isRefined: true},
-      {name: 'San Francisco', count: 1, isRefined: false},
-      {name: 'Paris', count: 3, isRefined: true}
+      {name: 'New York', value: 'New York', count: 1, isRefined: true},
+      {name: 'San Francisco', value: 'San Francisco', count: 1, isRefined: false},
+      {name: 'Paris', value: 'Paris', count: 3, isRefined: true}
     ];
 
     expect(cityValuesFn).toEqual(expectedCityValuesFn);


### PR DESCRIPTION
That will be used in InstantSearch for the value.

See also #888 for another approach, where all negative refinements are automatically escaped, which is possibly a breaking change.

Still to do:
- [ ] test whether the escape is sufficient
- [ ] hierarchical values