### PR TITLE
chore(tests): remove remaining lodash usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "jest-watch-typeahead": "0.3.0",
     "jsdoc-parse": "1.2.7",
     "jsdoc-to-markdown": "1.3.9",
-    "lodash": "4.17.19",
     "marked": "0.3.19",
     "metalsmith": "2.3.0",
     "metalsmith-changed": "2.0.0",

--- a/test/integration-spec/helper.derive.js
+++ b/test/integration-spec/helper.derive.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_derive' +
-  random(0, 5000);
+var indexName = createIndexName('helper_derive');
 
 var dataset = [
   {objectID: '0', content: 'tata'},

--- a/test/integration-spec/helper.distinct.facet.js
+++ b/test/integration-spec/helper.distinct.facet.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_distinct.facet' +
-  random(0, 5000);
+var indexName = createIndexName('helper_distinct.facet');
 
 var dataset = [
   {type: 'shoes', name: 'Adidas Stan Smith', colors: ['blue', 'red']},

--- a/test/integration-spec/helper.filters.js
+++ b/test/integration-spec/helper.filters.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_filters' +
-  random(0, 5000);
+var indexName = createIndexName('helper_filters');
 
 var dataset = [
   {facet: ['f1', 'f2']},

--- a/test/integration-spec/helper.geo.js
+++ b/test/integration-spec/helper.geo.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_geo' +
-  random(0, 5000);
+var indexName = createIndexName('helper_geo');
 
 var dataset = [
   {objectID: '1', _geoloc: {lat: 1, lng: 1}},

--- a/test/integration-spec/helper.highlight.js
+++ b/test/integration-spec/helper.highlight.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_highlight' +
-  random(0, 5000);
+var indexName = createIndexName('helper_highlight');
 
 var dataset = [
   {facet: ['f1', 'f2']},

--- a/test/integration-spec/helper.insights.js
+++ b/test/integration-spec/helper.insights.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_insights' +
-  random(0, 5000);
+var indexName = createIndexName('helper_insights');
 
 var dataset = [{objectID: '1', name: 'TestName'}];
 

--- a/test/integration-spec/helper.numerics.js
+++ b/test/integration-spec/helper.numerics.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_numerics' +
-  random(0, 5000);
+var indexName = createIndexName('helper_numerics');
 
 var dataset = [
   {objectID: '0', n: [6]},

--- a/test/integration-spec/helper.results.getFacetValues.js
+++ b/test/integration-spec/helper.results.getFacetValues.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_getfacetvalues' +
-  random(0, 5000);
+var indexName = createIndexName('helper_getfacetvalues');
 
 var dataset = [];
 

--- a/test/integration-spec/helper.searchForFacetValues.js
+++ b/test/integration-spec/helper.searchForFacetValues.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_sffv' +
-  random(0, 5000);
+var indexName = createIndexName('helper_sffv');
 
 var dataset = [
   {objectID: '1', f: 'ba', f2: ['b']},

--- a/test/integration-spec/helper.searchOnce.js
+++ b/test/integration-spec/helper.searchOnce.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_searchonce' +
-  random(0, 5000);
+var indexName = createIndexName('helper_searchonce');
 
 var dataset = [
   {objectID: '1', facet: ['f1', 'f2']},

--- a/test/integration-spec/helper.tags.js
+++ b/test/integration-spec/helper.tags.js
@@ -2,16 +2,11 @@
 
 var utils = require('../integration-utils.js');
 var setup = utils.setupSimple;
+var createIndexName = utils.createIndexName;
 
 var algoliasearchHelper = require('../../');
 
-var random = require('lodash/random');
-
-var indexName =
-  '_circle-algoliasearch-helper-js-' +
-  (process.env.CIRCLE_BUILD_NUM || 'DEV') +
-  'helper_refinements' +
-  random(0, 5000);
+var indexName = createIndexName('helper_refinements');
 
 var dataset = [
   {objectID: '0', _tags: ['t1', 't2']},

--- a/test/integration-utils.js
+++ b/test/integration-utils.js
@@ -47,6 +47,16 @@ function withDatasetAndConfig(indexName, dataset, config) {
   });
 }
 
+function createIndexName(name) {
+  return (
+    '_circle-algoliasearch-helper-js-' +
+    (process.env.CIRCLE_BUILD_NUM || 'DEV') +
+    name +
+    Math.round(Math.random() * 5000)
+  );
+}
+
 module.exports = {
-  setupSimple: withDatasetAndConfig
+  setupSimple: withDatasetAndConfig,
+  createIndexName: createIndexName
 };

--- a/test/spec/SearchParameters/constructorFn.js
+++ b/test/spec/SearchParameters/constructorFn.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var forOwn = require('lodash/forOwn');
 var SearchParameters = require('../../../src/SearchParameters');
 
 test('Constructor should accept an object with known keys', function() {
@@ -21,7 +20,7 @@ test('Constructor should accept an object with known keys', function() {
     ]
   };
   var params = new SearchParameters(legitConfig);
-  forOwn(legitConfig, function(v, k) {
+  Object.entries(legitConfig).forEach(function([k, v]) {
     expect(params[k]).toEqual(v);
   });
 });
@@ -46,7 +45,7 @@ test('Constructor should accept an object with unknown keys', function() {
     'otherBetaParameter': ['alpha', 'omega']
   };
   var params = new SearchParameters(betaConfig);
-  forOwn(betaConfig, function(v, k) {
+  Object.entries(betaConfig).forEach(function([k, v]) {
     expect(params[k]).toEqual(v);
   });
 });
@@ -100,7 +99,7 @@ test('Factory should accept an object with known keys', function() {
     ]
   };
   var params = SearchParameters.make(legitConfig);
-  forOwn(legitConfig, function(v, k) {
+  Object.entries(legitConfig).forEach(function([k, v]) {
     expect(params[k]).toEqual(v);
   });
 });
@@ -125,7 +124,7 @@ test('Factory should accept an object with unknown keys', function() {
     'otherBetaParameter': ['alpha', 'omega']
   };
   var params = SearchParameters.make(betaConfig);
-  forOwn(betaConfig, function(v, k) {
+  Object.entries(betaConfig).forEach(function([k, v]) {
     expect(params[k]).toEqual(v);
   });
 });

--- a/test/spec/SearchParameters/numericAttributes.js
+++ b/test/spec/SearchParameters/numericAttributes.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var forEach = require('lodash/forEach');
-
 var SearchParameters = require('../../../src/SearchParameters');
 
 var stateWithStringForIntegers = {
@@ -21,7 +19,7 @@ var stateWithStringForIntegers = {
 test('Constructor should parse the numeric attributes', function() {
   var state = new SearchParameters(stateWithStringForIntegers);
 
-  forEach(stateWithStringForIntegers, function(v, k) {
+  Object.entries(stateWithStringForIntegers).forEach(function([k, v]) {
     var parsedValue = parseFloat(v);
     expect(state[k]).toBe(parsedValue);
   });
@@ -30,7 +28,7 @@ test('Constructor should parse the numeric attributes', function() {
 test('setQueryParameter should parse the numeric attributes', function() {
   var state0 = new SearchParameters();
 
-  forEach(stateWithStringForIntegers, function(v, k) {
+  Object.entries(stateWithStringForIntegers).forEach(function([k, v]) {
     var parsedValue = parseFloat(v);
     var state1 = state0.setQueryParameter(k, v);
     expect(state1[k]).toBe(parsedValue);
@@ -41,7 +39,7 @@ test('setQueryParameters should parse the numeric attributes', function() {
   var state0 = new SearchParameters();
   var state1 = state0.setQueryParameters(stateWithStringForIntegers);
 
-  forEach(stateWithStringForIntegers, function(v, k) {
+  Object.entries(stateWithStringForIntegers).forEach(function([k, v]) {
     var parsedValue = parseFloat(v);
     expect(state1[k]).toBe(parsedValue);
   });

--- a/test/spec/SearchResults/getRefinements.js
+++ b/test/spec/SearchResults/getRefinements.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var filter = require('lodash/filter');
-var forEach = require('lodash/forEach');
-var find = require('lodash/find');
-
 var SearchResults = require('../../../src/SearchResults');
 var SearchParameters = require('../../../src/SearchParameters');
 
@@ -19,8 +15,10 @@ test('getRefinements(facetName) returns an empty array when there is no refineme
 
 function hasSameNames(l1, l2) {
   var res = true;
-  forEach(l1, function(e) {
-    var l2MatchingNameElement = find(l2, {name: e.name});
+  l1.forEach(function(l1Item) {
+    var l2MatchingNameElement = l2.find(function(l2Item) {
+      return l2Item.name === l1Item.name;
+    });
     if (!l2MatchingNameElement) res = false;
   });
   return res;
@@ -33,7 +31,7 @@ test('getRefinements(facetName) returns a refinement(facet) when a facet refinem
 
   var refinements = result.getRefinements();
   var facetValues = result.getFacetValues('brand');
-  var refinedFacetValues = filter(facetValues, function(f) {
+  var refinedFacetValues = facetValues.filter(function(f) {
     return f.isRefined === true;
   });
 
@@ -53,7 +51,7 @@ test('getRefinements(facetName) returns a refinement(exclude) when a facet exclu
 
   var refinements = result.getRefinements();
   var facetValues = result.getFacetValues('brand');
-  var refinedFacetValues = filter(facetValues, function(f) {
+  var refinedFacetValues = facetValues.filter(function(f) {
     return f.isExcluded === true;
   });
 
@@ -75,7 +73,7 @@ test(
 
     var refinements = result.getRefinements();
     var facetValues = result.getFacetValues('type');
-    var refinedFacetValues = filter(facetValues, function(f) {
+    var refinedFacetValues = facetValues.filter(function(f) {
       return f.isRefined === true;
     });
 

--- a/test/spec/algoliasearch.helper/clears.js
+++ b/test/spec/algoliasearch.helper/clears.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var algoliasearchHelper = require('../../../index');
-var forEach = require('lodash/forEach');
-var isUndefined = require('lodash/isUndefined');
 
 function fixture() {
   var helper = algoliasearchHelper({}, 'Index', {
@@ -78,9 +76,9 @@ test('Clearing the same field from multiple elements should remove it everywhere
   expect(helper.state.facetsExcludes.facet1).toEqual(['value']);
 
   helper.clearRefinements('facet1');
-  expect(isUndefined(helper.state.facetsRefinements.facet1)).toBeTruthy();
-  expect(isUndefined(helper.state.numericRefinements.facet1)).toBeTruthy();
-  expect(isUndefined(helper.state.facetsExcludes.facet1)).toBeTruthy();
+  expect(helper.state.facetsRefinements.facet1).toBeUndefined();
+  expect(helper.state.numericRefinements.facet1).toBeUndefined();
+  expect(helper.state.facetsExcludes.facet1).toBeUndefined();
 });
 
 test('Clear with a function: neutral predicate', function() {
@@ -138,7 +136,7 @@ test('Clear with a function: filtering', function() {
   });
 
   expect(Object.keys(checkType).length).toBe(5);
-  forEach(checkType, function(typeTest) {
+  Object.keys(checkType).forEach(function(typeTest) {
     expect(typeTest).toBeTruthy();
   });
 
@@ -166,28 +164,28 @@ test('Clearing twice the same attribute should be not problem', function() {
 
   expect(helper.state.facetsRefinements.facet1).toEqual(['0']);
   helper.clearRefinements('facet1');
-  expect(isUndefined(helper.state.facetsRefinements.facet1)).toBeTruthy();
+  expect(helper.state.facetsRefinements.facet1).toBeUndefined();
   expect(function() {
     helper.clearRefinements('facet1');
   }).not.toThrow();
 
   expect(helper.state.disjunctiveFacetsRefinements.disjunctiveFacet1).toEqual(['0']);
   helper.clearRefinements('disjunctiveFacet1');
-  expect(isUndefined(helper.state.disjunctiveFacetsRefinements.disjunctiveFacet1)).toBeTruthy();
+  expect(helper.state.disjunctiveFacetsRefinements.disjunctiveFacet1).toBeUndefined();
   expect(function() {
     helper.clearRefinements('disjunctiveFacet1');
   }).not.toThrow();
 
   expect(helper.state.facetsExcludes.excluded1).toEqual(['0']);
   helper.clearRefinements('excluded1');
-  expect(isUndefined(helper.state.facetsExcludes.excluded1)).toBeTruthy();
+  expect(helper.state.facetsExcludes.excluded1).toBeUndefined();
   expect(function() {
     helper.clearRefinements('excluded1');
   }).not.toThrow();
 
   expect(helper.state.numericRefinements.numeric1).toEqual({'>=': [0], '<': [10]});
   helper.clearRefinements('numeric1');
-  expect(isUndefined(helper.state.numericRefinements.numeric1)).toBeTruthy();
+  expect(helper.state.numericRefinements.numeric1).toBeUndefined();
   expect(function() {
     helper.clearRefinements('numeric1');
   }).not.toThrow();

--- a/test/spec/algoliasearch.helper/distinct.js
+++ b/test/spec/algoliasearch.helper/distinct.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var forEach = require('lodash/forEach');
-
 var algoliasearchHelper = require('../../../index.js');
 var requestBuilder = require('../../../src/requestBuilder');
 
@@ -25,7 +23,7 @@ test('Distinct not set', function() {
   expect(disjunctiveFacetSearchParam.distinct).toBe(undefined);
   facetSearchParam = requestBuilder._getHitsSearchParams(helper.state);
   expect(facetSearchParam.distinct).toBe(undefined);
-  forEach(requestBuilder._getQueries('', helper.state), function(q) {
+  requestBuilder._getQueries('', helper.state).forEach(function(q) {
     expect(q.hasOwnProperty('distinct')).toBeFalsy();
   });
 
@@ -35,7 +33,7 @@ test('Distinct not set', function() {
   expect(disjunctiveFacetSearchParam.distinct).toBe(undefined);
   facetSearchParam = requestBuilder._getHitsSearchParams(helper.state);
   expect(facetSearchParam.distinct).toBe(undefined);
-  forEach(requestBuilder._getQueries('', helper.state), function(q) {
+  requestBuilder._getQueries('', helper.state).forEach(function(q) {
     expect(q.hasOwnProperty('distinct')).toBeFalsy();
   });
 
@@ -45,7 +43,7 @@ test('Distinct not set', function() {
   expect(disjunctiveFacetSearchParam.distinct).toBe(undefined);
   facetSearchParam = requestBuilder._getHitsSearchParams(helper.state);
   expect(facetSearchParam.distinct).toBe(undefined);
-  forEach(requestBuilder._getQueries('', helper.state), function(q) {
+  requestBuilder._getQueries('', helper.state).forEach(function(q) {
     expect(q.hasOwnProperty('distinct')).toBeFalsy();
   });
 
@@ -55,7 +53,7 @@ test('Distinct not set', function() {
   expect(disjunctiveFacetSearchParam.distinct).toBe(undefined);
   facetSearchParam = requestBuilder._getHitsSearchParams(helper.state);
   expect(facetSearchParam.distinct).toBe(undefined);
-  forEach(requestBuilder._getQueries('', helper.state), function(q) {
+  requestBuilder._getQueries('', helper.state).forEach(function(q) {
     expect(q.hasOwnProperty('distinct')).toBeFalsy();
   });
 });

--- a/test/spec/algoliasearch.helper/hasRefinements.js
+++ b/test/spec/algoliasearch.helper/hasRefinements.js
@@ -2,13 +2,11 @@
 
 var algoliasearchHelper = require('../../../index');
 
-var _ = require('lodash');
-
 var fakeClient = {};
 
 test('undefined attribute', function() {
   var helper = algoliasearchHelper(fakeClient, 'index');
-  expect(_.partial(helper.hasRefinements, 'unknown')).toThrow(Error);
+  expect(helper.hasRefinements('unknown')).toBe(false);
 });
 
 describe('numericRefinement', function() {

--- a/test/spec/algoliasearch.helper/pages.js
+++ b/test/spec/algoliasearch.helper/pages.js
@@ -2,8 +2,6 @@
 
 var algoliasearchHelper = require('../../../index');
 
-var bind = require('lodash/bind');
-
 var fakeClient = {};
 
 test('setChange should change the current page', function() {
@@ -45,7 +43,7 @@ test('previousPage should decrement the current page by one', function() {
 test('previousPage should throw an error without a current page', function() {
   var helper = algoliasearchHelper(fakeClient, null, null);
 
-  expect(bind(helper.previousPage, helper)).toThrow('Page requested below 0.');
+  expect(function() {helper.previousPage();}).toThrow('Page requested below 0.');
 });
 
 test('pages should be reset if the mutation might change the number of pages', function() {
@@ -55,30 +53,28 @@ test('pages should be reset if the mutation might change the number of pages', f
   });
 
   [
-    ['clearRefinements', bind(helper.clearRefinements, helper)],
-    ['setQuery', bind(helper.setQuery, helper, 'query')],
-    ['addNumericRefinement', bind(helper.addNumericRefinement, helper, 'facet', '>', '2')],
-    ['removeNumericRefinement', bind(helper.removeNumericRefinement, helper, 'facet', '>')],
+    ['clearRefinements'],
+    ['setQuery', 'query'],
+    ['addNumericRefinement', 'facet', '>', '2'],
+    ['removeNumericRefinement', 'facet', '>'],
 
-    ['addExclude', bind(helper.addExclude, helper, 'facet1', 'val2')],
-    ['removeExclude', bind(helper.removeExclude, helper, 'facet1', 'val2')],
+    ['addExclude', 'facet1', 'val2'],
+    ['removeExclude', 'facet1', 'val2'],
 
-    ['addRefine', bind(helper.addRefine, helper, 'f2', 'val')],
-    ['removeRefine', bind(helper.removeRefine, helper, 'f2', 'val')],
+    ['addRefine', 'f2', 'val'],
+    ['removeRefine', 'f2', 'val'],
 
-    ['addDisjunctiveRefine', bind(helper.addDisjunctiveRefine, helper, 'f1', 'val')],
-    ['removeDisjunctiveRefine', bind(helper.removeDisjunctiveRefine, helper, 'f1', 'val')],
+    ['addDisjunctiveRefine', 'f1', 'val'],
+    ['removeDisjunctiveRefine', 'f1', 'val'],
 
-    ['toggleRefine', bind(helper.toggleRefine, helper, 'f1', 'v1')],
-    ['toggleExclude', bind(helper.toggleExclude, helper, 'facet1', '55')]
-  ].forEach(function(definition) {
-    var fn = definition[1];
-
+    ['toggleRefine', 'f1', 'v1'],
+    ['toggleExclude', 'facet1', '55']
+  ].forEach(function([fn, ...args]) {
     helper.setPage(10);
 
     expect(helper.getPage()).toBe(10);
 
-    fn();
+    helper[fn](...args);
 
     expect(helper.getPage()).toBe(0);
   });

--- a/test/spec/functions/defaultsPure.js
+++ b/test/spec/functions/defaultsPure.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var clone = require('lodash/clone');
 var defaults = require('../../../src/functions/defaultsPure');
 
 // tests modified from lodash source
@@ -58,10 +57,10 @@ it('should assign properties that shadow those on `Object.prototype`', function(
     'valueOf': 7
   };
 
-  var expected = clone(source);
+  var expected = Object.assign({}, source);
   expect(defaults({}, source)).toEqual(expected);
 
-  expected = clone(object);
+  expected = Object.assign({}, object);
   expect(defaults({}, object, source)).toEqual(expected);
 });
 

--- a/test/spec/hierarchical-facets/pagination.js
+++ b/test/spec/hierarchical-facets/pagination.js
@@ -2,7 +2,6 @@
 
 test('hierarchical facets: pagination', function(done) {
   var algoliasearch = require('algoliasearch');
-  var isArray = require('lodash/isArray');
 
   var algoliasearchHelper = require('../../../');
 
@@ -84,7 +83,7 @@ test('hierarchical facets: pagination', function(done) {
     // we do not yet support multiple values for hierarchicalFacetsRefinements
     // but at some point we may want to open multiple leafs of a hierarchical menu
     // So we set this as an array so that we do not have to bump major to handle it
-    expect(isArray(helper.state.hierarchicalFacetsRefinements.categories)).toBeTruthy();
+    expect(Array.isArray(helper.state.hierarchicalFacetsRefinements.categories)).toBeTruthy();
     done();
   });
 });

--- a/test/spec/hierarchical-facets/simple-usage.js
+++ b/test/spec/hierarchical-facets/simple-usage.js
@@ -2,7 +2,6 @@
 
 test('hierarchical facets: simple usage', function(done) {
   var algoliasearch = require('algoliasearch');
-  var isArray = require('lodash/isArray');
 
   var algoliasearchHelper = require('../../../');
 
@@ -191,7 +190,7 @@ test('hierarchical facets: simple usage', function(done) {
     // we do not yet support multiple values for hierarchicalFacetsRefinements
     // but at some point we may want to open multiple leafs of a hierarchical menu
     // So we set this as an array so that we do not have to bump major to handle it
-    expect(isArray(helper.state.hierarchicalFacetsRefinements.categories)).toBeTruthy();
+    expect(Array.isArray(helper.state.hierarchicalFacetsRefinements.categories)).toBeTruthy();
     done();
   });
 });

--- a/test/spec/hierarchical-facets/unknown-facet.js
+++ b/test/spec/hierarchical-facets/unknown-facet.js
@@ -1,11 +1,9 @@
 'use strict';
+var algoliasearch = require('algoliasearch');
+
+var algoliasearchHelper = require('../../../');
 
 test('hierarchical facets: throw on unknown facet', function() {
-  var bind = require('lodash/bind');
-  var algoliasearch = require('algoliasearch');
-
-  var algoliasearchHelper = require('../../../');
-
   var appId = 'hierarchical-throw-appId';
   var apiKey = 'hierarchical-throw-apiKey';
   var indexName = 'hierarchical-throw-indexName';
@@ -18,5 +16,5 @@ test('hierarchical facets: throw on unknown facet', function() {
     }]
   });
 
-  expect(bind(helper.toggleRefine, helper, 'unknownFacet', 'beers')).toThrow();
+  expect(function() {helper.toggleRefine('unknownFacet', 'beers');}).toThrow();
 });

--- a/test/spec/refinements.js
+++ b/test/spec/refinements.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var algoliasearchHelper = require('../../index');
 
 var emptyClient = {};
@@ -13,14 +12,14 @@ test('Adding refinements should add an entry to the refinements attribute', func
     facets: [facetName]
   });
 
-  expect(_.isEmpty(helper.state.facetsRefinements)).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(0);
   helper.addRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements)).toBe(1);
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(1);
   expect(helper.state.facetsRefinements.facet1).toEqual([facetValue]);
   helper.addRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements)).toBe(1);
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(1);
   helper.removeRefine(facetName, facetValue);
-  expect(_.size(helper.state.facetsRefinements)).toBe(1);
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(1);
   expect(helper.state.facetsRefinements[facetName]).toEqual([]);
 });
 
@@ -31,13 +30,13 @@ test('Adding several refinements for a single attribute should be handled', func
     facets: [facetName]
   });
 
-  expect(_.isEmpty(helper.state.facetsRefinements)).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(0);
   helper.addRefine(facetName, 'value1');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 1).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(1);
   helper.addRefine(facetName, 'value2');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 2).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(2);
   helper.addRefine(facetName, 'value1');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 2).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(2);
 });
 
 test('Toggling several refinements for a single attribute should be handled', function() {
@@ -47,20 +46,22 @@ test('Toggling several refinements for a single attribute should be handled', fu
     facets: [facetName]
   });
 
-  expect(_.isEmpty(helper.state.facetsRefinements)).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(0);
   helper.toggleRefine(facetName, 'value1');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 1).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(1);
   helper.toggleRefine(facetName, 'value2');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 2).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(2);
   helper.toggleRefine(facetName, 'value1');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 1).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(1);
   expect(helper.state.facetsRefinements[facetName]).toEqual(['value2']);
 });
 
 test('Using toggleRefine on a non specified facet should throw an exception', function() {
   var helper = algoliasearchHelper(emptyClient, null, {});
 
-  expect(_.partial(helper.toggleRefine, 'unknown', 'value')).toThrow();
+  expect(function() {
+    helper.toggleRefine('unknown', 'value');
+  }).toThrow();
 });
 
 test('Removing several refinements for a single attribute should be handled', function() {
@@ -70,13 +71,13 @@ test('Removing several refinements for a single attribute should be handled', fu
     facets: [facetName]
   });
 
-  expect(_.isEmpty(helper.state.facetsRefinements)).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements).length).toBe(0);
   helper.addRefine(facetName, 'value1');
   helper.addRefine(facetName, 'value2');
   helper.addRefine(facetName, 'value3');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 3).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(3);
   helper.removeRefine(facetName, 'value2');
-  expect(_.size(helper.state.facetsRefinements[facetName]) === 2).toBeTruthy();
+  expect(Object.keys(helper.state.facetsRefinements[facetName]).length).toBe(2);
   expect(helper.state.facetsRefinements[facetName]).toEqual(['value1', 'value3']);
 });
 
@@ -111,7 +112,7 @@ test('hasRefinements(facet) should return true if the facet is refined.', functi
 
   // in complete honesty we should be able to detect numeric facets but we can't
   // t.throws(helper.hasRefinements.bind(helper, 'notAFacet'), 'not a facet');
-  expect(_.bind(helper.hasRefinements, null)).toThrow();
+  expect(helper.hasRefinements(null)).toBe(false);
 });
 
 test('getRefinements should return all the refinements for a given facet', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,11 +7983,6 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
 lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
Long time coming, but if we do a migration to monorepo, it's nice to not have a stray lodash in the devDependencies