### PR TITLE
fix(SearchResults): use empty facets object for exclusion when results are artificial

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -588,7 +588,7 @@ function SearchResults(state, results, options) {
 
     self.facets[position] = {
       name: facetName,
-      data: mainSubResponse.facets[facetName],
+      data: mainFacets[facetName],
       exhaustive: mainSubResponse.exhaustiveFacetsCount
     };
     excludes.forEach(function(facetValue) {

--- a/test/spec/SearchResults/getRefinements.js
+++ b/test/spec/SearchResults/getRefinements.js
@@ -64,6 +64,27 @@ test('getRefinements(facetName) returns a refinement(exclude) when a facet exclu
   expect(hasSameNames(refinements, refinedFacetValues)).toBeTruthy();
 });
 
+// See: https://github.com/algolia/algoliasearch-helper-js/issues/921
+test.only('getRefinements(facetName) returns a refinement(exclude) when a facet exclusion is set and results are artificial', function() {
+  var data = require('./getRefinements/exclude-artificial-results.json');
+  var searchParams = new SearchParameters(data.state);
+  var result = new SearchResults(searchParams, data.content.results);
+
+  var refinements = result.getRefinements();
+  var facetValues = result.getFacetValues('brand');
+  var refinedFacetValues = facetValues.filter(function(f) {
+    return f.isExcluded === true;
+  });
+
+  var expected = [{
+    attributeName: 'brand', count: 0, exhaustive: true, name: 'Apple', type: 'exclude'
+  }];
+
+  expect(refinements).toEqual(expected);
+  expect(refinements.length).toBe(refinedFacetValues.length);
+  expect(hasSameNames(refinements, refinedFacetValues)).toBeTruthy();
+});
+
 test(
   'getRefinements(facetName) returns a refinement(disjunctive) when a disjunctive refinement is set',
   function() {

--- a/test/spec/SearchResults/getRefinements/exclude-artificial-results.json
+++ b/test/spec/SearchResults/getRefinements/exclude-artificial-results.json
@@ -1,0 +1,37 @@
+{
+  "content": {
+    "results": [{
+      "query": "",
+      "page": 0,
+      "hitsPerPage": 20,
+      "hits": [],
+      "nbHits": 0,
+      "nbPages": 0,
+      "params": "",
+      "exhaustiveNbHits": true,
+      "exhaustiveFacetsCount": true,
+      "processingTimeMS": 0,
+      "index": "instant_search"
+    }]
+  },
+  "state": {
+    "index": "instant_search",
+    "query": "",
+    "facets": [
+      "brand"
+    ],
+    "disjunctiveFacets": [],
+    "hierarchicalFacets": [],
+    "facetsRefinements": {},
+    "facetsExcludes": {
+      "brand": [
+        "Apple"
+      ]
+    },
+    "disjunctiveFacetsRefinements": {},
+    "numericRefinements": {},
+    "tagRefinements": [],
+    "hierarchicalFacetsRefinements": {},
+    "page": 0
+  }
+}


### PR DESCRIPTION
This PR ensures that facet exclusions are computed from a result's facets property that is defaulted to an empty object, in case this is called with artificial results.

FX-2179
Closes #921 