### PR TITLE
fix: prevent prototype pollution in rare error-cases

### DIFF
--- a/src/functions/merge.js
+++ b/src/functions/merge.js
@@ -23,7 +23,8 @@ function _merge(target, source) {
   for (var key in source) {
     if (
       !Object.prototype.hasOwnProperty.call(source, key) ||
-      key === '__proto__'
+      key === '__proto__' ||
+      key === 'constructor'
     ) {
       continue;
     }

--- a/test/spec/algoliasearch.helper/constructor.js
+++ b/test/spec/algoliasearch.helper/constructor.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var algoliasearchHelper = require('../../../index');
+
+test('not vulnerable to prototype pollution', () => {
+  try {
+    algoliasearchHelper({}, '', {constructor: {prototype: {test: 123}}});
+  } catch (e) {
+    // even if it throws an error, we need to be sure no vulnerability happens
+  }
+
+  expect({}.test).toBeUndefined();
+});

--- a/test/spec/functions/merge.js
+++ b/test/spec/functions/merge.js
@@ -183,3 +183,15 @@ it('does not pollute the prototype', () => {
 
   expect({}.polluted).toBe(undefined);
 });
+
+it('does not pollute the prototype in error condition', () => {
+  expect({}.polluted).toBe(undefined);
+
+  try {
+    merge({}, {'constructor': {'prototype': {'polluted': 'vulnerable to PP'}}});
+  } catch (e) {
+    // ignore
+  }
+
+  expect({}.polluted).toBe(undefined);
+});


### PR DESCRIPTION
If a user-provided search parameter is used to instantiate search parameters, it was possible to construct it in such a way that `constructor.prototype` is attempted to be written. That throws an error, but if the error would be caught, the resulting injection still happened.

This PR fixes that (small) vulnerability by ensuring `constructor`, is skipped, just like `__proto__`.

fixes #922

This is similar/a follow-up to #880