### PR TITLE
feat(disjunctiveFacetParams): reduce payload size

### DIFF
--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -121,8 +121,7 @@ var requestBuilder = {
       hitsPerPage: 0,
       page: 0,
       analytics: false,
-      clickAnalytics: false,
-      responseFields: ['facets', 'renderingContent']
+      clickAnalytics: false
     };
 
     if (tagFilters.length > 0) {

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -121,7 +121,8 @@ var requestBuilder = {
       hitsPerPage: 0,
       page: 0,
       analytics: false,
-      clickAnalytics: false
+      clickAnalytics: false,
+      responseFields: ["facets", "renderingContent"],
     };
     
     if (tagFilters.length > 0) {

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -118,15 +118,15 @@ var requestBuilder = {
     var numericFilters = requestBuilder._getNumericFilters(state, facet);
     var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
-      hitsPerPage: 1,
+      hitsPerPage: 0,
       page: 0,
-      attributesToRetrieve: [],
-      attributesToHighlight: [],
-      attributesToSnippet: [],
-      tagFilters: tagFilters,
       analytics: false,
       clickAnalytics: false
     };
+    
+    if (tagFilters.length > 0) {
+      additionalParams.tagFilters = tagFilters; 
+    }
 
     var hierarchicalFacet = state.getHierarchicalFacetByName(facet);
 

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -124,9 +124,9 @@ var requestBuilder = {
       clickAnalytics: false,
       responseFields: ['facets', 'renderingContent']
     };
-    
+
     if (tagFilters.length > 0) {
-      additionalParams.tagFilters = tagFilters; 
+      additionalParams.tagFilters = tagFilters;
     }
 
     var hierarchicalFacet = state.getHierarchicalFacetByName(facet);

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -122,7 +122,7 @@ var requestBuilder = {
       page: 0,
       analytics: false,
       clickAnalytics: false,
-      responseFields: ["facets", "renderingContent"],
+      responseFields: ['facets', 'renderingContent']
     };
     
     if (tagFilters.length > 0) {

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -125,44 +125,35 @@ test('orders parameters alphabetically in every query', function() {
   }));
   expect(JSON.stringify(queries[1].params)).toBe(JSON.stringify({
     analytics: false,
-    attributesToHighlight: [],
     attributesToRetrieve: ['this is last in parameters, but first in queries'],
-    attributesToSnippet: [],
     clickAnalytics: false,
     facetFilters: [['whatever:item']],
     facets: 'test_disjunctive',
-    hitsPerPage: 1,
+    hitsPerPage: 0,
     numericFilters: ['test_numeric>=10'],
-    page: 0,
-    tagFilters: ''
+    page: 0
   }));
   expect(JSON.stringify(queries[2].params)).toBe(JSON.stringify({
     analytics: false,
-    attributesToHighlight: [],
     attributesToRetrieve: ['this is last in parameters, but first in queries'],
-    attributesToSnippet: [],
     clickAnalytics: false,
     facetFilters: [
       ['test_disjunctive:test_disjunctive_value'],
       ['whatever:item']
     ],
     facets: 'test_numeric',
-    hitsPerPage: 1,
-    page: 0,
-    tagFilters: ''
+    hitsPerPage: 0,
+    page: 0
   }));
   expect(JSON.stringify(queries[3].params)).toBe(JSON.stringify({
     analytics: false,
-    attributesToHighlight: [],
     attributesToRetrieve: ['this is last in parameters, but first in queries'],
-    attributesToSnippet: [],
     clickAnalytics: false,
     facetFilters: [['test_disjunctive:test_disjunctive_value']],
     facets: ['whatever'],
-    hitsPerPage: 1,
+    hitsPerPage: 0,
     numericFilters: ['test_numeric>=10'],
-    page: 0,
-    tagFilters: ''
+    page: 0
   }));
 });
 


### PR DESCRIPTION
This PR reduces the amount of params sent for each disjunctive facet request.
It also reduces `hitsPerPage` from `1` to `0`, allowing us to remove the `attributes*` parameters at the same time.

This reduces:
* the payload sent by a few bytes
* and the response size by a few extra bytes as the previous implem sent back one `objectID` per additional request