### PR TITLE
fix(getFacetValues): reflect the value of _state in hierarchicalFacetValues

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -668,7 +668,33 @@ function extractNormalizedFacetValues(results, attribute) {
       };
     });
   } else if (results._state.isHierarchicalFacet(attribute)) {
-    return find(results.hierarchicalFacets, predicate);
+    var hierarchicalFacetValues = find(results.hierarchicalFacets, predicate);
+    if (!hierarchicalFacetValues) return hierarchicalFacetValues;
+
+    var hierarchicalFacet = results._state.getHierarchicalFacetByName(attribute);
+    var currentRefinementSplit = unescapeFacetValue(
+      results._state.getHierarchicalRefinement(attribute)[0] || ''
+    ).split(results._state._getHierarchicalFacetSeparator(hierarchicalFacet));
+    currentRefinementSplit.unshift(attribute);
+
+    setIsRefined(hierarchicalFacetValues, currentRefinementSplit, 0);
+
+    return hierarchicalFacetValues;
+  }
+}
+
+/**
+ * Set the isRefined of a hierarchical facet result based on the current state.
+ * @param {SearchResults.HierarchicalFacet} item Hierarchical facet to fix
+ * @param {string[]} currentRefinementSplit array of parts of the current hierarchical refinement
+ * @param {number} depth recursion depth in the currentRefinement
+ */
+function setIsRefined(item, currentRefinement, depth) {
+  item.isRefined = item.name === currentRefinement[depth];
+  if (item.data) {
+    item.data.forEach(function(child) {
+      setIsRefined(child, currentRefinement, depth + 1);
+    });
   }
 }
 

--- a/test/spec/SearchResults/getFacetValues/conjunctive.json
+++ b/test/spec/SearchResults/getFacetValues/conjunctive.json
@@ -1,0 +1,47 @@
+{
+  "content": {
+    "results": [
+      {
+        "hits": [
+          {
+            "objectID": "1696302"
+          }
+        ],
+        "nbHits": 10000,
+        "page": 0,
+        "nbPages": 1000,
+        "hitsPerPage": 1,
+        "processingTimeMS": 1,
+        "facets": {
+          "brand": {
+            "Insignia™": 551,
+            "Samsung": 511,
+            "Apple": 386
+          }
+        },
+        "exhaustiveFacetsCount": true,
+        "query": "",
+        "params": "query=&maxValuesPerFacet=3&page=0&hitsPerPage=1&attributesToRetrieve=%5B%5D&attributesToHighlight=%5B%5D&attributesToSnippet=%5B%5D&tagFilters=&facets=brand",
+        "index": "instant_search"
+      }
+    ]
+  },
+  "state": {
+    "index": "instant_search",
+    "query": "",
+    "facets": ["brand"],
+    "disjunctiveFacets": [],
+    "hierarchicalFacets": [],
+    "facetsRefinements": {
+      "brand": ["Apple"]
+    },
+    "facetsExcludes": {},
+    "disjunctiveFacetsRefinements": {},
+    "numericRefinements": {},
+    "tagRefinements": [],
+    "hierarchicalFacetsRefinements": {},
+    "maxValuesPerFacet": 3,
+    "page": 0
+  },
+  "error": null
+}


### PR DESCRIPTION
Before this commit, the behaviour of conjunctive/disjunctive facets and hierarchical facets is different when `results._state` has changed since the instantiation of the SearchResults class.

Conjunctive/disjunctive take the current value of `_state`, while `hierarchical` took `isRefined` from the constructor.

We want to make this change to enable optimistic UI, where we render the existing results with the next state. This causes the `isRefined` state to immediately be useful for display.

Regardless of optimistic UI, this change still makes sense to do, as it makes the behaviour of getFacetValues consistent between all types of facet.

FX-2201