### PR TITLE
feat(typing): Update SearchResults hits, expose optional hit typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,12 @@
 import EventEmitter from '@algolia/events';
 import {
   FindAnswersResponse,
+  HighlightResult,
+  RankingInfo,
   SearchClient,
   SearchOptions,
   SearchResponse,
+  SnippetResult,
 } from './types/algoliasearch';
 
 /**
@@ -1147,6 +1150,10 @@ declare namespace algoliasearchHelper {
      */
     hits: (T & {
       readonly objectID: string;
+      readonly _highlightResult?: HighlightResult<T>;
+      readonly _snippetResult?: SnippetResult<T>;
+      readonly _rankingInfo?: RankingInfo;
+      readonly _distinctSeqID?: number;
     })[];
     /**
      * index where the results come from

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -3,13 +3,13 @@
 // the version of the client installed by the developer.
 
 // @ts-ignore
-import type algoliasearch from "algoliasearch/lite";
+import type algoliasearch from 'algoliasearch/lite';
 // @ts-ignore
-import type * as AlgoliaSearchLite from "algoliasearch/lite";
+import type * as AlgoliaSearchLite from 'algoliasearch/lite';
 // @ts-ignore
-import type * as AlgoliaSearch from "algoliasearch";
+import type * as AlgoliaSearch from 'algoliasearch';
 // @ts-ignore
-import type * as ClientSearch from "@algolia/client-search";
+import type * as ClientSearch from '@algolia/client-search';
 
 // turns any to unknown, so it can be used as a conditional
 type AnyToUnknown<T> = (any extends T ? true : false) extends true
@@ -54,11 +54,11 @@ type PickForClient<
     v5: unknown;
   }
 > = ClientV5 extends SearchClientShape
-  ? T["v5"]
+  ? T['v5']
   : // @ts-ignore
   ClientV3_4 extends SearchClientV4Shape
-  ? T["v4"]
-  : T["v3"];
+  ? T['v4']
+  : T['v3'];
 
 type DefaultSearchClient = PickForClient<{
   v3: ClientV3_4;
@@ -100,7 +100,7 @@ export type SearchOptions = PickForClient<{
   v4: ClientSearch.SearchOptions;
   v5: NonNullable<
     // @ts-ignore
-    AlgoliaSearch.LegacySearchMethodProps[number]["params"]
+    AlgoliaSearch.LegacySearchMethodProps[number]['params']
   >;
 }>;
 
@@ -117,7 +117,7 @@ export type SearchResponse<T> = PickForClient<{
         values?: {
           [facet: string]: {
             order?: string[];
-            sortRemainingBy?: "count" | "alpha" | "hidden";
+            sortRemainingBy?: 'count' | 'alpha' | 'hidden';
           };
         };
       };
@@ -162,14 +162,14 @@ export type FindAnswersResponse<T> = PickForClient<{
 }>;
 
 export interface SearchClient {
-  search: DefaultSearchClient["search"];
+  search: DefaultSearchClient['search'];
   searchForFacetValues?: DefaultSearchClient extends {
     searchForFacetValues: unknown;
   }
-    ? DefaultSearchClient["searchForFacetValues"]
+    ? DefaultSearchClient['searchForFacetValues']
     : never;
   initIndex?: DefaultSearchClient extends { initIndex: unknown }
-    ? DefaultSearchClient["initIndex"]
+    ? DefaultSearchClient['initIndex']
     : never;
-  addAlgoliaAgent?: DefaultSearchClient["addAlgoliaAgent"];
+  addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
 }

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -66,6 +66,10 @@ type DefaultSearchClient = PickForClient<{
   v5: ClientV5;
 }>;
 
+export type HighlightResult<T> = ClientSearch.HighlightResult<T>;
+export type SnippetResult<T> = ClientSearch.SnippetResult<T>;
+export type RankingInfo = ClientSearch.RankingInfo;
+
 export type SearchOptions = PickForClient<{
   // @ts-ignore
   v3: AlgoliaSearch.QueryParameters;

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -67,30 +67,29 @@ type DefaultSearchClient = PickForClient<{
 }>;
 
 export type HighlightResult<T> = PickForClient<{
-  // @ts-ignore
+  // @ts-ignore this doesn't exist as an exact type in v3
   v3: any;
   // @ts-ignore
   v4: ClientSearch.HighlightResult<T>;
-  // @ts-ignore
+  // @ts-ignore the type in the v5 library is not yet correct https://github.com/algolia/api-clients-automation/issues/853
   v5: any;
 }>;
 
 export type SnippetResult<T> = PickForClient<{
-  // @ts-ignore
+  // @ts-ignore this doesn't exist as an exact type in v3
   v3: any;
   // @ts-ignore
   v4: ClientSearch.SnippetResult<T>;
-  // @ts-ignore
+  // @ts-ignore the type in the v5 library is not yet correct https://github.com/algolia/api-clients-automation/issues/853
   v5: any;
 }>;
 
 export type RankingInfo = PickForClient<{
-  // @ts-ignore
-  v3: any;
+  v3: Record<string, unknown>;
   // @ts-ignore
   v4: ClientSearch.RankingInfo;
   // @ts-ignore
-  v5: any;
+  v5: AlgoliaSearch.RankingInfo;
 }>;
 
 export type SearchOptions = PickForClient<{
@@ -126,7 +125,7 @@ export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
-  v5: AlgoliaSearch.SearchResponse; // TODO: should be generic
+  v5: AlgoliaSearch.SearchResponse; // TODO: should be generic https://github.com/algolia/api-clients-automation/issues/853
 }>;
 
 export type SearchResponses<T> = PickForClient<{
@@ -135,7 +134,7 @@ export type SearchResponses<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.MultipleQueriesResponse<T>;
   // @ts-ignore
-  v5: AlgoliaSearch.SearchResponses; // TODO: should be generic
+  v5: AlgoliaSearch.SearchResponses; // TODO: should be generic https://github.com/algolia/api-clients-automation/issues/853
 }>;
 
 export type SearchForFacetValuesResponse = PickForClient<{
@@ -148,17 +147,17 @@ export type SearchForFacetValuesResponse = PickForClient<{
 }>;
 
 export type FindAnswersOptions = PickForClient<{
-  v3: any;
+  v3: any; // answers only exists in v4
   // @ts-ignore
   v4: ClientSearch.FindAnswersOptions;
-  v5: any;
+  v5: any; // answers only exists in v4
 }>;
 
 export type FindAnswersResponse<T> = PickForClient<{
-  v3: any;
+  v3: any; // answers only exists in v4
   // @ts-ignore
   v4: ClientSearch.FindAnswersResponse<T>;
-  v5: any;
+  v5: any; // answers only exists in v4
 }>;
 
 export interface SearchClient {

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -3,13 +3,13 @@
 // the version of the client installed by the developer.
 
 // @ts-ignore
-import type algoliasearch from 'algoliasearch/lite';
+import type algoliasearch from "algoliasearch/lite";
 // @ts-ignore
-import type * as AlgoliaSearchLite from 'algoliasearch/lite';
+import type * as AlgoliaSearchLite from "algoliasearch/lite";
 // @ts-ignore
-import type * as AlgoliaSearch from 'algoliasearch';
+import type * as AlgoliaSearch from "algoliasearch";
 // @ts-ignore
-import type * as ClientSearch from '@algolia/client-search';
+import type * as ClientSearch from "@algolia/client-search";
 
 // turns any to unknown, so it can be used as a conditional
 type AnyToUnknown<T> = (any extends T ? true : false) extends true
@@ -54,11 +54,11 @@ type PickForClient<
     v5: unknown;
   }
 > = ClientV5 extends SearchClientShape
-  ? T['v5']
+  ? T["v5"]
   : // @ts-ignore
   ClientV3_4 extends SearchClientV4Shape
-  ? T['v4']
-  : T['v3'];
+  ? T["v4"]
+  : T["v3"];
 
 type DefaultSearchClient = PickForClient<{
   v3: ClientV3_4;
@@ -66,9 +66,32 @@ type DefaultSearchClient = PickForClient<{
   v5: ClientV5;
 }>;
 
-export type HighlightResult<T> = ClientSearch.HighlightResult<T>;
-export type SnippetResult<T> = ClientSearch.SnippetResult<T>;
-export type RankingInfo = ClientSearch.RankingInfo;
+export type HighlightResult<T> = PickForClient<{
+  // @ts-ignore
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.HighlightResult<T>;
+  // @ts-ignore
+  v5: any;
+}>;
+
+export type SnippetResult<T> = PickForClient<{
+  // @ts-ignore
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.SnippetResult<T>;
+  // @ts-ignore
+  v5: any;
+}>;
+
+export type RankingInfo = PickForClient<{
+  // @ts-ignore
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.RankingInfo;
+  // @ts-ignore
+  v5: any;
+}>;
 
 export type SearchOptions = PickForClient<{
   // @ts-ignore
@@ -77,7 +100,7 @@ export type SearchOptions = PickForClient<{
   v4: ClientSearch.SearchOptions;
   v5: NonNullable<
     // @ts-ignore
-    AlgoliaSearch.LegacySearchMethodProps[number]['params']
+    AlgoliaSearch.LegacySearchMethodProps[number]["params"]
   >;
 }>;
 
@@ -94,7 +117,7 @@ export type SearchResponse<T> = PickForClient<{
         values?: {
           [facet: string]: {
             order?: string[];
-            sortRemainingBy?: 'count' | 'alpha' | 'hidden';
+            sortRemainingBy?: "count" | "alpha" | "hidden";
           };
         };
       };
@@ -139,14 +162,14 @@ export type FindAnswersResponse<T> = PickForClient<{
 }>;
 
 export interface SearchClient {
-  search: DefaultSearchClient['search'];
+  search: DefaultSearchClient["search"];
   searchForFacetValues?: DefaultSearchClient extends {
     searchForFacetValues: unknown;
   }
-    ? DefaultSearchClient['searchForFacetValues']
+    ? DefaultSearchClient["searchForFacetValues"]
     : never;
   initIndex?: DefaultSearchClient extends { initIndex: unknown }
-    ? DefaultSearchClient['initIndex']
+    ? DefaultSearchClient["initIndex"]
     : never;
-  addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
+  addAlgoliaAgent?: DefaultSearchClient["addAlgoliaAgent"];
 }


### PR DESCRIPTION
## Motivation

- Add optional typings to `SearchResults` hit and expose the `HighlightResult` `RankingInfo` and `SnippetResult` typings for use elsewhere.
- The goal is to update the `@types/react-instantsearch-core` types to use the actual `SearchResults` from `algoliasearch-helper` rather than redefining their own. `SearchResults` + `HighlightResults`, etc.