### PR TITLE
fix(types): allow "__isArtificial"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1300,7 +1300,7 @@ declare namespace algoliasearchHelper {
 
     /**
      * Marker which can be added to search results to identify them as created without a search response.
-     * This is for internal use, eg. avoiding caching in infinite hits, or delaying the display of these results.
+     * This is for internal use, e.g., avoiding caching in infinite hits, or delaying the display of these results.
      */
     __isArtificial?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1298,6 +1298,12 @@ declare namespace algoliasearchHelper {
     _rawResults: SearchResponse<T>[];
     _state: SearchParameters;
 
+    /**
+     * Marker which can be added to search results to identify them as created without a search response.
+     * This is for internal use, eg. avoiding caching in infinite hits, or delaying the display of these results.
+     */
+    __isArtificial?: boolean;
+
     constructor(state: SearchParameters, results: SearchResponse<T>[]);
 
     /**


### PR DESCRIPTION
see https://github.com/algolia/react-instantsearch/pull/3378 for its use. As in every key of rawResults is added to the response, this does not require any code changes. You create artificial results like this: `new SearchResults(new SearchParameters(), [{ __isArtificial: true }])`

`__isArtificial` is a marker which can be added to search results to identify them as created without a search response. This is for internal use, eg. avoiding caching in infinite hits, or delaying the display of these results.