### PR TITLE
fix(types): improve conditional for client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "metalsmith-metallic": "1.0.0",
     "@metalsmith/sass": "1.4.0",
     "pug": "2.0.3",
-    "typescript": "4.6.2"
+    "typescript": "5.1.3"
   },
   "dependencies": {
     "@algolia/events": "^4.0.1"

--- a/types/algoliasearch.d.ts
+++ b/types/algoliasearch.d.ts
@@ -12,7 +12,8 @@ import type * as AlgoliaSearch from 'algoliasearch';
 import type * as ClientSearch from '@algolia/client-search';
 
 // turns any to unknown, so it can be used as a conditional
-type AnyToUnknown<T> = (any extends T ? true : false) extends true
+// more info in https://stackoverflow.com/a/49928360/3185307
+type AnyToUnknown<T> = (0 extends 1 & T ? true : false) extends true
   ? unknown
   : T;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7851,10 +7851,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
in TypeScript 5.1.3, the check `any extends T` when T is any no longer evaluates to one branch of the conditional, but the union of both branches.

This is fixed by using a "never possible to be true, unless T is any" condition as in https://stackoverflow.com/a/49928360/3185307

fixes https://github.com/algolia/instantsearch/issues/5658
FX-2396