### PR TITLE
feat(types): support algoliasearch v5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,45 +1,10 @@
-// Note: Below, we will be importing both algoliasearch
-// `v3` and algoliasearch `v4` types. The goal is being
-// able to export the algoliasearch-helper types using
-// the developer installed version of the client.
-
-import algoliasearch, {
-  // @ts-ignore
-  SearchClient as SearchClientV4,
-  // @ts-ignore
-  Client as SearchClientV3,
-  // @ts-ignore
-  QueryParameters as SearchOptionsV3,
-  // @ts-ignore
-  Response as SearchResponseV3,
-} from 'algoliasearch';
-import { 
-  SearchOptions as SearchOptionsV4,
-  SearchResponse as SearchResponseV4,
-  FindAnswersResponse
-  // @ts-ignore
-} from '@algolia/client-search';
 import EventEmitter from '@algolia/events';
-
-type DummySearchClientV4 = {
-  transporter: any;
-};
-
-type Client = ReturnType<typeof algoliasearch> extends DummySearchClientV4
-  ? SearchClientV4
-  : SearchClientV3;
-type SearchOptions = ReturnType<
-  typeof algoliasearch
-> extends DummySearchClientV4
-  ? SearchOptionsV4
-  : SearchOptionsV3;
-type SearchResponse<T> = ReturnType<
-  typeof algoliasearch
-> extends DummySearchClientV4
-  ? SearchResponseV4<T>
-  : SearchResponseV3<T>;
-
-type SearchClient = Pick<Client, 'search' | 'searchForFacetValues'>;
+import {
+  FindAnswersResponse,
+  SearchClient,
+  SearchOptions,
+  SearchResponse,
+} from './types/algoliasearch';
 
 /**
  * The algoliasearchHelper module is the function that will let its
@@ -272,7 +237,11 @@ declare namespace algoliasearchHelper {
      */
     addDisjunctiveRefine(facet: string, value: string): this;
     addHierarchicalFacetRefinement(facet: string, path: string): this;
-    addNumericRefinement(facet: string, operator?: SearchParameters.Operator, value?: number | number[]): this;
+    addNumericRefinement(
+      facet: string,
+      operator?: SearchParameters.Operator,
+      value?: number | number[]
+    ): this;
     addFacetRefinement(facet: string, value: string): this;
     /**
      * @deprecated since version 2.4.0, see {@link AlgoliaSearchHelper#addFacetRefinement}
@@ -284,7 +253,11 @@ declare namespace algoliasearchHelper {
      */
     addExclude: AlgoliaSearchHelper['addFacetExclusion'];
     addTag(tag: string): this;
-    removeNumericRefinement(facet: string, operator?: SearchParameters.Operator, value?: number | number[]): this;
+    removeNumericRefinement(
+      facet: string,
+      operator?: SearchParameters.Operator,
+      value?: number | number[]
+    ): this;
     removeDisjunctiveFacetRefinement(facet: string, value?: string): this;
     /**
      * @deprecated since version 2.4.0, see {@link AlgoliaSearchHelper#removeDisjunctiveFacetRefinement}
@@ -530,7 +503,7 @@ declare namespace algoliasearchHelper {
       'facetsRefinements',
       'hierarchicalFacets',
       'facetsExcludes',
-  
+
       'disjunctiveFacetsRefinements',
       'numericRefinements',
       'tagRefinements',
@@ -950,7 +923,7 @@ declare namespace algoliasearchHelper {
     queryType?: 'prefixAll' | 'prefixLast' | 'prefixNone';
     /**
      * Search entries inside a given area defined by a set of points
-     * defauly: ''
+     * default: ''
      * https://www.algolia.com/doc/api-reference/api-parameters/insidePolygon/
      */
     insidePolygon?: number[][];
@@ -1150,7 +1123,7 @@ declare namespace algoliasearchHelper {
      * Marker which can be added to search results to identify them as created without a search response.
      * This is for internal use, e.g., avoiding caching in infinite hits, or delaying the display of these results.
      */
-    __isArtificial?: boolean | undefined
+    __isArtificial?: boolean | undefined;
   }
 
   type ISearchResponse<T> = Omit<SearchResponse<T>, 'facets' | 'params'> &
