### PR TITLE
fix(getFacetValues): ignore `rootPath` for hierarchical facets

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -716,7 +716,11 @@ function extractNormalizedFacetValues(results, attribute) {
       results._state.getHierarchicalFacetByName(attribute);
     var currentRefinementSplit = unescapeFacetValue(
       results._state.getHierarchicalRefinement(attribute)[0] || ''
-    ).split(results._state._getHierarchicalFacetSeparator(hierarchicalFacet));
+    )
+      .split(results._state._getHierarchicalFacetSeparator(hierarchicalFacet))
+      .filter(function (name) {
+        return name !== hierarchicalFacet.rootPath;
+      });
     currentRefinementSplit.unshift(attribute);
 
     setIsRefined(hierarchicalFacetValues, currentRefinementSplit, 0);

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -720,7 +720,7 @@ function extractNormalizedFacetValues(results, attribute) {
       results._state.getHierarchicalRefinement(attribute)[0] || ''
     );
 
-    if (currentRefinement.startsWith(hierarchicalFacet.rootPath)) {
+    if (currentRefinement.indexOf(hierarchicalFacet.rootPath) === 0) {
       currentRefinement = currentRefinement.replace(
         hierarchicalFacet.rootPath + separator,
         ''

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -714,13 +714,20 @@ function extractNormalizedFacetValues(results, attribute) {
 
     var hierarchicalFacet =
       results._state.getHierarchicalFacetByName(attribute);
-    var currentRefinementSplit = unescapeFacetValue(
+    var separator =
+      results._state._getHierarchicalFacetSeparator(hierarchicalFacet);
+    var currentRefinement = unescapeFacetValue(
       results._state.getHierarchicalRefinement(attribute)[0] || ''
-    )
-      .split(results._state._getHierarchicalFacetSeparator(hierarchicalFacet))
-      .filter(function (name) {
-        return name !== hierarchicalFacet.rootPath;
-      });
+    );
+
+    if (hierarchicalFacet.rootPath) {
+      currentRefinement = currentRefinement.replace(
+        hierarchicalFacet.rootPath + separator,
+        ''
+      );
+    }
+
+    var currentRefinementSplit = currentRefinement.split(separator);
     currentRefinementSplit.unshift(attribute);
 
     setIsRefined(hierarchicalFacetValues, currentRefinementSplit, 0);

--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -720,7 +720,7 @@ function extractNormalizedFacetValues(results, attribute) {
       results._state.getHierarchicalRefinement(attribute)[0] || ''
     );
 
-    if (hierarchicalFacet.rootPath) {
+    if (currentRefinement.startsWith(hierarchicalFacet.rootPath)) {
       currentRefinement = currentRefinement.replace(
         hierarchicalFacet.rootPath + separator,
         ''

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -407,6 +407,94 @@ test('getFacetValues(hierarchical) returns escaped facet values', function () {
   expect(facetValues).toEqual(expected);
 });
 
+test('getFacetValues(hierarchical) ignores `rootPath`', function () {
+  var searchParams = new SearchParameters({
+    index: 'instant_search',
+    hierarchicalFacets: [
+      {
+        name: 'type',
+        attributes: ['type1', 'type2', 'type3'],
+        rootPath: 'cats',
+      },
+    ],
+    hierarchicalFacetsRefinements: { type: ['cats > british shorthair'] },
+  });
+
+  var result = {
+    query: '',
+    facets: {
+      type1: {
+        dogs: 1,
+        cats: 8,
+      },
+      type2: {
+        'dogs > hounds': 1,
+        'cats > chartreux': 5,
+        'cats > british shorthair': 4,
+      },
+      type3: {
+        'cats > british shorthair > blue': 1,
+        'cats > british shorthair > golden': 3,
+      },
+    },
+    exhaustiveFacetsCount: true,
+  };
+
+  var results = new SearchResults(searchParams, [result, result, result]);
+
+  var facetValues = results.getFacetValues('type');
+
+  var expected = {
+    data: [
+      {
+        count: 4,
+        data: [
+          {
+            count: 3,
+            data: null,
+            escapedValue: 'cats > british shorthair > golden',
+            exhaustive: true,
+            isRefined: false,
+            name: 'golden',
+            path: 'cats > british shorthair > golden',
+          },
+          {
+            count: 1,
+            data: null,
+            escapedValue: 'cats > british shorthair > blue',
+            exhaustive: true,
+            isRefined: false,
+            name: 'blue',
+            path: 'cats > british shorthair > blue',
+          },
+        ],
+        escapedValue: 'cats > british shorthair',
+        exhaustive: true,
+        isRefined: true,
+        name: 'british shorthair',
+        path: 'cats > british shorthair',
+      },
+      {
+        count: 5,
+        data: null,
+        escapedValue: 'cats > chartreux',
+        exhaustive: true,
+        isRefined: false,
+        name: 'chartreux',
+        path: 'cats > chartreux',
+      },
+    ],
+    exhaustive: true,
+    isRefined: true,
+    name: 'type',
+    path: null,
+    escapedValue: null,
+    count: null,
+  };
+
+  expect(facetValues).toEqual(expected);
+});
+
 test('getFacetValues(unknown) returns undefined (does not throw)', function () {
   var searchParams = new SearchParameters({
     index: 'instant_search',

--- a/test/spec/SearchResults/getFacetValues.js
+++ b/test/spec/SearchResults/getFacetValues.js
@@ -407,7 +407,7 @@ test('getFacetValues(hierarchical) returns escaped facet values', function () {
   expect(facetValues).toEqual(expected);
 });
 
-test('getFacetValues(hierarchical) ignores `rootPath`', function () {
+test('getFacetValues(hierarchical) takes `rootPath` into account', function () {
   var searchParams = new SearchParameters({
     index: 'instant_search',
     hierarchicalFacets: [


### PR DESCRIPTION
### [FX-2414](https://algolia.atlassian.net/browse/FX-2414) and [CR-3625](https://algolia.atlassian.net/browse/CR-3625)

Just removing the `rootPath` from `currentRefinementSplit` works !

[FX-2414]: https://algolia.atlassian.net/browse/FX-2414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CR-3625]: https://algolia.atlassian.net/browse/CR-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