### PR TITLE
feat(DerivedHelper): skip request for empty index

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1295,9 +1295,15 @@ AlgoliaSearchHelper.prototype._search = function(options) {
   });
 
   var queries = Array.prototype.concat.apply(mainQueries, derivedQueries);
-  var queryId = this._queryId++;
 
+  var queryId = this._queryId++;
   this._currentNbQueries++;
+
+  if (!queries.length) {
+    return Promise.resolve({results: []}).then(
+      this._dispatchAlgoliaResponse.bind(this, states, queryId)
+    );
+  }
 
   try {
     this.client.search(queries)

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1276,7 +1276,9 @@ AlgoliaSearchHelper.prototype._search = function(options) {
 
   var derivedQueries = this.derivedHelpers.map(function(derivedHelper) {
     var derivedState = derivedHelper.getModifiedState(state);
-    var derivedStateQueries = requestBuilder._getQueries(derivedState.index, derivedState);
+    var derivedStateQueries = derivedState.index
+      ? requestBuilder._getQueries(derivedState.index, derivedState)
+      : [];
 
     states.push({
       state: derivedState,
@@ -1340,6 +1342,14 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function(states, queryI
     var queriesCount = s.queriesCount;
     var helper = s.helper;
     var specificResults = results.splice(0, queriesCount);
+
+    if (!state.index) {
+      helper.emit('result', {
+        results: null,
+        state: state
+      });
+      return;
+    }
 
     var formattedResponse = helper.lastResults = new SearchResults(state, specificResults);
 

--- a/test/spec/algoliasearch.helper/derive/detach.js
+++ b/test/spec/algoliasearch.helper/derive/detach.js
@@ -6,7 +6,7 @@ test('[derived helper] detach a derived helper', function(done) {
   var client = {
     search: searchTest
   };
-  var helper = algoliasearchHelper(client, '');
+  var helper = algoliasearchHelper(client, 'indexName');
   var derivedHelper = helper.derive(function(s) { return s; });
   derivedHelper.on('result', function() {});
   helper.search();

--- a/test/spec/algoliasearch.helper/derive/empty-index.js
+++ b/test/spec/algoliasearch.helper/derive/empty-index.js
@@ -2,108 +2,183 @@
 
 var algoliasearchHelper = require('../../../../index.js');
 
-test('searches for each derived helper that has an index', function() {
-  var client = {
-    search: jest.fn(function(requests) {
-      return Promise.resolve({
-        results: requests.map(function() {
-          return {hits: []};
-        })
-      });
-    })
-  };
-  var helper = algoliasearchHelper(client, 'indexName');
+describe('searches', function() {
+  test('calls client.search for each derived helper that has an index', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
 
-  helper.derive(function(state) {
-    return state.setIndex('indexName');
-  });
-  helper.derive(function(state) {
-    return state.setIndex('');
-  });
-  helper.searchOnlyWithDerivedHelpers();
-
-  expect(client.search).toHaveBeenCalledTimes(1);
-  expect(client.search).toHaveBeenCalledWith([
-    {
-      indexName: 'indexName',
-      params: {
-        facets: [],
-        tagFilters: ''
-      }
-    }
-  ]);
-});
-
-test('gives a result for each derived helper that has an index', function() {
-  var client = {
-    search: jest.fn(function(requests) {
-      return Promise.resolve({
-        results: requests.map(function() {
-          return {hits: []};
-        })
-      });
-    })
-  };
-  var helper = algoliasearchHelper(client, 'indexName');
-
-  helper.derive(function(state) {
-    return state.setIndex('indexName');
-  });
-  helper.derive(function(state) {
-    return state.setIndex('');
-  });
-  helper.searchOnlyWithDerivedHelpers();
-
-  return Promise.resolve().then(function() {
-    expect(helper.derivedHelpers[0].lastResults).toEqual(
-      new algoliasearchHelper.SearchResults(
-        new algoliasearchHelper.SearchParameters({index: 'indexName'}),
-        [{hits: []}]
-      )
-    );
-    expect(helper.derivedHelpers[1].lastResults).toBe(null);
-  });
-});
-
-test('gives a result event for each derived helper that has an index', function() {
-  var client = {
-    search: jest.fn(function(requests) {
-      return Promise.resolve({
-        results: requests.map(function() {
-          return {hits: []};
-        })
-      });
-    })
-  };
-  var helper = algoliasearchHelper(client, 'indexName');
-
-  var derivedResultSpy1 = jest.fn();
-  helper
-    .derive(function(state) {
+    helper.derive(function(state) {
       return state.setIndex('indexName');
-    })
-    .on('result', derivedResultSpy1);
-  var derivedResultSpy2 = jest.fn();
-  helper
-    .derive(function(state) {
-      return state.setIndex('');
-    })
-    .on('result', derivedResultSpy2);
-  helper.searchOnlyWithDerivedHelpers();
-
-  return Promise.resolve().then(function() {
-    expect(derivedResultSpy1).toHaveBeenCalledTimes(1);
-    expect(derivedResultSpy1).toHaveBeenCalledWith({
-      state: new algoliasearchHelper.SearchParameters({index: 'indexName'}),
-      results: new algoliasearchHelper.SearchResults(
-        new algoliasearchHelper.SearchParameters({index: 'indexName'}),
-        [{hits: []}]
-      )
     });
-    expect(derivedResultSpy2).toHaveBeenCalledTimes(1);
-    expect(derivedResultSpy2).toHaveBeenCalledWith({
-      state: new algoliasearchHelper.SearchParameters({index: ''}),
-      results: null
+    helper.derive(function(state) {
+      return state.setIndex('');
+    });
+    helper.searchOnlyWithDerivedHelpers();
+
+    expect(client.search).toHaveBeenCalledTimes(1);
+    expect(client.search).toHaveBeenCalledWith([
+      {
+        indexName: 'indexName',
+        params: {
+          facets: [],
+          tagFilters: ''
+        }
+      }
+    ]);
+  });
+
+  test('does not call client.search if all indices are empty', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
+
+    helper.derive(function(state) {
+      return state.setIndex('');
+    });
+    helper.derive(function(state) {
+      return state.setIndex('');
+    });
+    helper.searchOnlyWithDerivedHelpers();
+
+    expect(client.search).toHaveBeenCalledTimes(0);
+  });
+
+  test('does not call client.search if no derived helpers', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
+
+    helper.searchOnlyWithDerivedHelpers();
+
+    expect(client.search).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('lastResults', function() {
+  test('gives a result for each derived helper that has an index', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
+
+    helper.derive(function(state) {
+      return state.setIndex('indexName');
+    });
+    helper.derive(function(state) {
+      return state.setIndex('');
+    });
+    helper.searchOnlyWithDerivedHelpers();
+
+    return Promise.resolve().then(function() {
+      expect(helper.derivedHelpers[0].lastResults).toEqual(
+        new algoliasearchHelper.SearchResults(
+          new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+          [{hits: []}]
+        )
+      );
+      expect(helper.derivedHelpers[1].lastResults).toBe(null);
+    });
+  });
+});
+
+describe('result event', function() {
+  test('gives a result event for each derived helper', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
+
+    var derivedResultSpy1 = jest.fn();
+    helper
+      .derive(function(state) {
+        return state.setIndex('indexName');
+      })
+      .on('result', derivedResultSpy1);
+    var derivedResultSpy2 = jest.fn();
+    helper
+      .derive(function(state) {
+        return state.setIndex('');
+      })
+      .on('result', derivedResultSpy2);
+    helper.searchOnlyWithDerivedHelpers();
+
+    return Promise.resolve().then(function() {
+      expect(derivedResultSpy1).toHaveBeenCalledTimes(1);
+      expect(derivedResultSpy1).toHaveBeenCalledWith({
+        state: new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+        results: new algoliasearchHelper.SearchResults(
+          new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+          [{hits: []}]
+        )
+      });
+      expect(derivedResultSpy2).toHaveBeenCalledTimes(1);
+      expect(derivedResultSpy2).toHaveBeenCalledWith({
+        state: new algoliasearchHelper.SearchParameters({index: ''}),
+        results: null
+      });
+    });
+  });
+
+  test('gives a result event for each derived helper when no query is done', function() {
+    var client = {
+      search: jest.fn(function(requests) {
+        return Promise.resolve({
+          results: requests.map(function() {
+            return {hits: []};
+          })
+        });
+      })
+    };
+    var helper = algoliasearchHelper(client, 'indexName');
+
+    var derivedResultSpy1 = jest.fn();
+    helper
+      .derive(function(state) {
+        return state.setIndex('');
+      })
+      .on('result', derivedResultSpy1);
+    helper.searchOnlyWithDerivedHelpers();
+
+    return Promise.resolve().then(function() {
+      expect(derivedResultSpy1).toHaveBeenCalledTimes(1);
+      expect(derivedResultSpy1).toHaveBeenCalledWith({
+        state: new algoliasearchHelper.SearchParameters({index: ''}),
+        results: null
+      });
     });
   });
 });

--- a/test/spec/algoliasearch.helper/derive/empty-index.js
+++ b/test/spec/algoliasearch.helper/derive/empty-index.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var algoliasearchHelper = require('../../../../index.js');
+
+test('searches for each derived helper that has an index', function() {
+  var client = {
+    search: jest.fn(function(requests) {
+      return Promise.resolve({
+        results: requests.map(function() {
+          return {hits: []};
+        })
+      });
+    })
+  };
+  var helper = algoliasearchHelper(client, 'indexName');
+
+  helper.derive(function(state) {
+    return state.setIndex('indexName');
+  });
+  helper.derive(function(state) {
+    return state.setIndex('');
+  });
+  helper.searchOnlyWithDerivedHelpers();
+
+  expect(client.search).toHaveBeenCalledTimes(1);
+  expect(client.search).toHaveBeenCalledWith([
+    {
+      indexName: 'indexName',
+      params: {
+        facets: [],
+        tagFilters: ''
+      }
+    }
+  ]);
+});
+
+test('gives a result for each derived helper that has an index', function() {
+  var client = {
+    search: jest.fn(function(requests) {
+      return Promise.resolve({
+        results: requests.map(function() {
+          return {hits: []};
+        })
+      });
+    })
+  };
+  var helper = algoliasearchHelper(client, 'indexName');
+
+  helper.derive(function(state) {
+    return state.setIndex('indexName');
+  });
+  helper.derive(function(state) {
+    return state.setIndex('');
+  });
+  helper.searchOnlyWithDerivedHelpers();
+
+  return Promise.resolve().then(function() {
+    expect(helper.derivedHelpers[0].lastResults).toEqual(
+      new algoliasearchHelper.SearchResults(
+        new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+        [{hits: []}]
+      )
+    );
+    expect(helper.derivedHelpers[1].lastResults).toBe(null);
+  });
+});
+
+test('gives a result event for each derived helper that has an index', function() {
+  var client = {
+    search: jest.fn(function(requests) {
+      return Promise.resolve({
+        results: requests.map(function() {
+          return {hits: []};
+        })
+      });
+    })
+  };
+  var helper = algoliasearchHelper(client, 'indexName');
+
+  var derivedResultSpy1 = jest.fn();
+  helper
+    .derive(function(state) {
+      return state.setIndex('indexName');
+    })
+    .on('result', derivedResultSpy1);
+  var derivedResultSpy2 = jest.fn();
+  helper
+    .derive(function(state) {
+      return state.setIndex('');
+    })
+    .on('result', derivedResultSpy2);
+  helper.searchOnlyWithDerivedHelpers();
+
+  return Promise.resolve().then(function() {
+    expect(derivedResultSpy1).toHaveBeenCalledTimes(1);
+    expect(derivedResultSpy1).toHaveBeenCalledWith({
+      state: new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+      results: new algoliasearchHelper.SearchResults(
+        new algoliasearchHelper.SearchParameters({index: 'indexName'}),
+        [{hits: []}]
+      )
+    });
+    expect(derivedResultSpy2).toHaveBeenCalledTimes(1);
+    expect(derivedResultSpy2).toHaveBeenCalledWith({
+      state: new algoliasearchHelper.SearchParameters({index: ''}),
+      results: null
+    });
+  });
+});

--- a/test/spec/algoliasearch.helper/derive/multiqueries.js
+++ b/test/spec/algoliasearch.helper/derive/multiqueries.js
@@ -14,7 +14,7 @@ function makeFakeClient(assertions) {
 
 test('trigger a search without derivation', function() {
   var client = makeFakeClient(assertions);
-  var helper = algoliasearchHelper(client, '');
+  var helper = algoliasearchHelper(client, 'indexName');
 
   helper.search();
 
@@ -25,7 +25,7 @@ test('trigger a search without derivation', function() {
 
 test('trigger a search with one derivation without a state change', function() {
   var client = makeFakeClient(assertions);
-  var helper = algoliasearchHelper(client, '');
+  var helper = algoliasearchHelper(client, 'indexName');
 
   helper.derive(function(state) {
     return state;
@@ -41,7 +41,7 @@ test('trigger a search with one derivation without a state change', function() {
 
 test('trigger a search with one derivation with a state change', function() {
   var client = makeFakeClient(assertions);
-  var helper = algoliasearchHelper(client, '');
+  var helper = algoliasearchHelper(client, 'indexName');
 
   helper.derive(function(state) {
     return state.setQuery('otherQuery');
@@ -63,7 +63,7 @@ test('trigger a search with one derivation with a state change', function() {
 
 test('trigger a search with derivation only', function() {
   var client = makeFakeClient(assertions);
-  var helper = algoliasearchHelper(client, '');
+  var helper = algoliasearchHelper(client, 'indexName');
 
   helper.derive(function(state) {
     return state;


### PR DESCRIPTION
We currently don't introspect, but if the indexName is empty, the search client will return an error, meaning skipping those queries isn't really a breaking change.

If no queries would be triggered at all, client.search is also not called.

Skipping those queries can be interesting to create patterns like "multiple sibling indices at root of instantsearch" and "orphan indices".

