### PR TITLE
test(unit): add retry mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc:publish": "yarn run doc && gh-pages -d documentation",
     "doc:staging": "scripts/staging-doc.sh",
     "readme:toc": "doctoc --notitle README.md --maxlevel 3",
-    "test": "scripts/test.sh",
+    "test": "scripts/retry.sh 3 'scripts/test.sh'",
     "test:unit": "jest",
     "test:watch": "jest --watch",
     "release": "./scripts/release.js",

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Retry a command up to a specific number of times until it exits successfully
+# Usage: scripts/retry.sh <retries> <command>
+
+retries="$1"
+command="$2"
+
+echo tyring "$command", $retries retries left
+
+# Run the command, and save the exit code
+($command)
+exit_code=$?
+
+# If the exit code is non-zero (i.e. command failed), and we have not
+# reached the maximum number of retries, run the command again
+if [[ $exit_code -ne 0 && $retries -gt 0 ]]; then
+  scripts/retry.sh $(($retries - 1)) "$command"
+else
+  # Return the exit code from the command
+  exit $exit_code
+fi
+

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -5,7 +5,7 @@
 retries="$1"
 command="$2"
 
-echo tyring "$command", $retries retries left
+echo trying "$command", $retries retries left
 
 # Run the command, and save the exit code
 ($command)


### PR DESCRIPTION
The tests are sometimes flaky (integration mostly), as we're not entirely sure what the cause is, retrying seems sensible

This can also be reused in the monorepo later