### PR TITLE
fix(requests): send a sorted object of parameters

### DIFF
--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -2,6 +2,17 @@
 
 var merge = require('./functions/merge');
 
+function sortObject(obj) {
+  return Object.keys(obj)
+    .sort(function(a, b) {
+      return a.localeCompare(b);
+    })
+    .reduce(function(acc, curr) {
+      acc[curr] = obj[curr];
+      return acc;
+    }, {});
+}
+
 var requestBuilder = {
   /**
    * Get all the queries to send to the client, those queries can used directly
@@ -92,7 +103,7 @@ var requestBuilder = {
       additionalParams.numericFilters = numericFilters;
     }
 
-    return merge({}, state.getQueryParams(), additionalParams);
+    return sortObject(merge({}, state.getQueryParams(), additionalParams));
   },
 
   /**
@@ -137,7 +148,7 @@ var requestBuilder = {
       additionalParams.facetFilters = facetFilters;
     }
 
-    return merge({}, state.getQueryParams(), additionalParams);
+    return sortObject(merge({}, state.getQueryParams(), additionalParams));
   },
 
   /**
@@ -330,11 +341,11 @@ var requestBuilder = {
     if (typeof maxFacetHits === 'number') {
       searchForFacetSearchParameters.maxFacetHits = maxFacetHits;
     }
-    return merge(
+    return sortObject(merge(
       {},
       requestBuilder._getHitsSearchParams(stateForSearchForFacetValues),
       searchForFacetSearchParameters
-    );
+    ));
   }
 };
 

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -91,6 +91,81 @@ test('does multiple queries to retrieve all facet values of hierarchical parent 
   expect(queries[3].params.facetFilters).toEqual(['categories.lvl0:beers']);
 });
 
+test('orders parameters alphabetically in every query', function() {
+  var searchParams = new SearchParameters({
+    facets: ['test'],
+    disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
+    disjunctiveFacetsRefinements: {
+      test_disjunctive: ['test_disjunctive_value']
+    },
+    numericRefinements: {
+      test_numeric: {
+        '>=': [10]
+      }
+    },
+    hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}],
+    hierarchicalFacetsRefinements: {
+      test_hierarchical: ['item']
+    },
+    attributesToRetrieve: ['this is last in parameters, but first in queries']
+  });
+
+  var queries = getQueries(searchParams.index, searchParams);
+
+  expect(queries.length).toBe(4);
+  expect(JSON.stringify(queries[0].params)).toBe(JSON.stringify({
+    attributesToRetrieve: ['this is last in parameters, but first in queries'],
+    facetFilters: [
+      ['test_disjunctive:test_disjunctive_value'],
+      ['whatever:item']
+    ],
+    facets: ['test', 'test_disjunctive', 'test_numeric', 'whatever'],
+    numericFilters: ['test_numeric>=10'],
+    tagFilters: ''
+  }));
+  expect(JSON.stringify(queries[1].params)).toBe(JSON.stringify({
+    analytics: false,
+    attributesToHighlight: [],
+    attributesToRetrieve: ['this is last in parameters, but first in queries'],
+    attributesToSnippet: [],
+    clickAnalytics: false,
+    facetFilters: [['whatever:item']],
+    facets: 'test_disjunctive',
+    hitsPerPage: 1,
+    numericFilters: ['test_numeric>=10'],
+    page: 0,
+    tagFilters: ''
+  }));
+  expect(JSON.stringify(queries[2].params)).toBe(JSON.stringify({
+    analytics: false,
+    attributesToHighlight: [],
+    attributesToRetrieve: ['this is last in parameters, but first in queries'],
+    attributesToSnippet: [],
+    clickAnalytics: false,
+    facetFilters: [
+      ['test_disjunctive:test_disjunctive_value'],
+      ['whatever:item']
+    ],
+    facets: 'test_numeric',
+    hitsPerPage: 1,
+    page: 0,
+    tagFilters: ''
+  }));
+  expect(JSON.stringify(queries[3].params)).toBe(JSON.stringify({
+    analytics: false,
+    attributesToHighlight: [],
+    attributesToRetrieve: ['this is last in parameters, but first in queries'],
+    attributesToSnippet: [],
+    clickAnalytics: false,
+    facetFilters: [['test_disjunctive:test_disjunctive_value']],
+    facets: ['whatever'],
+    hitsPerPage: 1,
+    numericFilters: ['test_numeric>=10'],
+    page: 0,
+    tagFilters: ''
+  }));
+});
+
 describe('wildcard facets', function() {
   test('keeps as-is if no * present', function() {
     var searchParams = new SearchParameters({


### PR DESCRIPTION
Having a sorted set of parameters helps with making sure the cache is hit in more cases.

For example, when you remove and immediately add the same widget again, and they no longer are in the same order, but have the same parameters conceptually.

This PR does not sort the items inside the parameters, eg. facets, which would be possible, but isn't done yet.

FX-1473