### PR TITLE
fix(answers): deprecate findAnswers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -147,6 +147,7 @@ declare namespace algoliasearchHelper {
      * @param {string[]} options.attributesForPrediction - Attributes to use for predictions. If empty, `searchableAttributes` is used instead.
      * @param {string[]} options.queryLanguages - The languages in the query. Currently only supports ['en'].
      * @param {number} options.nbHits - Maximum number of answers to retrieve from the Answers Engine. Cannot be greater than 1000.
+     * @deprecated answers is deprecated and will be replaced with new initiatives
      */
     findAnswers<TObject>(options: {
       attributesForPrediction: string[];

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -260,8 +260,10 @@ AlgoliaSearchHelper.prototype.searchOnce = function(options, cb) {
  * @param {number} options.nbHits - Maximum number of answers to retrieve from the Answers Engine. Cannot be greater than 1000.
  *
  * @return {promise} the answer results
+ * @deprecated answers is deprecated and will be replaced with new initiatives
  */
 AlgoliaSearchHelper.prototype.findAnswers = function(options) {
+  console.warn('[algoliasearch-helper] answers is no longer supported');
   var state = this.state;
   var derivedHelper = this.derivedHelpers[0];
   if (!derivedHelper) {


### PR DESCRIPTION
While this method still works, it's not used in InstantSearch and it no longer has any difference from a regular search, and therefore no longer needs its own function.