### PR TITLE
chore(devDeps): remove lodash.keyBy

### DIFF
--- a/documentation-src/plugins/jsdoc-data.js
+++ b/documentation-src/plugins/jsdoc-data.js
@@ -1,6 +1,17 @@
 'use strict';
 var jsdoc = require('jsdoc-to-markdown');
-var keyBy = require('lodash.keyby');
+
+/**
+ * Same as lodash keyBy, turns an array of objects into an object keyed by the
+ * value of the given key. When there are multiple objects with the same key,
+ * the last one wins.
+ */
+function keyBy(arr, key) {
+  return arr.reduce(function(obj, o) {
+    obj[o[key]] = o;
+    return obj;
+  }, {});
+}
 
 module.exports = function(opts) {
   if (!opts.src) throw new Error('opts.src must be defined');
@@ -8,8 +19,10 @@ module.exports = function(opts) {
 
   return function(_files, metalsmith) {
     var files = metalsmith.path(opts.src);
-    return jsdoc.getTemplateData({files: files}).then(data => {
-      var filteredData = data.filter(function(o) {return !o.deprecated;});
+    return jsdoc.getTemplateData({files: files}).then((data) => {
+      var filteredData = data.filter(function(o) {
+        return !o.deprecated;
+      });
       var metadata = metalsmith.metadata();
       if (!namespace) metadata.jsdoc = keyBy(filteredData, 'longname');
       else {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mversion": "1.13.0",
     "yargs": "13.2.4",
     "jsdoc-to-markdown": "8.0.0",
-    "lodash.keyby": "4.6.0",
     "handlebars": "4.1.0",
     "metalsmith": "2.5.1",
     "metalsmith-in-place": "1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5033,11 +5033,6 @@ lodash.istypedarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
   integrity sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=
 
-lodash.keyby@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.npmjs.org/lodash.keyby/-/lodash.keyby-4.6.0.tgz#7f6a1abda93fd24e22728a4d361ed8bcba5a4354"
-  integrity sha512-PRe4Cn20oJM2Sn6ljcZMeKgyhTHpzvzFmdsp9rK+6K0eJs6Tws0MqgGFpfX/o2HjcoQcBny1Eik9W7BnVTzjIQ==
-
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"


### PR DESCRIPTION
only used in the jsdoc-data plugin, and can easily be replaced without dependency