### PR TITLE
feat(searchForFacetValues): hierarchical facet isRefined and search state clearing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,13 +165,15 @@ declare namespace algoliasearchHelper {
      * @param [maxFacetHits] the maximum number values returned. Should be > 0 and <= 100
      * @param [userState] the set of custom parameters to use on top of the current state. Setting a property to `undefined` removes
      * it in the generated query.
+     * @param [includeHierarchical] if true, the search will consider hierarchical facet refinements during the search.
      * @return the results of the search
      */
     searchForFacetValues(
       facet: string,
       query: string,
       maxFacetHits: number,
-      userState?: PlainSearchParameters
+      userState?: PlainSearchParameters,
+      includeHierarchical?: boolean
     ): Promise<SearchForFacetValues.Result>;
 
     /**

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -326,9 +326,10 @@ AlgoliaSearchHelper.prototype.findAnswers = function(options) {
  * @param {number} [maxFacetHits] the maximum number values returned. Should be > 0 and <= 100
  * @param {object} [userState] the set of custom parameters to use on top of the current state. Setting a property to `undefined` removes
  * it in the generated query.
+ * @param {boolean} [includeHierarchical] if true, the search will consider hierarchical facet refinements during the search.
  * @return {promise.<FacetSearchResult>} the results of the search
  */
-AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits, userState) {
+AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxFacetHits, userState, includeHierarchical) {
   var clientHasSFFV = typeof this.client.searchForFacetValues === 'function';
   var clientHasInitIndex = typeof this.client.initIndex === 'function';
   if (
@@ -343,8 +344,8 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
 
   var state = this.state.setQueryParameters(userState || {});
   var isDisjunctive = state.isDisjunctiveFacet(facet);
-  var isHierarchical = state.isHierarchicalFacet(facet);
-  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state);
+  var isHierarchical = includeHierarchical && state.isHierarchicalFacet(facet);
+  var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state, includeHierarchical);
 
   this._currentNbQueries++;
   var self = this;

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -343,6 +343,7 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
 
   var state = this.state.setQueryParameters(userState || {});
   var isDisjunctive = state.isDisjunctiveFacet(facet);
+  var isHierarchical = state.isHierarchicalFacet(facet);
   var algoliaQuery = requestBuilder.getSearchForFacetQuery(facet, query, maxFacetHits, state);
 
   this._currentNbQueries++;
