### PR TITLE
fix(facetValues): use additional queries to retrieve refined facet values

### DIFF
--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -29,12 +29,24 @@ var requestBuilder = {
       params: requestBuilder._getHitsSearchParams(state)
     });
 
-    // One for each disjunctive facets
+    // One for each disjunctive facet
     state.getRefinedDisjunctiveFacets().forEach(function(refinedFacet) {
       queries.push({
         indexName: index,
         params: requestBuilder._getDisjunctiveFacetSearchParams(state, refinedFacet)
       });
+    });
+
+    // One for each conjunctive facet
+    state.facets.forEach(function(facet) {
+      if (state.getConjunctiveRefinements(facet).length > 0) {
+        var queryParams = requestBuilder._getDisjunctiveFacetSearchParams(state, facet);
+        queryParams.maxValuesPerFacet = 1000;
+        queries.push({
+          indexName: index,
+          params: queryParams
+        });
+      }
     });
 
     // More to get the parent levels of the hierarchical facets when refined

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -20,6 +20,29 @@ test('getFacetValues(facetName) returns a list of values using the defaults', fu
 });
 
 test(
+  'getFacetValues(facetName) adds refined values from other query results if necessary',
+  function() {
+    var data = require('./getFacetValues/refinedValuesFromOtherResults.json');
+    var searchParams = new SearchParameters(data.state);
+    var result = new SearchResults(searchParams, data.content.results);
+
+    var resultsFacet = result.facets.find(function(facet) {
+      return facet.name === 'tags';
+    });
+    expect(resultsFacet.data).not.toContain('Partner/REI');
+
+    var facetValues = result.getFacetValues('tags');
+    expect(facetValues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'Partner/REI',
+        count: 1,
+        isRefined: true
+      })
+    ]));
+  }
+);
+
+test(
   'getFacetValues(facetName) when no order is specified for isRefined the order is descending',
   function() {
     var data = require('./getFacetValues/disjunctive.json');

--- a/test/spec/SearchResults/getFacetValues/refinedValuesFromOtherResults.json
+++ b/test/spec/SearchResults/getFacetValues/refinedValuesFromOtherResults.json
@@ -1,0 +1,115 @@
+{
+  "content": {
+    "results": [
+      {
+        "hits": [],
+        "nbHits": 1,
+        "page": 0,
+        "nbPages": 1,
+        "hitsPerPage": 8,
+        "facets": {
+          "tags": {
+            "America": 1,
+            "Beneficial": 1,
+            "Big Business": 1,
+            "Branded": 1,
+            "Business": 1,
+            "Business Growth": 1,
+            "Care": 1,
+            "Charitable Cause": 1,
+            "Co-Op": 1,
+            "Co-Opportunity": 1
+          }
+        },
+        "exhaustiveFacetsCount": true,
+        "exhaustiveNbHits": true,
+        "exhaustiveTypo": true,
+        "exhaustive": {
+          "facetsCount": true,
+          "nbHits": true,
+          "typo": true
+        },
+        "query": "",
+        "params": "facetFilters=%5B%22tags%3APartner%2FREI%22%5D&facets=%5B%22tags%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&hitsPerPage=8&maxValuesPerFacet=10&page=0&query=&tagFilters=",
+        "index": "dev_attn",
+        "renderingContent": {},
+        "processingTimeMS": 1
+      },
+      {
+        "hits": [],
+        "nbHits": 1,
+        "page": 0,
+        "nbPages": 0,
+        "hitsPerPage": 0,
+        "facets": {
+          "tags": {
+            "America": 1,
+            "Beneficial": 1,
+            "Big Business": 1,
+            "Branded": 1,
+            "Business": 1,
+            "Business Growth": 1,
+            "Care": 1,
+            "Charitable Cause": 1,
+            "Co-Op": 1,
+            "Co-Opportunity": 1,
+            "Community": 1,
+            "Creative Solution": 1,
+            "Dimension/1:1": 1,
+            "Distribution": 1,
+            "Donate": 1,
+            "Employer": 1,
+            "Fair": 1,
+            "Feel Good": 1,
+            "Format/Explainer": 1,
+            "Honesty": 1,
+            "Kindness": 1,
+            "Length/90": 1,
+            "Opening/Featured Sub": 1,
+            "Partner/REI": 1,
+            "Partner/REI Co-op": 1,
+            "Partnership": 1,
+            "Profit": 1,
+            "Prosper": 1,
+            "REI": 1,
+            "Rememberance": 1,
+            "Sentiment/Informative": 1,
+            "Sentiment/Inspirational": 1,
+            "Sharing is Caring": 1,
+            "Small Business": 1,
+            "Source/ATTN: Original": 1,
+            "Source/Harvard University": 1,
+            "Success": 1,
+            "Timeliness/Evergreen": 1,
+            "Topic/Career": 1,
+            "Topic/Civic Engagement-Other": 1,
+            "Topic/Innovation-Social": 1,
+            "Topic/Money-Economy": 1,
+            "Transitional Employer": 1,
+            "Vertical/Apparel": 1,
+            "Workplace": 1
+          }
+        },
+        "exhaustiveFacetsCount": true,
+        "exhaustiveNbHits": true,
+        "exhaustiveTypo": true,
+        "exhaustive": {
+          "facetsCount": true,
+          "nbHits": true,
+          "typo": true
+        },
+        "query": "",
+        "params": "analytics=false&clickAnalytics=false&facetFilters=%5B%22tags%3APartner%2FREI%22%5D&facets=tags&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&hitsPerPage=0&maxValuesPerFacet=1000&page=0&query=",
+        "index": "dev_attn",
+        "renderingContent": {},
+        "processingTimeMS": 1
+      }
+    ]
+  },
+  "state": {
+    "facets": ["tags"],
+    "facetsRefinements": {
+      "tags": ["Partner/REI"]
+    }
+  }
+}

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -67,6 +67,29 @@ test('does only a single query if refinements are empty', function() {
   expect(queries).toHaveLength(1);
 });
 
+test('adds a query for each refined conjunctive facet', function() {
+  var searchParams = new SearchParameters({
+    facets: ['brand', 'color', 'tags']
+  })
+    .addFacetRefinement('brand', 'Samsung')
+    .addFacetRefinement('color', 'Blue')
+  ;
+
+  var queries = getQueries(searchParams.index, searchParams);
+
+  expect(queries.length).toBe(3);
+  expect(queries[1].params).toEqual(expect.objectContaining({
+    facets: 'brand',
+    facetFilters: ['brand:Samsung', 'color:Blue'],
+    maxValuesPerFacet: 1000
+  }));
+  expect(queries[2].params).toEqual(expect.objectContaining({
+    facets: 'color',
+    facetFilters: ['brand:Samsung', 'color:Blue'],
+    maxValuesPerFacet: 1000
+  }));
+});
+
 describe('hierarchical facets', function() {
   var searchParams = new SearchParameters({
     hierarchicalFacets: [{


### PR DESCRIPTION
**Issue**

When a refinement list is added to an InstantSearch application, its values are requested with the hits. By default, 10 values are requested per facet.

An option available in refinement lists allows the user to search and refine on specific facet values matching the search query. This creates an issue where sometimes, the refined facet value is not returned as part of the truncated list. For example, you might refine on "Zimbabwe" but the results will contain a list of 10 facet values that won't include it, and there is no way to ask the engine to [sort facet values](https://www.algolia.com/doc/api-reference/api-parameters/sortFacetValuesBy/) by refinement state at that stage.

The result is that once refined, a facet value disappears from the list, and can only be visible again if the user search for it in a searchable refinement list widget.

[CodeSandbox →](https://codesandbox.io/s/xenodochial-bash-kr1bck?file=/src/app.js)  
_(refine on "Partner/REI")_

**Solution**

The solution I have devised adds additional queries to the search request, to get the [maximum number of facet values](https://www.algolia.com/doc/api-reference/api-parameters/maxValuesPerFacet/) allowed for each refined facet.

Then, when facet values are requested, we check that every refined facet value from the state is present in the updated list of facet values. If one isn't, its name and associated count is added from the additional query results.

This solution has a caveat though, when the refined facet value is not present in the additional query results, because the facet contains than 1000 values. In this case, we still add the facet value, but its associated count is set to `0`.

[FX-1682](https://algolia.atlassian.net/browse/FX-1682)