@@ -1392,7 +1365,7 @@ declare namespace algoliasearchHelper {
 
     /**
      * Returns all refinements for all filters + tags. It also provides
-     * additional information: count and exhausistivity for each filter.
+     * additional information: count and exhaustiveness for each filter.
      *
      * See the [refinement type](#Refinement) for an exhaustive view of the available
      * data.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@algolia/events": "^4.0.1"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 5"
+    "algoliasearch": ">= 3.1 < 6"
   },
   "resolutions": {
     "node-sass": "4.14.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "dist",
     "src",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "types/algoliasearch.d.ts"
   ],
   "devDependencies": {
     "@types/algoliasearch": "3.34.11",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "src",
     "index.js",
     "index.d.ts",
-    "types/algoliasearch.d.ts"
+    "types/algoliasearch.d.ts",
+    "types/algoliasearch.js"
   ],
   "devDependencies": {
     "@types/algoliasearch": "3.34.11",

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -5,8 +5,6 @@
 // @ts-ignore
 import type algoliasearch from 'algoliasearch/lite';
 // @ts-ignore
-import type * as AlgoliaSearchLite from 'algoliasearch/lite';
-// @ts-ignore
 import type * as AlgoliaSearchLiteV5 from 'algoliasearch-lite';
 // @ts-ignore
 import type * as AlgoliaSearch from 'algoliasearch';
@@ -58,7 +56,7 @@ type DefaultSearchClient = PickForClient<{
 
 export type SearchOptions = PickForClient<{
   // @ts-ignore
-  v3: AlgoliaSearchLite.QueryParameters;
+  v3: AlgoliaSearch.QueryParameters;
   // @ts-ignore
   v4: ClientSearch.SearchOptions;
   v5: NonNullable<
@@ -69,7 +67,7 @@ export type SearchOptions = PickForClient<{
 
 export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
-  v3: AlgoliaSearchLite.Response<T>;
+  v3: AlgoliaSearch.Response<T>;
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
@@ -87,7 +85,7 @@ export type SearchResponses<T> = PickForClient<{
 
 export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
-  v3: AlgoliaSearchLite.SearchForFacetValues.Response;
+  v3: AlgoliaSearch.SearchForFacetValues.Response;
   // @ts-ignore
   v4: ClientSearch.SearchForFacetValuesResponse;
   // @ts-ignore

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -12,7 +12,9 @@ import type * as AlgoliaSearch from 'algoliasearch';
 import type * as ClientSearch from '@algolia/client-search';
 
 // turns any to unknown, so it can be used as a conditional
-type AnyToUnknown<T> = any extends T ? unknown : T;
+type AnyToUnknown<T> = (any extends T ? true : false) extends true
+  ? unknown
+  : T;
 
 type DummySearchClientV4 = {
   transporter: unknown;
@@ -21,6 +23,9 @@ type DummySearchClientV4 = {
 type DummySearchClient = {
   search: unknown;
 };
+
+// @ts-ignore
+type ClientV3_4 = ReturnType<typeof algoliasearch>;
 
 type ClientLiteV5 = AnyToUnknown<
   // @ts-ignore
@@ -50,16 +55,14 @@ type PickForClient<
   }
 > = ClientV5 extends DummySearchClient
   ? T['v5']
-  : ReturnType<typeof algoliasearch> extends DummySearchClientV4
+  : // @ts-ignore
+  ClientV3_4 extends DummySearchClientV4
   ? T['v4']
   : T['v3'];
 
 type DefaultSearchClient = PickForClient<{
-  // @ts-ignore
-  v3: ReturnType<typeof algoliasearch>;
-  // @ts-ignore
-  v4: ReturnType<typeof algoliasearch>;
-  // @ts-ignore
+  v3: ClientV3_4;
+  v4: ClientV3_4;
   v5: ClientV5;
 }>;
 
@@ -70,7 +73,7 @@ export type SearchOptions = PickForClient<{
   v4: ClientSearch.SearchOptions;
   v5: NonNullable<
     // @ts-ignore
-    ClientSearch.LegacySearchMethodProps[number]['params']
+    AlgoliaSearch.LegacySearchMethodProps[number]['params']
   >;
 }>;
 
@@ -96,7 +99,7 @@ export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
-  v5: ClientSearch.SearchResponse; // TODO: should be generic
+  v5: AlgoliaSearch.SearchResponse; // TODO: should be generic
 }>;
 
 export type SearchResponses<T> = PickForClient<{
@@ -105,7 +108,7 @@ export type SearchResponses<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.MultipleQueriesResponse<T>;
   // @ts-ignore
-  v5: ClientSearch.SearchResponses; // TODO: should be generic
+  v5: AlgoliaSearch.SearchResponses; // TODO: should be generic
 }>;
 
 export type SearchForFacetValuesResponse = PickForClient<{
@@ -114,7 +117,7 @@ export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchForFacetValuesResponse;
   // @ts-ignore
-  v5: ClientSearch.SearchForFacetValuesResponse;
+  v5: AlgoliaSearch.SearchForFacetValuesResponse;
 }>;
 
 export type FindAnswersOptions = PickForClient<{

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -5,7 +5,7 @@
 // @ts-ignore
 import type algoliasearch from 'algoliasearch/lite';
 // @ts-ignore
-import type * as AlgoliaSearchLiteV5 from 'algoliasearch-lite';
+import type * as AlgoliaSearchLite from 'algoliasearch/lite';
 // @ts-ignore
 import type * as AlgoliaSearch from 'algoliasearch';
 // @ts-ignore
@@ -22,16 +22,25 @@ type DummySearchClient = {
   search: unknown;
 };
 
-// @ts-ignore
-type ClientLiteV5 = ReturnType<
+type ClientLiteV5 = AnyToUnknown<
   // @ts-ignore
-  typeof AlgoliaSearchLiteV5.algoliasearchLiteClient
+  ReturnType<typeof AlgoliaSearchLite.liteClient>
 >;
-// @ts-ignore
-type ClientFullV5 = ReturnType<typeof AlgoliaSearch.algoliasearch>;
-type ClientV5 = AnyToUnknown<
-  ClientLiteV5 extends DummySearchClient ? ClientLiteV5 : ClientFullV5
+type ClientFullV5 = AnyToUnknown<
+  // @ts-ignore
+  ReturnType<typeof AlgoliaSearch.algoliasearch>
 >;
+type ClientSearchV5 = AnyToUnknown<
+  // @ts-ignore
+  ReturnType<typeof ClientSearch.searchClient>
+>;
+type ClientV5 = ClientLiteV5 extends DummySearchClient
+  ? ClientLiteV5
+  : ClientSearchV5 extends DummySearchClient
+  ? ClientSearchV5
+  : ClientFullV5 extends DummySearchClient
+  ? ClientFullV5
+  : unknown;
 
 type PickForClient<
   T extends {

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -29,9 +29,9 @@ type ClientLiteV5 = ReturnType<
 >;
 // @ts-ignore
 type ClientFullV5 = ReturnType<typeof AlgoliaSearch.algoliasearch>;
-type ClientV5 = AnyToUnknown<ClientLiteV5 extends DummySearchClient
-  ? ClientLiteV5
-  : ClientFullV5>;
+type ClientV5 = AnyToUnknown<
+  ClientLiteV5 extends DummySearchClient ? ClientLiteV5 : ClientFullV5
+>;
 
 type PickForClient<
   T extends {
@@ -67,7 +67,10 @@ export type SearchOptions = PickForClient<{
 
 export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
-  v3: AlgoliaSearch.Response<T>;
+  v3: AlgoliaSearch.Response<T> & {
+    appliedRelevancyStrictness?: number;
+    nbSortedHits?: number;
+  };
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -15,12 +15,15 @@ import type * as AlgoliaSearchFullV5 from '@experimental-api-clients-automation/
 // @ts-ignore
 import * as ClientSearchV5 from '@experimental-api-clients-automation/client-search';
 
+// turns any to unknown, so it can be used as a conditional
+type AnyToUnknown<T> = any extends T ? unknown : T;
+
 type DummySearchClientV4 = {
-  transporter: any;
+  transporter: unknown;
 };
 
-type DummySearchClientV5 = {
-  search: any;
+type DummySearchClient = {
+  search: unknown;
 };
 
 // @ts-ignore
@@ -30,18 +33,18 @@ type ClientLiteV5 = ReturnType<
 >;
 // @ts-ignore
 type ClientFullV5 = ReturnType<typeof AlgoliaSearchFullV5.algoliasearch>;
+type ClientV5 = AnyToUnknown<ClientLiteV5 extends DummySearchClient
+  ? ClientLiteV5
+  : ClientFullV5>;
 
 type PickForClient<
   T extends {
     v3: unknown;
     v4: unknown;
-    v5lite: unknown;
-    v5full: unknown;
+    v5: unknown;
   }
-> = ClientLiteV5 extends DummySearchClientV5
-  ? T['v5lite']
-  : ClientFullV5 extends DummySearchClientV5
-  ? T['v5full']
+> = ClientV5 extends DummySearchClient
+  ? T['v5']
   : ReturnType<typeof algoliasearch> extends DummySearchClientV4
   ? T['v4']
   : T['v3'];
@@ -52,9 +55,7 @@ type DefaultSearchClient = PickForClient<{
   // @ts-ignore
   v4: ReturnType<typeof algoliasearch>;
   // @ts-ignore
-  v5lite: ClientLiteV5;
-  // @ts-ignore
-  v5full: ClientFullV5;
+  v5: ClientV5;
 }>;
 
 export type SearchOptions = PickForClient<{
@@ -62,11 +63,7 @@ export type SearchOptions = PickForClient<{
   v3: AlgoliaSearchLite.QueryParameters;
   // @ts-ignore
   v4: ClientSearch.SearchOptions;
-  v5lite: NonNullable<
-    // @ts-ignore
-    ClientSearchV5.LegacySearchMethodProps[number]['params']
-  >;
-  v5full: NonNullable<
+  v5: NonNullable<
     // @ts-ignore
     ClientSearchV5.LegacySearchMethodProps[number]['params']
   >;
@@ -78,9 +75,7 @@ export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
-  v5lite: ClientSearchV5.SearchResponse; // TODO: should be generic
-  // @ts-ignore
-  v5full: ClientSearchV5.SearchResponse;
+  v5: ClientSearchV5.SearchResponse; // TODO: should be generic
 }>;
 
 export type SearchForFacetValuesResponse = PickForClient<{
@@ -89,25 +84,21 @@ export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchForFacetValuesResponse;
   // @ts-ignore
-  v5lite: ClientSearchV5.SearchForFacetValuesResponse;
-  // @ts-ignore
-  v5full: ClientSearchV5.SearchForFacetValuesResponse;
+  v5: ClientSearchV5.SearchForFacetValuesResponse;
 }>;
 
 export type FindAnswersOptions = PickForClient<{
   v3: any;
   // @ts-ignore
   v4: ClientSearch.FindAnswersOptions;
-  v5lite: any;
-  v5full: any;
+  v5: any;
 }>;
 
 export type FindAnswersResponse<T> = PickForClient<{
   v3: any;
   // @ts-ignore
   v4: ClientSearch.FindAnswersResponse<T>;
-  v5lite: any;
-  v5full: any;
+  v5: any;
 }>;
 
 export interface SearchClient {

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -1,0 +1,124 @@
+// Note: Below, we will be importing all algoliasearch v3,4,5 types.
+// The goal is being able to export the algoliasearch-helper types using
+// the version of the client installed by the developer.
+
+// @ts-ignore
+import type algoliasearch from 'algoliasearch/lite';
+// @ts-ignore
+import type * as AlgoliaSearchLite from 'algoliasearch/lite';
+// @ts-ignore
+import type * as ClientSearch from '@algolia/client-search';
+// @ts-ignore
+import type * as AlgoliaSearchLiteV5 from '@experimental-api-clients-automation/algoliasearch-lite';
+// @ts-ignore
+import type * as AlgoliaSearchFullV5 from '@experimental-api-clients-automation/algoliasearch';
+// @ts-ignore
+import * as ClientSearchV5 from '@experimental-api-clients-automation/client-search';
+
+type DummySearchClientV4 = {
+  transporter: any;
+};
+
+type DummySearchClientV5 = {
+  search: any;
+};
+
+// @ts-ignore
+type ClientLiteV5 = ReturnType<
+  // @ts-ignore
+  typeof AlgoliaSearchLiteV5.algoliasearchLiteClient
+>;
+// @ts-ignore
+type ClientFullV5 = ReturnType<typeof AlgoliaSearchFullV5.algoliasearch>;
+
+type PickForClient<
+  T extends {
+    v3: unknown;
+    v4: unknown;
+    v5lite: unknown;
+    v5full: unknown;
+  }
+> = ClientLiteV5 extends DummySearchClientV5
+  ? T['v5lite']
+  : ClientFullV5 extends DummySearchClientV5
+  ? T['v5full']
+  : ReturnType<typeof algoliasearch> extends DummySearchClientV4
+  ? T['v4']
+  : T['v3'];
+
+type DefaultSearchClient = PickForClient<{
+  // @ts-ignore
+  v3: ReturnType<typeof algoliasearch>;
+  // @ts-ignore
+  v4: ReturnType<typeof algoliasearch>;
+  // @ts-ignore
+  v5lite: ClientLiteV5;
+  // @ts-ignore
+  v5full: ClientFullV5;
+}>;
+
+export type SearchOptions = PickForClient<{
+  // @ts-ignore
+  v3: AlgoliaSearchLite.QueryParameters;
+  // @ts-ignore
+  v4: ClientSearch.SearchOptions;
+  v5lite: NonNullable<
+    // @ts-ignore
+    ClientSearchV5.LegacySearchMethodProps[number]['params']
+  >;
+  v5full: NonNullable<
+    // @ts-ignore
+    ClientSearchV5.LegacySearchMethodProps[number]['params']
+  >;
+}>;
+
+export type SearchResponse<T> = PickForClient<{
+  // @ts-ignore
+  v3: AlgoliaSearchLite.Response<T>;
+  // @ts-ignore
+  v4: ClientSearch.SearchResponse<T>;
+  // @ts-ignore
+  v5lite: ClientSearchV5.SearchResponse; // TODO: should be generic
+  // @ts-ignore
+  v5full: ClientSearchV5.SearchResponse;
+}>;
+
+export type SearchForFacetValuesResponse = PickForClient<{
+  // @ts-ignore
+  v3: AlgoliaSearchLite.SearchForFacetValues.Response;
+  // @ts-ignore
+  v4: ClientSearch.SearchForFacetValuesResponse;
+  // @ts-ignore
+  v5lite: ClientSearchV5.SearchForFacetValuesResponse;
+  // @ts-ignore
+  v5full: ClientSearchV5.SearchForFacetValuesResponse;
+}>;
+
+export type FindAnswersOptions = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.FindAnswersOptions;
+  v5lite: any;
+  v5full: any;
+}>;
+
+export type FindAnswersResponse<T> = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.FindAnswersResponse<T>;
+  v5lite: any;
+  v5full: any;
+}>;
+
+export interface SearchClient {
+  search: DefaultSearchClient['search'];
+  searchForFacetValues?: DefaultSearchClient extends {
+    searchForFacetValues: unknown;
+  }
+    ? DefaultSearchClient['searchForFacetValues']
+    : never;
+  initIndex?: DefaultSearchClient extends { initIndex: unknown }
+    ? DefaultSearchClient['initIndex']
+    : never;
+  addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
+}

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -7,13 +7,11 @@ import type algoliasearch from 'algoliasearch/lite';
 // @ts-ignore
 import type * as AlgoliaSearchLite from 'algoliasearch/lite';
 // @ts-ignore
+import type * as AlgoliaSearchLiteV5 from 'algoliasearch-lite';
+// @ts-ignore
+import type * as AlgoliaSearch from 'algoliasearch';
+// @ts-ignore
 import type * as ClientSearch from '@algolia/client-search';
-// @ts-ignore
-import type * as AlgoliaSearchLiteV5 from '@experimental-api-clients-automation/algoliasearch-lite';
-// @ts-ignore
-import type * as AlgoliaSearchFullV5 from '@experimental-api-clients-automation/algoliasearch';
-// @ts-ignore
-import * as ClientSearchV5 from '@experimental-api-clients-automation/client-search';
 
 // turns any to unknown, so it can be used as a conditional
 type AnyToUnknown<T> = any extends T ? unknown : T;
@@ -32,7 +30,7 @@ type ClientLiteV5 = ReturnType<
   typeof AlgoliaSearchLiteV5.algoliasearchLiteClient
 >;
 // @ts-ignore
-type ClientFullV5 = ReturnType<typeof AlgoliaSearchFullV5.algoliasearch>;
+type ClientFullV5 = ReturnType<typeof AlgoliaSearch.algoliasearch>;
 type ClientV5 = AnyToUnknown<ClientLiteV5 extends DummySearchClient
   ? ClientLiteV5
   : ClientFullV5>;
@@ -65,7 +63,7 @@ export type SearchOptions = PickForClient<{
   v4: ClientSearch.SearchOptions;
   v5: NonNullable<
     // @ts-ignore
-    ClientSearchV5.LegacySearchMethodProps[number]['params']
+    ClientSearch.LegacySearchMethodProps[number]['params']
   >;
 }>;
 
@@ -75,7 +73,7 @@ export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
-  v5: ClientSearchV5.SearchResponse; // TODO: should be generic
+  v5: ClientSearch.SearchResponse; // TODO: should be generic
 }>;
 
 export type SearchForFacetValuesResponse = PickForClient<{
@@ -84,7 +82,7 @@ export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchForFacetValuesResponse;
   // @ts-ignore
-  v5: ClientSearchV5.SearchForFacetValuesResponse;
+  v5: ClientSearch.SearchForFacetValuesResponse;
 }>;
 
 export type FindAnswersOptions = PickForClient<{

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -76,6 +76,15 @@ export type SearchResponse<T> = PickForClient<{
   v5: ClientSearch.SearchResponse; // TODO: should be generic
 }>;
 
+export type SearchResponses<T> = PickForClient<{
+  // @ts-ignore
+  v3: AlgoliaSearch.MultiResponse<T>;
+  // @ts-ignore
+  v4: ClientSearch.MultipleQueriesResponse<T>;
+  // @ts-ignore
+  v5: ClientSearch.SearchResponses; // TODO: should be generic
+}>;
+
 export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
   v3: AlgoliaSearchLite.SearchForFacetValues.Response;

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -16,11 +16,11 @@ type AnyToUnknown<T> = (any extends T ? true : false) extends true
   ? unknown
   : T;
 
-type DummySearchClientV4 = {
+type SearchClientV4Shape = {
   transporter: unknown;
 };
 
-type DummySearchClient = {
+type SearchClientShape = {
   search: unknown;
 };
 
@@ -39,11 +39,11 @@ type ClientSearchV5 = AnyToUnknown<
   // @ts-ignore
   ReturnType<typeof ClientSearch.searchClient>
 >;
-type ClientV5 = ClientLiteV5 extends DummySearchClient
+type ClientV5 = ClientLiteV5 extends SearchClientShape
   ? ClientLiteV5
-  : ClientSearchV5 extends DummySearchClient
+  : ClientSearchV5 extends SearchClientShape
   ? ClientSearchV5
-  : ClientFullV5 extends DummySearchClient
+  : ClientFullV5 extends SearchClientShape
   ? ClientFullV5
   : unknown;
 
@@ -53,10 +53,10 @@ type PickForClient<
     v4: unknown;
     v5: unknown;
   }
-> = ClientV5 extends DummySearchClient
+> = ClientV5 extends SearchClientShape
   ? T['v5']
   : // @ts-ignore
-  ClientV3_4 extends DummySearchClientV4
+  ClientV3_4 extends SearchClientV4Shape
   ? T['v4']
   : T['v3'];
 

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -70,6 +70,19 @@ export type SearchResponse<T> = PickForClient<{
   v3: AlgoliaSearch.Response<T> & {
     appliedRelevancyStrictness?: number;
     nbSortedHits?: number;
+    renderingContent?: {
+      facetOrdering?: {
+        facets?: {
+          order?: string[];
+        };
+        values?: {
+          [facet: string]: {
+            order?: string[];
+            sortRemainingBy?: 'count' | 'alpha' | 'hidden';
+          };
+        };
+      };
+    };
   };
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;

--- a/types/algoliasearch.js
+++ b/types/algoliasearch.js
@@ -1,1 +1,1 @@
-// fake file to work with the types
+// fake file to allow `export * from 'algoliasearch-helper/types/algoliasearch'`

--- a/types/algoliasearch.js
+++ b/types/algoliasearch.js
@@ -1,0 +1,1 @@
+// fake file to work with the types


### PR DESCRIPTION
Algoliasearch v5 has different type names and packages, so needs to be supported separately.

This pull request has the following changes:

1. add a folder `/types/algoliasearch` with both a .d.ts and .js file
2. add utilities and simplify the dealing of importing different types across the major versions

FX-1434