@@ -390,9 +391,13 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function(facet, query, maxF
 
     content.facetHits.forEach(function(f) {
       f.escapedValue = escapeFacetValue(f.value);
-      f.isRefined = isDisjunctive
-        ? state.isDisjunctiveFacetRefined(facet, f.escapedValue)
-        : state.isFacetRefined(facet, f.escapedValue);
+      if (isDisjunctive) {
+        f.isRefined = state.isDisjunctiveFacetRefined(facet, f.escapedValue);
+      } else if (isHierarchical) {
+        f.isRefined = state.isHierarchicalFacetRefined(facet, f.escapedValue);
+      } else {
+        f.isRefined = state.isFacetRefined(facet, f.escapedValue);
+      }
     });
 
     return content;

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -360,7 +360,9 @@ var requestBuilder = {
   },
 
   getSearchForFacetQuery: function(facetName, query, maxFacetHits, state) {
-    var stateForSearchForFacetValues = state.isDisjunctiveFacet(facetName) ?
+    // Clear the refinement state before searching for disjunctive or hierarchical facets, because we
+    // want to search the entire list of facet values, not just the subset of refined ones.
+    var stateForSearchForFacetValues = state.isDisjunctiveFacet(facetName) || state.isHierarchicalFacet(facetName) ?
       state.clearRefinements(facetName) :
       state;
     var searchForFacetSearchParameters = {

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -359,10 +359,14 @@ var requestBuilder = {
     return hierarchicalFacet.attributes.slice(0, parentLevel + 1);
   },
 
-  getSearchForFacetQuery: function(facetName, query, maxFacetHits, state) {
+  getSearchForFacetQuery: function(facetName, query, maxFacetHits, state, includeHierarchical) {
     // Clear the refinement state before searching for disjunctive or hierarchical facets, because we
     // want to search the entire list of facet values, not just the subset of refined ones.
-    var stateForSearchForFacetValues = state.isDisjunctiveFacet(facetName) || state.isHierarchicalFacet(facetName) ?
+    var shouldClear = includeHierarchical
+      ? state.isDisjunctiveFacet(facetName) || state.isHierarchicalFacet(facetName)
+      : state.isDisjunctiveFacet(facetName);
+
+    var stateForSearchForFacetValues = shouldClear ?
       state.clearRefinements(facetName) :
       state;
     var searchForFacetSearchParameters = {

--- a/src/requestBuilder.js
+++ b/src/requestBuilder.js
@@ -362,6 +362,7 @@ var requestBuilder = {
   getSearchForFacetQuery: function(facetName, query, maxFacetHits, state, includeHierarchical) {
     // Clear the refinement state before searching for disjunctive or hierarchical facets, because we
     // want to search the entire list of facet values, not just the subset of refined ones.
+    // @MAJOR: only support includeHierarchical === true
     var shouldClear = includeHierarchical
       ? state.isDisjunctiveFacet(facetName) || state.isHierarchicalFacet(facetName)
       : state.isDisjunctiveFacet(facetName);

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -504,7 +504,7 @@ test('escaped hierarchical facet value is marked as refined', function() {
     }
   });
 
-  return helper.searchForFacetValues('categories', 'k', 1).then(function(content) {
+  return helper.searchForFacetValues('categories', 'k', 1, {}, true).then(function(content) {
     expect(content).toEqual({
       exhaustiveFacetsCount: true,
       processingTimeMS: 3,

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -481,6 +481,11 @@ test('escaped hierarchical facet value is marked as refined', function() {
               count: 318,
               highlighted: 'beers > fancy ones',
               value: 'beers > fancy ones'
+            },
+            {
+              count: 1,
+              highlighted: '-20%',
+              value: '-20%'
             }
           ],
           processingTimeMS: 3
@@ -495,7 +500,7 @@ test('escaped hierarchical facet value is marked as refined', function() {
       attributes: ['categories.lvl0', 'categories.lvl1']
     }],
     hierarchicalFacetsRefinements: {
-      categories: ['beers > fancy ones']
+      categories: ['beers > fancy ones', '\\-20%']
     }
   });
 
@@ -510,6 +515,13 @@ test('escaped hierarchical facet value is marked as refined', function() {
           isRefined: true,
           escapedValue: 'beers > fancy ones',
           value: 'beers > fancy ones'
+        },
+        {
+          count: 1,
+          highlighted: '-20%',
+          isRefined: true,
+          escapedValue: '\\-20%',
+          value: '-20%'
         }
       ]
     });

--- a/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -413,7 +413,7 @@ test('value is escaped when it starts with `-`', function() {
 });
 
 
-test('escaped value is marked as refined', function() {
+test('escaped disjunctive facet value is marked as refined', function() {
   var fakeClient = {
     addAlgoliaAgent: function() {},
     searchForFacetValues: function() {
@@ -463,6 +463,53 @@ test('escaped value is marked as refined', function() {
           isRefined: true,
           escapedValue: '\\-20%',
           value: '-20%'
+        }
+      ]
+    });
+  });
+});
+
+test('escaped hierarchical facet value is marked as refined', function() {
+  var fakeClient = {
+    addAlgoliaAgent: function() {},
+    searchForFacetValues: function() {
+      return Promise.resolve([
+        {
+          exhaustiveFacetsCount: true,
+          facetHits: [
+            {
+              count: 318,
+              highlighted: 'beers > fancy ones',
+              value: 'beers > fancy ones'
+            }
+          ],
+          processingTimeMS: 3
+        }
+      ]);
+    }
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    hierarchicalFacets: [{
+      name: 'categories',
+      attributes: ['categories.lvl0', 'categories.lvl1']
+    }],
+    hierarchicalFacetsRefinements: {
+      categories: ['beers > fancy ones']
+    }
+  });
+
+  return helper.searchForFacetValues('categories', 'k', 1).then(function(content) {
+    expect(content).toEqual({
+      exhaustiveFacetsCount: true,
+      processingTimeMS: 3,
+      facetHits: [
+        {
+          count: 318,
+          highlighted: 'beers > fancy ones',
+          isRefined: true,
+          escapedValue: 'beers > fancy ones',
+          value: 'beers > fancy ones'
         }
       ]
     });

--- a/test/spec/requestBuilder.js
+++ b/test/spec/requestBuilder.js
@@ -265,7 +265,7 @@ describe('getSearchForFacetQuery', function() {
     ]);
   });
 
-  test('should clear hierarchical facet by name before searching within the facet', function() {
+  test('should not clear hierarchical facet refinements when not explicitly specified', function() {
     var searchParams = new SearchParameters({
       facets: ['test'],
       disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
@@ -284,6 +284,32 @@ describe('getSearchForFacetQuery', function() {
     });
 
     var searchRequest = getSearchForFacetQuery('test_hierarchical', '', 1, searchParams);
+
+    expect(searchRequest.facetFilters).toEqual([
+      ['test_disjunctive:test_disjunctive_value'],
+      ['whatever:item']
+    ]);
+  });
+
+  test('should clear hierarchical facet by name before searching within the facet', function() {
+    var searchParams = new SearchParameters({
+      facets: ['test'],
+      disjunctiveFacets: ['test_disjunctive', 'test_numeric'],
+      disjunctiveFacetsRefinements: {
+        test_disjunctive: ['test_disjunctive_value']
+      },
+      numericRefinements: {
+        test_numeric: {
+          '>=': [10]
+        }
+      },
+      hierarchicalFacets: [{name: 'test_hierarchical', attributes: ['whatever']}],
+      hierarchicalFacetsRefinements: {
+        test_hierarchical: ['item']
+      }
+    });
+
+    var searchRequest = getSearchForFacetQuery('test_hierarchical', '', 1, searchParams, true);
 
     expect(searchRequest.facetFilters).toEqual([
       ['test_disjunctive:test_disjunctive_value']


### PR DESCRIPTION
This PR adds the ability to mark hierarchical facets as refined, as well as clear the search refinement state on searching for a hierarchical facet. 

The motivation behind this is to add search functionality to the `Menu` instantsearch widget, which utilizes hierarchical facets for refinement. In order to be able to search through these (single level) facets, we need to mark the results as refined, and clear the search state while building the request so that the current refinements aren't taken into account during the search.

See https://github.com/algolia/instantsearch.js/tree/feat/searchable-menu for reference

[SRCH-5213]

[SRCH-5213]: https://algolia.atlassian.net/browse/SRCH-5213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