### PR TITLE
fix(disjunctiveFacets): avoid escaping non-string values

### DIFF
--- a/src/functions/escapeFacetValue.js
+++ b/src/functions/escapeFacetValue.js
@@ -3,20 +3,24 @@
 /**
  * Replaces a leading - with \-
  * @private
- * @param {string} value the facet value to replace
- * @returns string
+ * @param {any} value the facet value to replace
+ * @returns any
  */
 function escapeFacetValue(value) {
-  return value.replace(/^-/, '\\-');
+  if (typeof value !== 'string') return value;
+
+  return String(value).replace(/^-/, '\\-');
 }
 
 /**
  * Replaces a leading \- with -
  * @private
- * @param {string} value the escaped facet value
- * @returns string
+ * @param {any} value the escaped facet value
+ * @returns any
  */
 function unescapeFacetValue(value) {
+  if (typeof value !== 'string') return value;
+
   return value.replace(/^\\-/, '-');
 }
 

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -237,6 +237,36 @@ test('getFacetValues(disjunctive) returns escaped facet values', function() {
   expect(facetValues.length).toBe(3);
 });
 
+test('getFacetValues introduces numeric disjunctive refinements', function() {
+  var searchParams = new SearchParameters({
+    index: 'instant_search',
+    disjunctiveFacets: ['type'],
+    disjunctiveFacetsRefinements: {
+      type: ['5', 50]
+    }
+  });
+
+  var result = {
+    query: '',
+    facets: {
+      type: {}
+    }
+  };
+
+  var results = new SearchResults(searchParams, [result, result]);
+
+  var facetValues = results.getFacetValues('type');
+
+  var expected = [
+    {name: '5', escapedValue: '5', count: 0, isRefined: true},
+    // even though this could be considered refined, it's not because it's a number (existing bug)
+    {name: '50', escapedValue: '50', count: 0, isRefined: false}
+  ];
+
+  expect(facetValues).toEqual(expected);
+  expect(facetValues.length).toBe(2);
+});
+
 test('getFacetValues(hierachical) returns escaped facet values', function() {
   var searchParams = new SearchParameters({
     index: 'instant_search',


### PR DESCRIPTION
This wasn't fully functioning behaviour before #889 already, as numeric values don't show as refined, even if they are (see https://github.com/algolia/algoliasearch-helper-js/blob/dd375ab18513336817bd8d5d78341ac33ae94954/src/SearchParameters/RefinementList.js#L141 where it's purposely casted to a string, but the input values aren't), but it didn't throw an error, which became the case in #889

A customer discovered this in https://algolia.atlassian.net/browse/CR-883